### PR TITLE
refactor: replace magic string literals with named constants

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -448,7 +448,7 @@ func executeTask(
 	result, err := lnch.Launch(ctx, task.Agent, task.Context)
 	if err != nil {
 		log.Printf("[worker] agent %s failed: %v", task.AgentName, err)
-		if err := st.UpdateTaskStatus(task.TaskID, "failed"); err != nil {
+		if err := st.UpdateTaskStatus(task.TaskID, store.TaskStatusFailed); err != nil {
 			log.Printf("[worker] failed to update task status: %v", err)
 		}
 		sm.MarkAgentCompleted(task.Repo, task.IssueNum, nil)
@@ -456,12 +456,12 @@ func executeTask(
 	}
 
 	// Determine task status
-	status := "completed"
+	status := store.TaskStatusCompleted
 	if result.ExitCode != 0 {
-		status = "failed"
+		status = store.TaskStatusFailed
 	}
 	if result.Meta != nil && result.Meta["timeout"] == "true" {
-		status = "timeout"
+		status = store.TaskStatusTimeout
 	}
 
 	// Update task status
@@ -504,19 +504,19 @@ func executeTask(
 // recoverTasks marks running tasks as failed and re-routes pending tasks on restart.
 func recoverTasks(st *store.Store) error {
 	// Mark all running tasks as failed (subprocess lost on restart)
-	running, err := st.QueryTasks("running")
+	running, err := st.QueryTasks(store.TaskStatusRunning)
 	if err != nil {
 		return fmt.Errorf("query running tasks: %w", err)
 	}
 	for _, t := range running {
 		log.Printf("[serve] recovery: marking task %s as failed (was running)", t.ID)
-		if err := st.UpdateTaskStatus(t.ID, "failed"); err != nil {
+		if err := st.UpdateTaskStatus(t.ID, store.TaskStatusFailed); err != nil {
 			log.Printf("[serve] recovery: failed to mark task %s: %v", t.ID, err)
 		}
 	}
 
 	// Log pending tasks that will be re-dispatched via normal poller cycle
-	pending, err := st.QueryTasks("pending")
+	pending, err := st.QueryTasks(store.TaskStatusPending)
 	if err != nil {
 		return fmt.Errorf("query pending tasks: %w", err)
 	}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -205,7 +205,7 @@ func TestServe_RecoverTasks(t *testing.T) {
 		IssueNum:  1,
 		AgentName: "dev-agent",
 		WorkerID:  "worker-1",
-		Status:    "running",
+		Status:    store.TaskStatusRunning,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -216,7 +216,7 @@ func TestServe_RecoverTasks(t *testing.T) {
 		Repo:      "owner/repo",
 		IssueNum:  2,
 		AgentName: "dev-agent",
-		Status:    "pending",
+		Status:    store.TaskStatusPending,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -236,7 +236,7 @@ func TestServe_RecoverTasks(t *testing.T) {
 	}
 
 	// Verify running task is now failed
-	tasks, err := st2.QueryTasks("failed")
+	tasks, err := st2.QueryTasks(store.TaskStatusFailed)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -245,7 +245,7 @@ func TestServe_RecoverTasks(t *testing.T) {
 	}
 
 	// Verify pending task is still pending
-	pending, err := st2.QueryTasks("pending")
+	pending, err := st2.QueryTasks(store.TaskStatusPending)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -219,7 +219,7 @@ func validateStates(fname string, wf *WorkflowConfig) error {
 // (a transition where To references a state that appears earlier or the same
 // state, indicating a cycle/retry) but no explicit "failed" state.
 func autoAddFailedState(wf *WorkflowConfig) {
-	if _, exists := wf.States["failed"]; exists {
+	if _, exists := wf.States[StateNameFailed]; exists {
 		return
 	}
 	// Check for back-edges: any transition whose To target is a state that
@@ -240,8 +240,8 @@ func autoAddFailedState(wf *WorkflowConfig) {
 	}
 
 	if hasBackEdge {
-		wf.States["failed"] = &State{
-			EnterLabel: "status:failed",
+		wf.States[StateNameFailed] = &State{
+			EnterLabel: LabelFailed,
 		}
 	}
 }

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -532,11 +532,11 @@ states:
 		t.Fatalf("unexpected error: %v", err)
 	}
 	wf := cfg.Workflows["retry-wf"]
-	failedState, ok := wf.States["failed"]
+	failedState, ok := wf.States[StateNameFailed]
 	if !ok {
 		t.Fatal("expected auto-added 'failed' state")
 	}
-	if failedState.EnterLabel != "status:failed" {
-		t.Errorf("failed state enter_label = %q, want %q", failedState.EnterLabel, "status:failed")
+	if failedState.EnterLabel != LabelFailed {
+		t.Errorf("failed state enter_label = %q, want %q", failedState.EnterLabel, LabelFailed)
 	}
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -2,6 +2,12 @@ package config
 
 import "time"
 
+// Well-known state names.
+const (
+	StateNameFailed  = "failed"
+	LabelFailed      = "status:failed"
+)
+
 // GlobalConfig is the top-level configuration loaded from config.yaml.
 type GlobalConfig struct {
 	Repo         string        `yaml:"repo"`

--- a/internal/eventlog/eventlog.go
+++ b/internal/eventlog/eventlog.go
@@ -12,15 +12,21 @@ import (
 
 // Supported event types.
 const (
-	TypePoll             = "poll"
-	TypeTransition       = "transition"
-	TypeDispatch         = "dispatch"
-	TypeCompleted        = "completed"
-	TypeError            = "error"
-	TypeReport           = "report"
-	TypeRetryLimit       = "retry_limit"
-	TypeWorkerRegistered = "worker_registered"
-	TypeWorkerOffline    = "worker_offline"
+	TypePoll                   = "poll"
+	TypeTransition             = "transition"
+	TypeDispatch               = "dispatch"
+	TypeCompleted              = "completed"
+	TypeError                  = "error"
+	TypeReport                 = "report"
+	TypeRetryLimit             = "retry_limit"
+	TypeWorkerRegistered       = "worker_registered"
+	TypeWorkerOffline          = "worker_offline"
+	TypeStateEntry             = "state_entry"
+	TypeErrorMultiWorkflow     = "error_multi_workflow"
+	TypeCycleLimitReached      = "cycle_limit_reached"
+	TypeTransitionToFailed     = "transition_to_failed"
+	TypeStuckDetected          = "stuck_detected"
+	TypeDispatchSkippedInflight = "dispatch_skipped_inflight"
 )
 
 // AllEventTypes lists every recognised event type.
@@ -34,6 +40,12 @@ var AllEventTypes = []string{
 	TypeRetryLimit,
 	TypeWorkerRegistered,
 	TypeWorkerOffline,
+	TypeStateEntry,
+	TypeErrorMultiWorkflow,
+	TypeCycleLimitReached,
+	TypeTransitionToFailed,
+	TypeStuckDetected,
+	TypeDispatchSkippedInflight,
 }
 
 // EventFilter specifies optional criteria for querying events.

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -14,6 +14,19 @@ import (
 )
 
 // ---------------------------------------------------------------------------
+// Event type constants
+// ---------------------------------------------------------------------------
+
+// Event types emitted by the Poller.
+const (
+	EventIssueCreated   = "issue_created"
+	EventLabelAdded     = "label_added"
+	EventLabelRemoved   = "label_removed"
+	EventPRCreated      = "pr_created"
+	EventPRStateChanged = "pr_state_changed"
+)
+
+// ---------------------------------------------------------------------------
 // Domain types
 // ---------------------------------------------------------------------------
 
@@ -36,7 +49,7 @@ type PR struct {
 
 // ChangeEvent describes a detected change between two polls.
 type ChangeEvent struct {
-	Type     string // "issue_created", "label_added", "label_removed", "pr_created", "pr_checks_changed", "pr_review_changed"
+	Type     string // EventIssueCreated, EventLabelAdded, EventLabelRemoved, EventPRCreated, EventPRStateChanged
 	Repo     string
 	IssueNum int
 	Labels   []string
@@ -180,7 +193,7 @@ func (p *Poller) diffIssue(ctx context.Context, iss Issue) {
 	if cached == nil {
 		// New issue (or first sync after restart).
 		p.emit(ctx, ChangeEvent{
-			Type:     "issue_created",
+			Type:     EventIssueCreated,
 			Repo:     p.repo,
 			IssueNum: iss.Number,
 			Labels:   iss.Labels,
@@ -192,7 +205,7 @@ func (p *Poller) diffIssue(ctx context.Context, iss Issue) {
 		added, removed := diffLabels(oldLabels, iss.Labels)
 		for _, l := range added {
 			p.emit(ctx, ChangeEvent{
-				Type:     "label_added",
+				Type:     EventLabelAdded,
 				Repo:     p.repo,
 				IssueNum: iss.Number,
 				Labels:   iss.Labels,
@@ -201,7 +214,7 @@ func (p *Poller) diffIssue(ctx context.Context, iss Issue) {
 		}
 		for _, l := range removed {
 			p.emit(ctx, ChangeEvent{
-				Type:     "label_removed",
+				Type:     EventLabelRemoved,
 				Repo:     p.repo,
 				IssueNum: iss.Number,
 				Labels:   iss.Labels,
@@ -236,7 +249,7 @@ func (p *Poller) diffPR(ctx context.Context, pr PR) {
 
 	if cached == nil {
 		p.emit(ctx, ChangeEvent{
-			Type:     "pr_created",
+			Type:     EventPRCreated,
 			Repo:     p.repo,
 			IssueNum: pr.Number,
 			Detail:   pr.Branch,
@@ -244,7 +257,7 @@ func (p *Poller) diffPR(ctx context.Context, pr PR) {
 	} else if cached.State != stateVal {
 		// Detect state changes (checks, reviews show as state changes).
 		p.emit(ctx, ChangeEvent{
-			Type:     "pr_state_changed",
+			Type:     EventPRStateChanged,
 			Repo:     p.repo,
 			IssueNum: pr.Number,
 			Detail:   fmt.Sprintf("%s -> %s", cached.State, stateVal),

--- a/internal/poller/poller_test.go
+++ b/internal/poller/poller_test.go
@@ -113,7 +113,7 @@ func TestNewIssueDetection(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d: %+v", len(events), events)
 	}
-	if events[0].Type != "issue_created" {
+	if events[0].Type != EventIssueCreated {
 		t.Errorf("expected issue_created, got %s", events[0].Type)
 	}
 	if events[0].IssueNum != 1 {
@@ -158,11 +158,11 @@ func TestLabelAddedRemoved(t *testing.T) {
 	for _, ev := range events {
 		types[ev.Type] = ev.Detail
 	}
-	if types["label_added"] != "enhancement" {
-		t.Errorf("expected label_added=enhancement, got %q", types["label_added"])
+	if types[EventLabelAdded] != "enhancement" {
+		t.Errorf("expected label_added=enhancement, got %q", types[EventLabelAdded])
 	}
-	if types["label_removed"] != "bug" {
-		t.Errorf("expected label_removed=bug, got %q", types["label_removed"])
+	if types[EventLabelRemoved] != "bug" {
+		t.Errorf("expected label_removed=bug, got %q", types[EventLabelRemoved])
 	}
 }
 
@@ -219,7 +219,7 @@ func TestPRCreated(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d: %+v", len(events), events)
 	}
-	if events[0].Type != "pr_created" {
+	if events[0].Type != EventPRCreated {
 		t.Errorf("expected pr_created, got %s", events[0].Type)
 	}
 }
@@ -255,7 +255,7 @@ func TestPRStateChanged(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d: %+v", len(events), events)
 	}
-	if events[0].Type != "pr_state_changed" {
+	if events[0].Type != EventPRStateChanged {
 		t.Errorf("expected pr_state_changed, got %s", events[0].Type)
 	}
 }
@@ -379,10 +379,10 @@ func TestCrashRecovery_FullSync(t *testing.T) {
 	for _, ev := range events {
 		types[ev.Type] = true
 	}
-	if !types["label_added"] {
+	if !types[EventLabelAdded] {
 		t.Error("expected label_added event")
 	}
-	if !types["issue_created"] {
+	if !types[EventIssueCreated] {
 		t.Error("expected issue_created event")
 	}
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -87,7 +87,7 @@ func (r *Router) handleDispatch(ctx context.Context, req statemachine.DispatchRe
 		Repo:      req.Repo,
 		IssueNum:  req.IssueNum,
 		AgentName: req.AgentName,
-		Status:    "pending",
+		Status:    store.TaskStatusPending,
 	}); err != nil {
 		log.Printf("[router] failed to insert task: %v", err)
 		return
@@ -128,7 +128,7 @@ func (r *Router) handleDispatch(ctx context.Context, req statemachine.DispatchRe
 
 	select {
 	case r.taskChan <- task:
-		if err := r.store.UpdateTaskStatus(taskID, "running"); err != nil {
+		if err := r.store.UpdateTaskStatus(taskID, store.TaskStatusRunning); err != nil {
 			log.Printf("[router] failed to update task status: %v", err)
 		}
 	case <-ctx.Done():

--- a/internal/statemachine/rules.go
+++ b/internal/statemachine/rules.go
@@ -4,16 +4,30 @@ package statemachine
 import (
 	"log"
 	"strings"
+
+	"github.com/Lincyaw/workbuddy/internal/poller"
+)
+
+// Checks state constants.
+const (
+	ChecksPassed = "passed"
+	ChecksFailed = "failed"
+)
+
+// Event type constants used in condition evaluation.
+const (
+	EventApproved         = "approved"
+	EventChangesRequested = "changes_requested"
 )
 
 // EvalContext holds the data needed to evaluate a transition condition.
 type EvalContext struct {
-	EventType     string   // "label_added", "label_removed", "pr_created", etc.
+	EventType     string   // poller.EventLabelAdded, poller.EventLabelRemoved, poller.EventPRCreated, etc.
 	Labels        []string // current labels on the issue
 	LabelAdded    string   // label that was just added (if event is label_added)
 	LabelRemoved  string   // label that was just removed (if event is label_removed)
 	PRState       string   // "open", "closed", "merged", "" if no PR
-	ChecksState   string   // "passed", "failed", "" if unknown
+	ChecksState   string   // ChecksPassed, ChecksFailed, or "" if unknown
 	LatestComment string   // body of the most recent comment
 }
 
@@ -58,15 +72,15 @@ func EvaluateCondition(when string, ctx *EvalContext) bool {
 	// Simple keyword conditions.
 	switch when {
 	case "pr_opened":
-		return ctx.EventType == "pr_created"
+		return ctx.EventType == poller.EventPRCreated
 	case "checks_passed":
-		return ctx.ChecksState == "passed"
+		return ctx.ChecksState == ChecksPassed
 	case "checks_failed":
-		return ctx.ChecksState == "failed"
+		return ctx.ChecksState == ChecksFailed
 	case "approved":
-		return ctx.EventType == "approved"
+		return ctx.EventType == EventApproved
 	case "changes_requested":
-		return ctx.EventType == "changes_requested"
+		return ctx.EventType == EventChangesRequested
 	default:
 		log.Printf("[statemachine] warning: unknown condition type: %q", when)
 		return false

--- a/internal/statemachine/statemachine.go
+++ b/internal/statemachine/statemachine.go
@@ -8,12 +8,14 @@ import (
 	"time"
 
 	"github.com/Lincyaw/workbuddy/internal/config"
+	"github.com/Lincyaw/workbuddy/internal/eventlog"
+	"github.com/Lincyaw/workbuddy/internal/poller"
 	"github.com/Lincyaw/workbuddy/internal/store"
 )
 
 // ChangeEvent represents a state change detected by the Poller.
 type ChangeEvent struct {
-	Type     string // "label_added", "label_removed", "pr_created", etc.
+	Type     string // poller.EventLabelAdded, poller.EventLabelRemoved, poller.EventPRCreated, etc.
 	Repo     string
 	IssueNum int
 	Labels   []string // current labels on the issue
@@ -123,7 +125,7 @@ func (sm *StateMachine) HandleEvent(event ChangeEvent) error {
 			"workflows": names,
 			"labels":    event.Labels,
 		})
-		sm.eventlog.Log("error_multi_workflow", event.Repo, event.IssueNum, string(payload))
+		sm.eventlog.Log(eventlog.TypeErrorMultiWorkflow, event.Repo, event.IssueNum, string(payload))
 		return fmt.Errorf("statemachine: issue %s#%d matches %d workflows", event.Repo, event.IssueNum, len(matched))
 	}
 
@@ -162,12 +164,12 @@ func (sm *StateMachine) processWorkflowEvent(wf *config.WorkflowConfig, event Ch
 	// State-entry detection: dispatch the agent if:
 	// 1. label_added matches the current state's enter_label (label just changed), OR
 	// 2. issue_created and the issue already has a state label with an agent (first seen)
-	stateEntryDetected := (event.Type == "label_added" && event.Detail == currentState.EnterLabel) ||
-		(event.Type == "issue_created")
+	stateEntryDetected := (event.Type == poller.EventLabelAdded && event.Detail == currentState.EnterLabel) ||
+		(event.Type == poller.EventIssueCreated)
 	if stateEntryDetected && currentState.Agent != "" {
 		log.Printf("[statemachine] state entry detected: %s#%d entered %q, dispatching agent %q",
 			event.Repo, event.IssueNum, currentStateName, currentState.Agent)
-		sm.eventlog.Log("state_entry", event.Repo, event.IssueNum,
+		sm.eventlog.Log(eventlog.TypeStateEntry, event.Repo, event.IssueNum,
 			fmt.Sprintf(`{"state":"%s","agent":"%s"}`, currentStateName, currentState.Agent))
 
 		// Clear any stale inflight flag: if the label changed, the previous agent's
@@ -190,9 +192,9 @@ func (sm *StateMachine) processWorkflowEvent(wf *config.WorkflowConfig, event Ch
 		LatestComment: event.Detail,
 	}
 	switch event.Type {
-	case "label_added":
+	case poller.EventLabelAdded:
 		ctx.LabelAdded = event.Detail
-	case "label_removed":
+	case poller.EventLabelRemoved:
 		ctx.LabelRemoved = event.Detail
 	}
 
@@ -225,7 +227,7 @@ func (sm *StateMachine) processWorkflowEvent(wf *config.WorkflowConfig, event Ch
 
 			if count >= maxRetries {
 				// Reject back-edge, transition to failed.
-				sm.eventlog.Log("cycle_limit_reached", event.Repo, event.IssueNum,
+				sm.eventlog.Log(eventlog.TypeCycleLimitReached, event.Repo, event.IssueNum,
 					fmt.Sprintf(`{"from":"%s","to":"%s","count":%d,"max_retries":%d}`,
 						currentStateName, targetStateName, count, maxRetries))
 
@@ -233,7 +235,7 @@ func (sm *StateMachine) processWorkflowEvent(wf *config.WorkflowConfig, event Ch
 				// The "failed" state and "needs-human" label would be applied
 				// by the system. Since Go code doesn't write labels (agents do),
 				// we record the event. In v0.1.0, we still record the intent.
-				sm.eventlog.Log("transition_to_failed", event.Repo, event.IssueNum,
+				sm.eventlog.Log(eventlog.TypeTransitionToFailed, event.Repo, event.IssueNum,
 					fmt.Sprintf(`{"from":"%s","rejected_to":"%s","needs_human":true}`,
 						currentStateName, targetStateName))
 				return nil
@@ -247,7 +249,7 @@ func (sm *StateMachine) processWorkflowEvent(wf *config.WorkflowConfig, event Ch
 		}
 
 		// Log the transition.
-		sm.eventlog.Log("transition", event.Repo, event.IssueNum,
+		sm.eventlog.Log(eventlog.TypeTransition, event.Repo, event.IssueNum,
 			fmt.Sprintf(`{"from":"%s","to":"%s"}`, currentStateName, targetStateName))
 
 		// If the target state has an agent, dispatch it.
@@ -272,7 +274,7 @@ func (sm *StateMachine) dispatchAgent(repo string, issueNum int, agentName, work
 	sm.inflightMu.Lock()
 	if sm.inflight[issueKey] {
 		sm.inflightMu.Unlock()
-		sm.eventlog.Log("dispatch_skipped_inflight", repo, issueNum,
+		sm.eventlog.Log(eventlog.TypeDispatchSkippedInflight, repo, issueNum,
 			fmt.Sprintf(`{"agent":"%s","reason":"agent already running"}`, agentName))
 		return nil
 	}
@@ -362,7 +364,7 @@ func (sm *StateMachine) CheckStuck(repo string, issueNum int, currentLabels []st
 	currentJSON, _ := json.Marshal(currentLabels)
 	if string(currentJSON) == rec.labels {
 		// Labels unchanged after timeout — stuck!
-		sm.eventlog.Log("stuck_detected", repo, issueNum,
+		sm.eventlog.Log(eventlog.TypeStuckDetected, repo, issueNum,
 			fmt.Sprintf(`{"since":"%s","labels":%s}`, rec.at.Format(time.RFC3339), rec.labels))
 
 		// Clear the record so we don't keep firing.

--- a/internal/statemachine/statemachine_test.go
+++ b/internal/statemachine/statemachine_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/Lincyaw/workbuddy/internal/config"
+	"github.com/Lincyaw/workbuddy/internal/eventlog"
+	"github.com/Lincyaw/workbuddy/internal/poller"
 	"github.com/Lincyaw/workbuddy/internal/store"
 )
 
@@ -113,7 +115,7 @@ func TestNormalTransition(t *testing.T) {
 	sm, rec, dispatch := newTestSM(t)
 
 	event := ChangeEvent{
-		Type:     "label_added",
+		Type:     poller.EventLabelAdded,
 		Repo:     "test/repo",
 		IssueNum: 1,
 		Labels:   []string{"workbuddy", "status:developing"},
@@ -125,7 +127,7 @@ func TestNormalTransition(t *testing.T) {
 	}
 
 	// Should have logged a transition.
-	transitions := rec.find("transition")
+	transitions := rec.find(eventlog.TypeTransition)
 	if len(transitions) != 1 {
 		t.Fatalf("expected 1 transition event, got %d", len(transitions))
 	}
@@ -150,7 +152,7 @@ func TestBackEdgeCount(t *testing.T) {
 
 	// First: developing → reviewing (creates history for reviewing).
 	ev1 := ChangeEvent{
-		Type:     "label_added",
+		Type:     poller.EventLabelAdded,
 		Repo:     "test/repo",
 		IssueNum: 2,
 		Labels:   []string{"workbuddy", "status:developing"},
@@ -167,7 +169,7 @@ func TestBackEdgeCount(t *testing.T) {
 
 	// Now: reviewing → developing (this is a back-edge since developing was visited).
 	ev2 := ChangeEvent{
-		Type:     "label_added",
+		Type:     poller.EventLabelAdded,
 		Repo:     "test/repo",
 		IssueNum: 2,
 		Labels:   []string{"workbuddy", "status:reviewing"},
@@ -226,7 +228,7 @@ func TestRetryLimitFailed(t *testing.T) {
 
 	// Step 1: developing → reviewing (not a back-edge)
 	if err := sm.HandleEvent(ChangeEvent{
-		Type: "label_added", Repo: repo, IssueNum: issueNum,
+		Type: poller.EventLabelAdded, Repo: repo, IssueNum: issueNum,
 		Labels: []string{"workbuddy", "status:developing"}, Detail: "status:reviewing",
 	}); err != nil {
 		t.Fatalf("HandleEvent step 1: %v", err)
@@ -239,7 +241,7 @@ func TestRetryLimitFailed(t *testing.T) {
 	// not yet a target. Actually, let's check: is there any prior transition TO developing?
 	// No — step 1 was TO reviewing. So this is NOT a back-edge.)
 	if err := sm.HandleEvent(ChangeEvent{
-		Type: "label_added", Repo: repo, IssueNum: issueNum,
+		Type: poller.EventLabelAdded, Repo: repo, IssueNum: issueNum,
 		Labels: []string{"workbuddy", "status:reviewing"}, Detail: "status:developing",
 	}); err != nil {
 		t.Fatalf("HandleEvent step 2: %v", err)
@@ -252,7 +254,7 @@ func TestRetryLimitFailed(t *testing.T) {
 	// This IS a back-edge. Count for developing→reviewing: was 1, increment to 2.
 	// 2 >= max_retries (2) → cycle_limit_reached → transition to failed.
 	err := sm.HandleEvent(ChangeEvent{
-		Type: "label_added", Repo: repo, IssueNum: issueNum,
+		Type: poller.EventLabelAdded, Repo: repo, IssueNum: issueNum,
 		Labels: []string{"workbuddy", "status:developing"}, Detail: "status:reviewing",
 	})
 	if err != nil {
@@ -268,10 +270,10 @@ func TestRetryLimitFailed(t *testing.T) {
 	}
 
 	// Should have logged cycle_limit_reached and transition_to_failed.
-	if len(rec.find("cycle_limit_reached")) == 0 {
+	if len(rec.find(eventlog.TypeCycleLimitReached)) == 0 {
 		t.Error("expected cycle_limit_reached event")
 	}
-	if len(rec.find("transition_to_failed")) == 0 {
+	if len(rec.find(eventlog.TypeTransitionToFailed)) == 0 {
 		t.Error("expected transition_to_failed event")
 	}
 }
@@ -281,7 +283,7 @@ func TestNoMatchSkip(t *testing.T) {
 	sm, rec, _ := newTestSM(t)
 
 	err := sm.HandleEvent(ChangeEvent{
-		Type:     "label_added",
+		Type:     poller.EventLabelAdded,
 		Repo:     "test/repo",
 		IssueNum: 99,
 		Labels:   []string{"bug", "priority:high"}, // no "workbuddy" trigger label
@@ -320,7 +322,7 @@ func TestMultiWorkflowReject(t *testing.T) {
 	)
 
 	err := sm.HandleEvent(ChangeEvent{
-		Type:     "label_added",
+		Type:     poller.EventLabelAdded,
 		Repo:     "test/repo",
 		IssueNum: 10,
 		Labels:   []string{"workbuddy", "status:developing"},
@@ -330,7 +332,7 @@ func TestMultiWorkflowReject(t *testing.T) {
 		t.Error("expected error for multi-workflow match")
 	}
 
-	if len(rec.find("error_multi_workflow")) == 0 {
+	if len(rec.find(eventlog.TypeErrorMultiWorkflow)) == 0 {
 		t.Error("expected error_multi_workflow event")
 	}
 }
@@ -340,7 +342,7 @@ func TestIdempotent(t *testing.T) {
 	sm, rec, dispatch := newTestSM(t)
 
 	event := ChangeEvent{
-		Type:     "label_added",
+		Type:     poller.EventLabelAdded,
 		Repo:     "test/repo",
 		IssueNum: 5,
 		Labels:   []string{"workbuddy", "status:developing"},
@@ -358,7 +360,7 @@ func TestIdempotent(t *testing.T) {
 	}
 
 	// Should have only 1 transition event.
-	transitions := rec.find("transition")
+	transitions := rec.find(eventlog.TypeTransition)
 	if len(transitions) != 1 {
 		t.Errorf("expected 1 transition (idempotent), got %d", len(transitions))
 	}
@@ -378,7 +380,7 @@ func TestExecutionMutex(t *testing.T) {
 
 	// First event triggers dispatch (developing → reviewing, dispatches review-agent).
 	if err := sm.HandleEvent(ChangeEvent{
-		Type: "label_added", Repo: "r", IssueNum: 7,
+		Type: poller.EventLabelAdded, Repo: "r", IssueNum: 7,
 		Labels: []string{"workbuddy", "status:developing"}, Detail: "status:reviewing",
 	}); err != nil {
 		t.Fatalf("HandleEvent 1: %v", err)
@@ -390,7 +392,7 @@ func TestExecutionMutex(t *testing.T) {
 
 	// Now try reviewing → developing (which would dispatch dev-agent).
 	if err := sm.HandleEvent(ChangeEvent{
-		Type: "label_added", Repo: "r", IssueNum: 7,
+		Type: poller.EventLabelAdded, Repo: "r", IssueNum: 7,
 		Labels: []string{"workbuddy", "status:reviewing"}, Detail: "status:developing",
 	}); err != nil {
 		t.Fatalf("HandleEvent 2: %v", err)
@@ -405,7 +407,7 @@ func TestExecutionMutex(t *testing.T) {
 	}
 
 	// Should have logged the skip.
-	if len(rec.find("dispatch_skipped_inflight")) == 0 {
+	if len(rec.find(eventlog.TypeDispatchSkippedInflight)) == 0 {
 		t.Error("expected dispatch_skipped_inflight event")
 	}
 }
@@ -417,7 +419,7 @@ func TestStuckDetection(t *testing.T) {
 
 	// Trigger a transition.
 	if err := sm.HandleEvent(ChangeEvent{
-		Type: "label_added", Repo: "test/repo", IssueNum: 8,
+		Type: poller.EventLabelAdded, Repo: "test/repo", IssueNum: 8,
 		Labels: []string{"workbuddy", "status:developing"}, Detail: "status:reviewing",
 	}); err != nil {
 		t.Fatalf("HandleEvent: %v", err)
@@ -434,7 +436,7 @@ func TestStuckDetection(t *testing.T) {
 	// Check stuck with same labels (unchanged).
 	sm.CheckStuck("test/repo", 8, labels)
 
-	if len(rec.find("stuck_detected")) == 0 {
+	if len(rec.find(eventlog.TypeStuckDetected)) == 0 {
 		t.Error("expected stuck_detected event")
 	}
 }
@@ -445,7 +447,7 @@ func TestStuckDetection(t *testing.T) {
 
 func TestConditionLabeled_Positive(t *testing.T) {
 	ctx := &EvalContext{
-		EventType:  "label_added",
+		EventType:  poller.EventLabelAdded,
 		LabelAdded: "status:reviewing",
 		Labels:     []string{"status:reviewing"},
 	}
@@ -456,7 +458,7 @@ func TestConditionLabeled_Positive(t *testing.T) {
 
 func TestConditionLabeled_Negative(t *testing.T) {
 	ctx := &EvalContext{
-		EventType:  "label_added",
+		EventType:  poller.EventLabelAdded,
 		LabelAdded: "status:developing",
 		Labels:     []string{"status:developing"},
 	}
@@ -466,70 +468,70 @@ func TestConditionLabeled_Negative(t *testing.T) {
 }
 
 func TestConditionPrOpened_Positive(t *testing.T) {
-	ctx := &EvalContext{EventType: "pr_created"}
+	ctx := &EvalContext{EventType: poller.EventPRCreated}
 	if !EvaluateCondition("pr_opened", ctx) {
 		t.Error("pr_opened should match pr_created event")
 	}
 }
 
 func TestConditionPrOpened_Negative(t *testing.T) {
-	ctx := &EvalContext{EventType: "label_added"}
+	ctx := &EvalContext{EventType: poller.EventLabelAdded}
 	if EvaluateCondition("pr_opened", ctx) {
 		t.Error("pr_opened should not match label_added event")
 	}
 }
 
 func TestConditionChecksPassed_Positive(t *testing.T) {
-	ctx := &EvalContext{ChecksState: "passed"}
+	ctx := &EvalContext{ChecksState: ChecksPassed}
 	if !EvaluateCondition("checks_passed", ctx) {
 		t.Error("checks_passed should match")
 	}
 }
 
 func TestConditionChecksPassed_Negative(t *testing.T) {
-	ctx := &EvalContext{ChecksState: "failed"}
+	ctx := &EvalContext{ChecksState: ChecksFailed}
 	if EvaluateCondition("checks_passed", ctx) {
 		t.Error("checks_passed should not match failed")
 	}
 }
 
 func TestConditionChecksFailed_Positive(t *testing.T) {
-	ctx := &EvalContext{ChecksState: "failed"}
+	ctx := &EvalContext{ChecksState: ChecksFailed}
 	if !EvaluateCondition("checks_failed", ctx) {
 		t.Error("checks_failed should match")
 	}
 }
 
 func TestConditionChecksFailed_Negative(t *testing.T) {
-	ctx := &EvalContext{ChecksState: "passed"}
+	ctx := &EvalContext{ChecksState: ChecksPassed}
 	if EvaluateCondition("checks_failed", ctx) {
 		t.Error("checks_failed should not match passed")
 	}
 }
 
 func TestConditionApproved_Positive(t *testing.T) {
-	ctx := &EvalContext{EventType: "approved"}
+	ctx := &EvalContext{EventType: EventApproved}
 	if !EvaluateCondition("approved", ctx) {
 		t.Error("approved should match")
 	}
 }
 
 func TestConditionApproved_Negative(t *testing.T) {
-	ctx := &EvalContext{EventType: "changes_requested"}
+	ctx := &EvalContext{EventType: EventChangesRequested}
 	if EvaluateCondition("approved", ctx) {
 		t.Error("approved should not match changes_requested")
 	}
 }
 
 func TestConditionChangesRequested_Positive(t *testing.T) {
-	ctx := &EvalContext{EventType: "changes_requested"}
+	ctx := &EvalContext{EventType: EventChangesRequested}
 	if !EvaluateCondition("changes_requested", ctx) {
 		t.Error("changes_requested should match")
 	}
 }
 
 func TestConditionChangesRequested_Negative(t *testing.T) {
-	ctx := &EvalContext{EventType: "approved"}
+	ctx := &EvalContext{EventType: EventApproved}
 	if EvaluateCondition("changes_requested", ctx) {
 		t.Error("changes_requested should not match approved")
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -11,6 +11,15 @@ import (
 	_ "modernc.org/sqlite" // sqlite driver
 )
 
+// Task status constants.
+const (
+	TaskStatusPending   = "pending"
+	TaskStatusRunning   = "running"
+	TaskStatusCompleted = "completed"
+	TaskStatusFailed    = "failed"
+	TaskStatusTimeout   = "timeout"
+)
+
 // Store provides typed CRUD access to the workbuddy SQLite database.
 type Store struct {
 	db *sql.DB

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -46,11 +46,11 @@ func TestCreateAndReadWrite(t *testing.T) {
 	}
 
 	// --- Tasks ---
-	err = s.InsertTask(TaskRecord{ID: "task-1", Repo: "org/repo", IssueNum: 1, AgentName: "dev", Status: "pending"})
+	err = s.InsertTask(TaskRecord{ID: "task-1", Repo: "org/repo", IssueNum: 1, AgentName: "dev", Status: TaskStatusPending})
 	if err != nil {
 		t.Fatalf("InsertTask: %v", err)
 	}
-	tasks, err := s.QueryTasks("pending")
+	tasks, err := s.QueryTasks(TaskStatusPending)
 	if err != nil {
 		t.Fatalf("QueryTasks: %v", err)
 	}
@@ -58,14 +58,14 @@ func TestCreateAndReadWrite(t *testing.T) {
 		t.Fatalf("unexpected tasks: %+v", tasks)
 	}
 	// Update status.
-	if err := s.UpdateTaskStatus("task-1", "running"); err != nil {
+	if err := s.UpdateTaskStatus("task-1", TaskStatusRunning); err != nil {
 		t.Fatalf("UpdateTaskStatus: %v", err)
 	}
-	tasks, _ = s.QueryTasks("pending")
+	tasks, _ = s.QueryTasks(TaskStatusPending)
 	if len(tasks) != 0 {
 		t.Fatalf("expected 0 pending tasks after update, got %d", len(tasks))
 	}
-	tasks, _ = s.QueryTasks("running")
+	tasks, _ = s.QueryTasks(TaskStatusRunning)
 	if len(tasks) != 1 {
 		t.Fatalf("expected 1 running task, got %d", len(tasks))
 	}
@@ -213,7 +213,7 @@ func TestRestartRetention(t *testing.T) {
 	if err != nil {
 		t.Fatalf("InsertEvent: %v", err)
 	}
-	err = s1.InsertTask(TaskRecord{ID: "t-1", Repo: "org/repo", IssueNum: 1, AgentName: "dev", Status: "pending"})
+	err = s1.InsertTask(TaskRecord{ID: "t-1", Repo: "org/repo", IssueNum: 1, AgentName: "dev", Status: TaskStatusPending})
 	if err != nil {
 		t.Fatalf("InsertTask: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Define named constants for poller event types (`EventLabelAdded`, `EventIssueCreated`, etc.) in `internal/poller/`
- Add missing eventlog type constants (`TypeStateEntry`, `TypeCycleLimitReached`, `TypeStuckDetected`, etc.) to `internal/eventlog/`
- Define task status constants (`TaskStatusPending`, `TaskStatusRunning`, `TaskStatusCompleted`, `TaskStatusFailed`, `TaskStatusTimeout`) in `internal/store/`
- Define checks state constants (`ChecksPassed`, `ChecksFailed`) and event types (`EventApproved`, `EventChangesRequested`) in `internal/statemachine/`
- Define config state constants (`StateNameFailed`, `LabelFailed`) in `internal/config/`
- Replace all magic string literals across 14 source and test files

Closes #3

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1` — all 12 packages pass
- [x] No new external dependencies added
- [x] Grep confirms no remaining magic strings for replaced categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)