### PR TITLE
Fix critical bugs and add issue cancellation mechanism

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -476,7 +476,7 @@ func executeTask(ctx context.Context, task router.WorkerTask, deps *workerDeps) 
 		if err := deps.store.UpdateTaskStatus(task.TaskID, store.TaskStatusFailed); err != nil {
 			log.Printf("[worker] failed to update task status: %v", err)
 		}
-		deps.sm.MarkAgentCompleted(task.Repo, task.IssueNum, nil)
+		deps.sm.MarkAgentCompleted(task.Repo, task.IssueNum, fetchCachedLabels(deps.store, task.Repo, task.IssueNum))
 		return
 	}
 
@@ -522,7 +522,7 @@ func executeTask(ctx context.Context, task router.WorkerTask, deps *workerDeps) 
 	}
 
 	// Mark agent completed in state machine
-	deps.sm.MarkAgentCompleted(task.Repo, task.IssueNum, nil)
+	deps.sm.MarkAgentCompleted(task.Repo, task.IssueNum, fetchCachedLabels(deps.store, task.Repo, task.IssueNum))
 }
 
 // addClaimReaction adds an eyes (👀) reaction to the issue to signal an agent claimed it.
@@ -534,6 +534,21 @@ func addClaimReaction(repo string, issueNum int, agentName string) {
 		log.Printf("[worker] failed to add claim reaction for %s on %s#%d: %v (output: %s)",
 			agentName, repo, issueNum, err, string(out))
 	}
+}
+
+// fetchCachedLabels retrieves the current labels for an issue from the store's
+// issue cache. Returns nil if the cache entry is missing or unparseable.
+func fetchCachedLabels(st *store.Store, repo string, issueNum int) []string {
+	cached, err := st.QueryIssueCache(repo, issueNum)
+	if err != nil || cached == nil {
+		return nil
+	}
+	var labels []string
+	if err := json.Unmarshal([]byte(cached.Labels), &labels); err != nil {
+		log.Printf("[worker] failed to parse cached labels for %s#%d: %v", repo, issueNum, err)
+		return nil
+	}
+	return labels
 }
 
 // recoverTasks marks running tasks as failed and re-routes pending tasks on restart.

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -341,7 +341,7 @@ func runServeWithOpts(opts *serveOpts, ghReader poller.GHReader, launcherOverrid
 					Labels:   ev.Labels,
 					Detail:   ev.Detail,
 				}
-				if err := sm.HandleEvent(smEvent); err != nil {
+				if err := sm.HandleEvent(ctx, smEvent); err != nil {
 					log.Printf("[serve] state machine error: %v", err)
 				}
 			}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -37,6 +37,50 @@ const (
 	agentShutdownWait   = 60 * time.Second
 )
 
+// RunningTasks is a thread-safe registry of cancel functions for running agent tasks.
+type RunningTasks struct {
+	mu    sync.Mutex
+	tasks map[string]context.CancelFunc // key: "repo#issueNum"
+}
+
+// NewRunningTasks creates a new RunningTasks registry.
+func NewRunningTasks() *RunningTasks {
+	return &RunningTasks{tasks: make(map[string]context.CancelFunc)}
+}
+
+func runningTaskKey(repo string, issue int) string {
+	return fmt.Sprintf("%s#%d", repo, issue)
+}
+
+// Register stores a cancel function for a running task.
+func (rt *RunningTasks) Register(repo string, issue int, cancel context.CancelFunc) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	rt.tasks[runningTaskKey(repo, issue)] = cancel
+}
+
+// Cancel cancels the running task for the given repo+issue and returns true,
+// or returns false if no such task is running.
+func (rt *RunningTasks) Cancel(repo string, issue int) bool {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	key := runningTaskKey(repo, issue)
+	cancel, ok := rt.tasks[key]
+	if !ok {
+		return false
+	}
+	cancel()
+	delete(rt.tasks, key)
+	return true
+}
+
+// Remove removes the entry for a completed task (without cancelling).
+func (rt *RunningTasks) Remove(repo string, issue int) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	delete(rt.tasks, runningTaskKey(repo, issue))
+}
+
 // serveOpts holds parsed CLI flags for the serve command.
 type serveOpts struct {
 	port         int
@@ -322,6 +366,9 @@ func runServeWithOpts(opts *serveOpts, ghReader poller.GHReader, launcherOverrid
 		}
 	}()
 
+	// Running tasks registry for cancellation on issue close.
+	runningTasks := NewRunningTasks()
+
 	// 7. Start StateMachine event processor (reads from poller events)
 	wg.Add(1)
 	go func() {
@@ -333,6 +380,13 @@ func runServeWithOpts(opts *serveOpts, ghReader poller.GHReader, launcherOverrid
 			case ev, ok := <-p.Events():
 				if !ok {
 					return
+				}
+				// Handle issue closure: cancel running agent and skip state machine.
+				if ev.Type == poller.EventIssueClosed {
+					if cancelled := runningTasks.Cancel(ev.Repo, ev.IssueNum); cancelled {
+						log.Printf("[serve] cancelled agent for closed issue %s#%d", ev.Repo, ev.IssueNum)
+					}
+					continue // don't pass to state machine
 				}
 				smEvent := statemachine.ChangeEvent{
 					Type:     ev.Type,
@@ -359,14 +413,15 @@ func runServeWithOpts(opts *serveOpts, ghReader poller.GHReader, launcherOverrid
 
 	// 9. Start embedded Worker goroutine
 	deps := &workerDeps{
-		launcher: lnch,
-		auditor:  auditor,
-		reporter: rep,
-		store:    st,
-		sm:       sm,
-		workerID: workerID,
-		cfg:      cfg,
-		wsMgr:    wsMgr,
+		launcher:     lnch,
+		auditor:      auditor,
+		reporter:     rep,
+		store:        st,
+		sm:           sm,
+		workerID:     workerID,
+		cfg:          cfg,
+		wsMgr:        wsMgr,
+		runningTasks: runningTasks,
 	}
 	workerDone := make(chan struct{})
 	wg.Add(1)
@@ -423,14 +478,15 @@ func runServeWithOpts(opts *serveOpts, ghReader poller.GHReader, launcherOverrid
 
 // workerDeps bundles the dependencies for the embedded worker, avoiding parameter sprawl.
 type workerDeps struct {
-	launcher *launcher.Launcher
-	auditor  *audit.Auditor
-	reporter *reporter.Reporter
-	store    *store.Store
-	sm       *statemachine.StateMachine
-	workerID string
-	cfg      *config.FullConfig
-	wsMgr    *workspace.Manager
+	launcher     *launcher.Launcher
+	auditor      *audit.Auditor
+	reporter     *reporter.Reporter
+	store        *store.Store
+	sm           *statemachine.StateMachine
+	workerID     string
+	cfg          *config.FullConfig
+	wsMgr        *workspace.Manager
+	runningTasks *RunningTasks
 }
 
 // runEmbeddedWorker runs the embedded worker loop.
@@ -450,6 +506,16 @@ func runEmbeddedWorker(ctx context.Context, taskCh <-chan router.WorkerTask, dep
 
 // executeTask runs a single agent task and handles reporting/auditing.
 func executeTask(ctx context.Context, task router.WorkerTask, deps *workerDeps) {
+	// Create a per-task context that can be cancelled independently (e.g., on issue close).
+	taskCtx, taskCancel := context.WithCancel(ctx)
+	defer taskCancel()
+
+	// Register for cancellation on issue close.
+	if deps.runningTasks != nil {
+		deps.runningTasks.Register(task.Repo, task.IssueNum, taskCancel)
+		defer deps.runningTasks.Remove(task.Repo, task.IssueNum)
+	}
+
 	// Clean up worktree after task completes.
 	if task.WorktreePath != "" && deps.wsMgr != nil {
 		defer func() {
@@ -470,7 +536,7 @@ func executeTask(ctx context.Context, task router.WorkerTask, deps *workerDeps) 
 		log.Printf("[worker] report started failed: %v", err)
 	}
 
-	result, err := deps.launcher.Launch(ctx, task.Agent, task.Context)
+	result, err := deps.launcher.Launch(taskCtx, task.Agent, task.Context)
 	if err != nil {
 		log.Printf("[worker] agent %s failed: %v", task.AgentName, err)
 		if err := deps.store.UpdateTaskStatus(task.TaskID, store.TaskStatusFailed); err != nil {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -528,7 +528,7 @@ func executeTask(ctx context.Context, task router.WorkerTask, deps *workerDeps) 
 		task.TaskID, task.AgentName, task.Repo, task.IssueNum)
 
 	// Add claim reaction (eyes) to signal this issue is being worked on.
-	addClaimReaction(task.Repo, task.IssueNum, task.AgentName)
+	addClaimReaction(taskCtx, task.Repo, task.IssueNum, task.AgentName)
 
 	// Post "Agent Started" comment with session link.
 	sessionID := task.Context.Session.ID
@@ -591,12 +591,15 @@ func executeTask(ctx context.Context, task router.WorkerTask, deps *workerDeps) 
 	deps.sm.MarkAgentCompleted(task.Repo, task.IssueNum, fetchCachedLabels(deps.store, task.Repo, task.IssueNum))
 }
 
-// addClaimReaction adds an eyes (👀) reaction to the issue to signal an agent claimed it.
-func addClaimReaction(repo string, issueNum int, agentName string) {
-	cmd := exec.Command("gh", "api",
+// addClaimReaction adds an eyes reaction to the issue to signal an agent claimed it.
+func addClaimReaction(ctx context.Context, repo string, issueNum int, agentName string) {
+	cmd := exec.CommandContext(ctx, "gh", "api",
 		fmt.Sprintf("repos/%s/issues/%d/reactions", repo, issueNum),
 		"-f", "content=eyes", "--silent")
 	if out, err := cmd.CombinedOutput(); err != nil {
+		if ctx.Err() != nil {
+			return // cancelled, don't log
+		}
 		log.Printf("[worker] failed to add claim reaction for %s on %s#%d: %v (output: %s)",
 			agentName, repo, issueNum, err, string(out))
 	}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -320,3 +320,71 @@ func TestServe_HealthEndpoint(t *testing.T) {
 		t.Fatal("serve did not exit within timeout")
 	}
 }
+
+// TestRunningTasks_RegisterCancelRemove verifies the RunningTasks registry.
+func TestRunningTasks_RegisterCancelRemove(t *testing.T) {
+	rt := NewRunningTasks()
+
+	// Cancel non-existent task returns false.
+	if rt.Cancel("owner/repo", 1) {
+		t.Error("expected Cancel to return false for unregistered task")
+	}
+
+	// Register a task with a cancellable context.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	rt.Register("owner/repo", 1, cancel)
+
+	// Cancel should return true and actually cancel the context.
+	if !rt.Cancel("owner/repo", 1) {
+		t.Error("expected Cancel to return true for registered task")
+	}
+	if ctx.Err() == nil {
+		t.Error("expected context to be cancelled after Cancel()")
+	}
+
+	// Second cancel should return false (already removed).
+	if rt.Cancel("owner/repo", 1) {
+		t.Error("expected Cancel to return false after already cancelled")
+	}
+}
+
+// TestRunningTasks_Remove verifies that Remove prevents future Cancel.
+func TestRunningTasks_Remove(t *testing.T) {
+	rt := NewRunningTasks()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	rt.Register("owner/repo", 5, cancel)
+
+	// Remove without cancelling.
+	rt.Remove("owner/repo", 5)
+
+	// Cancel should now return false.
+	if rt.Cancel("owner/repo", 5) {
+		t.Error("expected Cancel to return false after Remove")
+	}
+
+	// Context should NOT have been cancelled by Remove.
+	if ctx.Err() != nil {
+		t.Error("expected context to still be active after Remove (not Cancel)")
+	}
+}
+
+// TestRunningTasks_Concurrent verifies thread safety.
+func TestRunningTasks_Concurrent(t *testing.T) {
+	rt := NewRunningTasks()
+	var wg sync.WaitGroup
+
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			_, cancel := context.WithCancel(context.Background())
+			rt.Register("owner/repo", n, cancel)
+			rt.Cancel("owner/repo", n)
+			rt.Remove("owner/repo", n)
+		}(i)
+	}
+	wg.Wait()
+}

--- a/internal/launcher/launcher_test.go
+++ b/internal/launcher/launcher_test.go
@@ -98,9 +98,11 @@ func TestLaunch_TemplateRender(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	// Issue.Title is auto-escaped (wrapped in single quotes) for shell safety.
+	// Non-issue fields (Repo, Session.ID, PR.*) are not escaped.
 	expected := []string{
 		"issue=42",
-		"title=test issue",
+		"title='test issue'",
 		"repo=" + task.Repo,
 		"session=session-abc-123",
 		"pr=https://github.com/test/repo/pull/1",
@@ -502,5 +504,147 @@ func TestRenderCommand(t *testing.T) {
 	}
 	if rendered != "echo 7 sess-1" {
 		t.Errorf("unexpected rendered command: %q", rendered)
+	}
+}
+
+// Test: shellEscape correctly wraps values
+func TestShellEscape(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"hello", "'hello'"},
+		{"it's", `'it'\''s'`},
+		{`"; rm -rf / #`, `'"; rm -rf / #'`},
+		{"", "''"},
+		{"a'b'c", `'a'\''b'\''c'`},
+	}
+	for _, tt := range tests {
+		got := shellEscape(tt.input)
+		if got != tt.want {
+			t.Errorf("shellEscape(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+// Test: renderCommand auto-escapes user-controlled issue fields
+func TestRenderCommand_AutoEscapesIssueFields(t *testing.T) {
+	task := &TaskContext{
+		Issue: IssueContext{
+			Number: 1,
+			Title:  `"; rm -rf / #`,
+			Body:   "$(evil command)",
+			Labels: []string{"label; whoami"},
+		},
+		Repo: "owner/repo",
+		Session: SessionContext{ID: "s1"},
+	}
+
+	rendered, err := renderCommand("echo {{.Issue.Title}}", task)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The title must be wrapped in single quotes, neutralizing the shell metacharacters
+	if !strings.Contains(rendered, "'") {
+		t.Errorf("expected shell-escaped title with single quotes, got: %q", rendered)
+	}
+	if strings.Contains(rendered, "rm -rf") && !strings.Contains(rendered, "'") {
+		t.Error("shell metacharacters in title are not escaped")
+	}
+}
+
+// Test: shell injection via issue title is neutralized end-to-end
+func TestLaunch_ShellInjectionTitle(t *testing.T) {
+	launcher := NewLauncher()
+	dir := t.TempDir()
+
+	// A malicious title that tries to create a file via command injection
+	markerFile := filepath.Join(dir, "pwned.txt")
+
+	task := &TaskContext{
+		Issue: IssueContext{
+			Number: 99,
+			Title:  `"; touch ` + markerFile + ` #`,
+			Body:   "normal body",
+			Labels: []string{"status:dev"},
+		},
+		Repo:    "test/repo",
+		WorkDir: dir,
+		Session: SessionContext{ID: "sec-test"},
+	}
+
+	agent := &config.AgentConfig{
+		Name:    "injection-test",
+		Runtime: "claude-code",
+		Command: `echo {{.Issue.Title}}`,
+		Timeout: 10 * time.Second,
+	}
+
+	result, err := launcher.Launch(context.Background(), agent, task)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The command should have printed the escaped title, not executed injection
+	if result.ExitCode != 0 {
+		t.Logf("stderr: %s", result.Stderr)
+	}
+
+	// The marker file must NOT exist — injection must have been prevented
+	if _, err := os.Stat(markerFile); err == nil {
+		t.Fatal("SECURITY: shell injection succeeded — marker file was created")
+	}
+}
+
+// Test: shell injection via issue body is neutralized end-to-end
+func TestLaunch_ShellInjectionBody(t *testing.T) {
+	launcher := NewLauncher()
+	dir := t.TempDir()
+
+	markerFile := filepath.Join(dir, "pwned_body.txt")
+
+	task := &TaskContext{
+		Issue: IssueContext{
+			Number: 100,
+			Title:  "safe title",
+			Body:   "$(touch " + markerFile + ")",
+			Labels: []string{"status:dev"},
+		},
+		Repo:    "test/repo",
+		WorkDir: dir,
+		Session: SessionContext{ID: "sec-test-2"},
+	}
+
+	agent := &config.AgentConfig{
+		Name:    "injection-body-test",
+		Runtime: "claude-code",
+		Command: `echo {{.Issue.Body}}`,
+		Timeout: 10 * time.Second,
+	}
+
+	_, err := launcher.Launch(context.Background(), agent, task)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err := os.Stat(markerFile); err == nil {
+		t.Fatal("SECURITY: shell injection via body succeeded — marker file was created")
+	}
+}
+
+// Test: shellEscape template function is available for explicit use
+func TestRenderCommand_ShellEscapeFunc(t *testing.T) {
+	task := &TaskContext{
+		Issue:   IssueContext{Number: 1, Title: "test"},
+		Repo:    "owner/repo",
+		Session: SessionContext{ID: "s1"},
+	}
+
+	rendered, err := renderCommand(`echo {{shellEscape .Repo}}`, task)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rendered != "echo 'owner/repo'" {
+		t.Errorf("unexpected rendered: %q", rendered)
 	}
 }

--- a/internal/launcher/launcher_test.go
+++ b/internal/launcher/launcher_test.go
@@ -419,10 +419,11 @@ func TestParseMeta(t *testing.T) {
 // Test: extractPrompt detects claude -p commands and extracts the prompt
 func TestExtractPrompt(t *testing.T) {
 	tests := []struct {
-		name      string
-		input     string
-		wantOK    bool
+		name       string
+		input      string
+		wantOK     bool
 		wantPrompt string
+		wantArgs   []string
 	}{
 		{
 			name:       "double quoted",
@@ -455,6 +456,13 @@ func TestExtractPrompt(t *testing.T) {
 			wantPrompt: "run `echo hello`",
 		},
 		{
+			name:       "with --print flag preserved",
+			input:      `claude --print -p "hello world"`,
+			wantOK:     true,
+			wantPrompt: "hello world",
+			wantArgs:   []string{"--print"},
+		},
+		{
 			name:   "not a claude command",
 			input:  `echo "hello world"`,
 			wantOK: false,
@@ -468,12 +476,22 @@ func TestExtractPrompt(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			prompt, ok := extractPrompt(tt.input)
+			prompt, args, ok := extractPrompt(tt.input)
 			if ok != tt.wantOK {
 				t.Fatalf("extractPrompt ok=%v, want %v", ok, tt.wantOK)
 			}
 			if ok && prompt != tt.wantPrompt {
 				t.Errorf("extractPrompt prompt=%q, want %q", prompt, tt.wantPrompt)
+			}
+			if ok && len(tt.wantArgs) > 0 {
+				if len(args) != len(tt.wantArgs) {
+					t.Fatalf("extractPrompt args=%v, want %v", args, tt.wantArgs)
+				}
+				for i, a := range args {
+					if a != tt.wantArgs[i] {
+						t.Errorf("extractPrompt args[%d]=%q, want %q", i, a, tt.wantArgs[i])
+					}
+				}
 			}
 		})
 	}

--- a/internal/launcher/process.go
+++ b/internal/launcher/process.go
@@ -42,9 +42,11 @@ func launchProcess(
 
 	// If the command is "claude -p '...'" or similar, extract the prompt and
 	// pass it via stdin to avoid shell quoting issues with issue bodies.
+	// Preserve any extra flags (e.g., --print) from the original command.
 	var cmd *exec.Cmd
-	if prompt, ok := extractPrompt(rendered); ok {
-		cmd = exec.CommandContext(execCtx, "claude", "-p")
+	if prompt, args, ok := extractPrompt(rendered); ok {
+		cmdArgs := append(args, "-p")
+		cmd = exec.CommandContext(execCtx, "claude", cmdArgs...)
 		cmd.Stdin = strings.NewReader(prompt)
 	} else {
 		cmd = exec.CommandContext(execCtx, "sh", "-c", rendered)

--- a/internal/launcher/process.go
+++ b/internal/launcher/process.go
@@ -43,11 +43,19 @@ func launchProcess(
 	// If the command is "claude -p '...'" or similar, extract the prompt and
 	// pass it via stdin to avoid shell quoting issues with issue bodies.
 	// Preserve any extra flags (e.g., --print) from the original command.
+	// Use a raw (unescaped) render for the stdin prompt — shell escaping would
+	// corrupt the content when it's not going through sh -c.
 	var cmd *exec.Cmd
-	if prompt, args, ok := extractPrompt(rendered); ok {
+	if _, args, ok := extractPrompt(rendered); ok {
+		// Re-render without shell escaping to get the raw prompt for stdin.
+		rawRendered, rawErr := renderCommandRaw(agent.Command, task)
+		if rawErr != nil {
+			return nil, rawErr
+		}
+		rawPrompt, _, _ := extractPrompt(rawRendered)
 		cmdArgs := append(args, "-p")
 		cmd = exec.CommandContext(execCtx, "claude", cmdArgs...)
-		cmd.Stdin = strings.NewReader(prompt)
+		cmd.Stdin = strings.NewReader(rawPrompt)
 	} else {
 		cmd = exec.CommandContext(execCtx, "sh", "-c", rendered)
 	}

--- a/internal/launcher/template.go
+++ b/internal/launcher/template.go
@@ -61,24 +61,44 @@ func renderCommand(cmdTemplate string, task *TaskContext) (string, error) {
 // promptPattern matches "claude -p ..." or "claude --print -p ..." command prefixes.
 var promptPattern = regexp.MustCompile(`^claude\s+(?:--print\s+)?-p\s+["']`)
 
-// extractPrompt detects a "claude -p '...'" or 'claude -p "..."' command and
-// extracts the prompt text. This allows passing the prompt via stdin instead of
-// sh -c, avoiding shell quoting issues with issue bodies that contain quotes,
-// backticks, or code blocks.
-func extractPrompt(rendered string) (string, bool) {
+// extractPrompt detects a "claude [flags] -p '...'" command and extracts the
+// prompt text along with any extra flags before -p (e.g., --print). This allows
+// passing the prompt via stdin instead of sh -c, avoiding shell quoting issues
+// with issue bodies that contain quotes, backticks, or code blocks.
+func extractPrompt(rendered string) (prompt string, extraArgs []string, ok bool) {
 	rendered = strings.TrimSpace(rendered)
 	if !promptPattern.MatchString(rendered) {
-		return "", false
+		return "", nil, false
 	}
-	idx := strings.IndexAny(rendered, `"'`)
-	if idx < 0 {
-		return "", false
+
+	// Parse flags between "claude" and the quoted prompt.
+	// The regex guarantees the string starts with "claude" followed by
+	// optional flags and then -p <quote>.
+	afterClaude := strings.TrimSpace(rendered[len("claude"):])
+	var args []string
+	for {
+		if strings.HasPrefix(afterClaude, "-p ") || strings.HasPrefix(afterClaude, "-p\t") {
+			afterClaude = strings.TrimSpace(afterClaude[2:])
+			break
+		}
+		// Consume the next whitespace-delimited token as an extra arg.
+		spaceIdx := strings.IndexAny(afterClaude, " \t")
+		if spaceIdx < 0 {
+			return "", nil, false
+		}
+		args = append(args, afterClaude[:spaceIdx])
+		afterClaude = strings.TrimSpace(afterClaude[spaceIdx:])
 	}
-	quote := rendered[idx]
-	rest := rendered[idx+1:]
+
+	// afterClaude now starts with the opening quote.
+	if len(afterClaude) == 0 {
+		return "", nil, false
+	}
+	quote := afterClaude[0]
+	rest := afterClaude[1:]
 	lastIdx := strings.LastIndexByte(rest, quote)
 	if lastIdx < 0 {
-		return "", false
+		return "", nil, false
 	}
-	return rest[:lastIdx], true
+	return rest[:lastIdx], args, true
 }

--- a/internal/launcher/template.go
+++ b/internal/launcher/template.go
@@ -58,6 +58,23 @@ func renderCommand(cmdTemplate string, task *TaskContext) (string, error) {
 	return buf.String(), nil
 }
 
+// renderCommandRaw renders the command template without shell-escaping.
+// Used when the output will be passed via stdin (not sh -c), so escaping
+// would corrupt the content.
+func renderCommandRaw(cmdTemplate string, task *TaskContext) (string, error) {
+	tmpl, err := template.New("command").Funcs(templateFuncMap).Parse(cmdTemplate)
+	if err != nil {
+		return "", fmt.Errorf("launcher: parse command template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, task); err != nil {
+		return "", fmt.Errorf("launcher: render command template: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
 // promptPattern matches "claude -p ..." or "claude --print -p ..." command prefixes.
 var promptPattern = regexp.MustCompile(`^claude\s+(?:--print\s+)?-p\s+["']`)
 

--- a/internal/launcher/template.go
+++ b/internal/launcher/template.go
@@ -8,15 +8,50 @@ import (
 	"text/template"
 )
 
+// shellEscape wraps a string in single quotes with proper escaping so it is
+// safe to interpolate into a shell command. Interior single quotes are replaced
+// with the sequence '\'' (end quote, escaped quote, start quote).
+func shellEscape(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// safeTaskContext returns a shallow copy of TaskContext where user-controlled
+// fields (Issue.Title, Issue.Body, Issue.Labels) are shell-escaped so that
+// direct interpolation via {{.Issue.Title}} etc. cannot inject shell commands.
+func safeTaskContext(task *TaskContext) *TaskContext {
+	escaped := *task
+	escaped.Issue = IssueContext{
+		Number: task.Issue.Number,
+		Title:  shellEscape(task.Issue.Title),
+		Body:   shellEscape(task.Issue.Body),
+		Labels: make([]string, len(task.Issue.Labels)),
+	}
+	for i, l := range task.Issue.Labels {
+		escaped.Issue.Labels[i] = shellEscape(l)
+	}
+	return &escaped
+}
+
+// templateFuncMap provides helper functions available inside command templates.
+var templateFuncMap = template.FuncMap{
+	"shellEscape": shellEscape,
+}
+
 // renderCommand renders the agent command template with the given task context.
+// User-controlled fields from the GitHub issue (Title, Body, Labels) are
+// automatically shell-escaped to prevent command injection when the rendered
+// string is passed to sh -c. The {{shellEscape .Field}} function is also
+// available for explicit escaping of any value.
 func renderCommand(cmdTemplate string, task *TaskContext) (string, error) {
-	tmpl, err := template.New("command").Parse(cmdTemplate)
+	tmpl, err := template.New("command").Funcs(templateFuncMap).Parse(cmdTemplate)
 	if err != nil {
 		return "", fmt.Errorf("launcher: parse command template: %w", err)
 	}
 
+	safe := safeTaskContext(task)
+
 	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, task); err != nil {
+	if err := tmpl.Execute(&buf, safe); err != nil {
 		return "", fmt.Errorf("launcher: render command template: %w", err)
 	}
 

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -27,6 +27,11 @@ const (
 	EventIssueClosed    = "issue_closed"
 )
 
+// ghListLimit is the maximum number of results returned by gh issue/pr list.
+// When a poll returns this many results, the list may be truncated and close
+// detection is skipped to avoid false positives.
+const ghListLimit = 100
+
 // ---------------------------------------------------------------------------
 // Domain types
 // ---------------------------------------------------------------------------
@@ -183,6 +188,12 @@ func (p *Poller) poll(ctx context.Context) {
 	// --- Detect closed/deleted issues ---
 	// Compare cached issue numbers against what we saw this poll.
 	// Issues in cache but not in current results have been closed/deleted.
+	// Skip this check if the result set may be truncated (gh --limit 100),
+	// since issues beyond the first page would be falsely classified as closed.
+	if len(issues) >= ghListLimit {
+		log.Printf("[poller] issue list may be truncated (%d results), skipping close detection", len(issues))
+		return
+	}
 	openIssueNums := make(map[int]bool, len(issues))
 	for _, iss := range issues {
 		openIssueNums[iss.Number] = true

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -24,6 +24,7 @@ const (
 	EventLabelRemoved   = "label_removed"
 	EventPRCreated      = "pr_created"
 	EventPRStateChanged = "pr_state_changed"
+	EventIssueClosed    = "issue_closed"
 )
 
 // ---------------------------------------------------------------------------
@@ -177,6 +178,44 @@ func (p *Poller) poll(ctx context.Context) {
 			return
 		}
 		p.diffPR(ctx, pr)
+	}
+
+	// --- Detect closed/deleted issues ---
+	// Compare cached issue numbers against what we saw this poll.
+	// Issues in cache but not in current results have been closed/deleted.
+	openIssueNums := make(map[int]bool, len(issues))
+	for _, iss := range issues {
+		openIssueNums[iss.Number] = true
+	}
+	// Also include PR numbers so we don't treat them as closed issues.
+	openPRNums := make(map[int]bool, len(prs))
+	for _, pr := range prs {
+		openPRNums[pr.Number] = true
+	}
+
+	cachedNums, err := p.store.ListCachedIssueNums(p.repo)
+	if err != nil {
+		log.Printf("[poller] error listing cached issue nums for %s: %v", p.repo, err)
+		return
+	}
+
+	for _, num := range cachedNums {
+		if ctx.Err() != nil {
+			return
+		}
+		if openIssueNums[num] || openPRNums[num] {
+			continue
+		}
+		// This issue was in cache but not in current poll results — it was closed/deleted.
+		p.emit(ctx, ChangeEvent{
+			Type:     EventIssueClosed,
+			Repo:     p.repo,
+			IssueNum: num,
+			Detail:   "issue no longer in open issues list",
+		})
+		if err := p.store.DeleteIssueCache(p.repo, num); err != nil {
+			log.Printf("[poller] error deleting cache for closed issue %s#%d: %v", p.repo, num, err)
+		}
 	}
 }
 

--- a/internal/poller/poller_test.go
+++ b/internal/poller/poller_test.go
@@ -416,6 +416,101 @@ func TestLabelsFromJSON_Empty(t *testing.T) {
 	}
 }
 
+func TestIssueClosedDetection(t *testing.T) {
+	st := testStore(t)
+
+	// Seed cache: issue 1 and issue 2 are known open issues.
+	for _, ic := range []store.IssueCache{
+		{Repo: "owner/repo", IssueNum: 1, Labels: `["bug"]`, State: "open"},
+		{Repo: "owner/repo", IssueNum: 2, Labels: `["feature"]`, State: "open"},
+	} {
+		if err := st.UpsertIssueCache(ic); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// GitHub now only returns issue 1 — issue 2 has been closed.
+	gh := &mockGHReader{
+		issues: []Issue{
+			{Number: 1, Title: "Bug report", State: "open", Labels: []string{"bug"}},
+		},
+	}
+	p := NewPoller(gh, st, "owner/repo", time.Hour)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		_ = p.Run(ctx)
+	}()
+
+	events := drain(p.Events(), 500*time.Millisecond)
+	cancel()
+
+	// Should get exactly one EventIssueClosed for issue 2.
+	var closeEvents []ChangeEvent
+	for _, ev := range events {
+		if ev.Type == EventIssueClosed {
+			closeEvents = append(closeEvents, ev)
+		}
+	}
+	if len(closeEvents) != 1 {
+		t.Fatalf("expected 1 issue_closed event, got %d: %+v", len(closeEvents), events)
+	}
+	if closeEvents[0].IssueNum != 2 {
+		t.Errorf("expected issue_closed for issue 2, got %d", closeEvents[0].IssueNum)
+	}
+
+	// Cache entry for issue 2 should have been deleted.
+	ic, err := st.QueryIssueCache("owner/repo", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ic != nil {
+		t.Errorf("expected cache entry for issue 2 to be deleted, but it still exists")
+	}
+}
+
+func TestIssueClosedDoesNotAffectPRs(t *testing.T) {
+	st := testStore(t)
+
+	// Seed cache: issue 1 (open) and PR 10 (pr:open).
+	if err := st.UpsertIssueCache(store.IssueCache{
+		Repo: "owner/repo", IssueNum: 1, Labels: `["bug"]`, State: "open",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertIssueCache(store.IssueCache{
+		Repo: "owner/repo", IssueNum: 10, Labels: "", State: "pr:open",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// GitHub returns issue 1 still open, PR 10 still open.
+	gh := &mockGHReader{
+		issues: []Issue{
+			{Number: 1, Title: "Bug report", State: "open", Labels: []string{"bug"}},
+		},
+		prs: []PR{
+			{Number: 10, URL: "https://github.com/owner/repo/pull/10", Branch: "feature", State: "open"},
+		},
+	}
+	p := NewPoller(gh, st, "owner/repo", time.Hour)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		_ = p.Run(ctx)
+	}()
+
+	events := drain(p.Events(), 500*time.Millisecond)
+	cancel()
+
+	// Should have no close events — PR should not trigger issue_closed.
+	for _, ev := range events {
+		if ev.Type == EventIssueClosed {
+			t.Errorf("unexpected issue_closed event: %+v", ev)
+		}
+	}
+}
+
 func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -153,6 +153,12 @@ func (r *Router) handleDispatch(ctx context.Context, req statemachine.DispatchRe
 			log.Printf("[router] failed to update task status: %v", err)
 		}
 	case <-ctx.Done():
+		// Clean up worktree that was created but never dispatched.
+		if worktreePath != "" && r.wsMgr != nil {
+			if err := r.wsMgr.Remove(worktreePath); err != nil {
+				log.Printf("[router] failed to clean up worktree on cancellation: %v", err)
+			}
+		}
 		return
 	}
 }

--- a/internal/statemachine/statemachine.go
+++ b/internal/statemachine/statemachine.go
@@ -1,6 +1,7 @@
 package statemachine
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -97,11 +98,14 @@ func (sm *StateMachine) SetStuckTimeout(d time.Duration) {
 // Call this at the start of each poll cycle so that events from
 // different cycles are not suppressed.
 func (sm *StateMachine) ResetDedup() {
-	sm.processedEvents = sync.Map{}
+	sm.processedEvents.Range(func(key, value interface{}) bool {
+		sm.processedEvents.Delete(key)
+		return true
+	})
 }
 
 // HandleEvent processes a single ChangeEvent from the Poller.
-func (sm *StateMachine) HandleEvent(event ChangeEvent) error {
+func (sm *StateMachine) HandleEvent(ctx context.Context, event ChangeEvent) error {
 	// Idempotency: build a unique key for this event.
 	eventKey := fmt.Sprintf("%s#%d#%s#%s", event.Repo, event.IssueNum, event.Type, event.Detail)
 	if _, loaded := sm.processedEvents.LoadOrStore(eventKey, struct{}{}); loaded {
@@ -130,7 +134,7 @@ func (sm *StateMachine) HandleEvent(event ChangeEvent) error {
 	}
 
 	wf := matched[0]
-	return sm.processWorkflowEvent(wf, event)
+	return sm.processWorkflowEvent(ctx, wf, event)
 }
 
 // findMatchingWorkflows returns workflows whose trigger label is present on the issue.
@@ -152,7 +156,7 @@ func (sm *StateMachine) findMatchingWorkflows(event ChangeEvent) []*config.Workf
 }
 
 // processWorkflowEvent handles the event for a single matched workflow.
-func (sm *StateMachine) processWorkflowEvent(wf *config.WorkflowConfig, event ChangeEvent) error {
+func (sm *StateMachine) processWorkflowEvent(ctx context.Context, wf *config.WorkflowConfig, event ChangeEvent) error {
 	// Determine current state from labels.
 	currentStateName, currentState := sm.findCurrentState(wf, event.Labels)
 	if currentState == nil {
@@ -170,7 +174,7 @@ func (sm *StateMachine) processWorkflowEvent(wf *config.WorkflowConfig, event Ch
 		log.Printf("[statemachine] state entry detected: %s#%d entered %q, dispatching agent %q",
 			event.Repo, event.IssueNum, currentStateName, currentState.Agent)
 		sm.eventlog.Log(eventlog.TypeStateEntry, event.Repo, event.IssueNum,
-			fmt.Sprintf(`{"state":"%s","agent":"%s"}`, currentStateName, currentState.Agent))
+			map[string]string{"state": currentStateName, "agent": currentState.Agent})
 
 		// Clear any stale inflight flag: if the label changed, the previous agent's
 		// work is done (it was the one that changed the label). The worker goroutine
@@ -180,11 +184,11 @@ func (sm *StateMachine) processWorkflowEvent(wf *config.WorkflowConfig, event Ch
 		delete(sm.inflight, issueKey)
 		sm.inflightMu.Unlock()
 
-		return sm.dispatchAgent(event.Repo, event.IssueNum, currentState.Agent, wf.Name, currentStateName)
+		return sm.dispatchAgent(ctx, event.Repo, event.IssueNum, currentState.Agent, wf.Name, currentStateName)
 	}
 
 	// Build evaluation context.
-	ctx := &EvalContext{
+	evalCtx := &EvalContext{
 		EventType:     event.Type,
 		Labels:        event.Labels,
 		LabelAdded:    "",
@@ -193,14 +197,14 @@ func (sm *StateMachine) processWorkflowEvent(wf *config.WorkflowConfig, event Ch
 	}
 	switch event.Type {
 	case poller.EventLabelAdded:
-		ctx.LabelAdded = event.Detail
+		evalCtx.LabelAdded = event.Detail
 	case poller.EventLabelRemoved:
-		ctx.LabelRemoved = event.Detail
+		evalCtx.LabelRemoved = event.Detail
 	}
 
 	// Evaluate transitions.
 	for _, tr := range currentState.Transitions {
-		if !EvaluateCondition(tr.When, ctx) {
+		if !EvaluateCondition(tr.When, evalCtx) {
 			continue
 		}
 
@@ -228,16 +232,14 @@ func (sm *StateMachine) processWorkflowEvent(wf *config.WorkflowConfig, event Ch
 			if count >= maxRetries {
 				// Reject back-edge, transition to failed.
 				sm.eventlog.Log(eventlog.TypeCycleLimitReached, event.Repo, event.IssueNum,
-					fmt.Sprintf(`{"from":"%s","to":"%s","count":%d,"max_retries":%d}`,
-						currentStateName, targetStateName, count, maxRetries))
+					map[string]interface{}{"from": currentStateName, "to": targetStateName, "count": count, "max_retries": maxRetries})
 
 				// Mark as failed — dispatch request not sent.
 				// The "failed" state and "needs-human" label would be applied
 				// by the system. Since Go code doesn't write labels (agents do),
 				// we record the event. In v0.1.0, we still record the intent.
 				sm.eventlog.Log(eventlog.TypeTransitionToFailed, event.Repo, event.IssueNum,
-					fmt.Sprintf(`{"from":"%s","rejected_to":"%s","needs_human":true}`,
-						currentStateName, targetStateName))
+					map[string]interface{}{"from": currentStateName, "rejected_to": targetStateName, "needs_human": true})
 				return nil
 			}
 		} else {
@@ -250,11 +252,11 @@ func (sm *StateMachine) processWorkflowEvent(wf *config.WorkflowConfig, event Ch
 
 		// Log the transition.
 		sm.eventlog.Log(eventlog.TypeTransition, event.Repo, event.IssueNum,
-			fmt.Sprintf(`{"from":"%s","to":"%s"}`, currentStateName, targetStateName))
+			map[string]string{"from": currentStateName, "to": targetStateName})
 
 		// If the target state has an agent, dispatch it.
 		if targetState.Agent != "" {
-			if err := sm.dispatchAgent(event.Repo, event.IssueNum, targetState.Agent, wf.Name, targetStateName); err != nil {
+			if err := sm.dispatchAgent(ctx, event.Repo, event.IssueNum, targetState.Agent, wf.Name, targetStateName); err != nil {
 				return err
 			}
 		}
@@ -267,7 +269,7 @@ func (sm *StateMachine) processWorkflowEvent(wf *config.WorkflowConfig, event Ch
 }
 
 // dispatchAgent sends a dispatch request for the given agent, respecting the inflight mutex.
-func (sm *StateMachine) dispatchAgent(repo string, issueNum int, agentName, workflow, state string) error {
+func (sm *StateMachine) dispatchAgent(ctx context.Context, repo string, issueNum int, agentName, workflow, state string) error {
 	issueKey := fmt.Sprintf("%s#%d", repo, issueNum)
 
 	// Execution mutex: don't dispatch if agent is already running.
@@ -275,18 +277,27 @@ func (sm *StateMachine) dispatchAgent(repo string, issueNum int, agentName, work
 	if sm.inflight[issueKey] {
 		sm.inflightMu.Unlock()
 		sm.eventlog.Log(eventlog.TypeDispatchSkippedInflight, repo, issueNum,
-			fmt.Sprintf(`{"agent":"%s","reason":"agent already running"}`, agentName))
+			map[string]string{"agent": agentName, "reason": "agent already running"})
 		return nil
 	}
 	sm.inflight[issueKey] = true
 	sm.inflightMu.Unlock()
 
-	sm.dispatch <- DispatchRequest{
+	req := DispatchRequest{
 		Repo:      repo,
 		IssueNum:  issueNum,
 		AgentName: agentName,
 		Workflow:  workflow,
 		State:     state,
+	}
+	select {
+	case sm.dispatch <- req:
+	case <-ctx.Done():
+		// Context cancelled; undo the inflight flag since we never dispatched.
+		sm.inflightMu.Lock()
+		delete(sm.inflight, issueKey)
+		sm.inflightMu.Unlock()
+		return ctx.Err()
 	}
 	return nil
 }
@@ -365,7 +376,7 @@ func (sm *StateMachine) CheckStuck(repo string, issueNum int, currentLabels []st
 	if string(currentJSON) == rec.labels {
 		// Labels unchanged after timeout — stuck!
 		sm.eventlog.Log(eventlog.TypeStuckDetected, repo, issueNum,
-			fmt.Sprintf(`{"since":"%s","labels":%s}`, rec.at.Format(time.RFC3339), rec.labels))
+			map[string]interface{}{"since": rec.at.Format(time.RFC3339), "labels": json.RawMessage(rec.labels)})
 
 		// Clear the record so we don't keep firing.
 		sm.completionMu.Lock()

--- a/internal/statemachine/statemachine_test.go
+++ b/internal/statemachine/statemachine_test.go
@@ -1,6 +1,8 @@
 package statemachine
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -122,7 +124,7 @@ func TestNormalTransition(t *testing.T) {
 		Detail:   "status:reviewing",
 	}
 
-	if err := sm.HandleEvent(event); err != nil {
+	if err := sm.HandleEvent(context.Background(),event); err != nil {
 		t.Fatalf("HandleEvent: %v", err)
 	}
 
@@ -158,7 +160,7 @@ func TestBackEdgeCount(t *testing.T) {
 		Labels:   []string{"workbuddy", "status:developing"},
 		Detail:   "status:reviewing",
 	}
-	if err := sm.HandleEvent(ev1); err != nil {
+	if err := sm.HandleEvent(context.Background(),ev1); err != nil {
 		t.Fatalf("HandleEvent 1: %v", err)
 	}
 	<-dispatch // drain
@@ -175,7 +177,7 @@ func TestBackEdgeCount(t *testing.T) {
 		Labels:   []string{"workbuddy", "status:reviewing"},
 		Detail:   "status:developing",
 	}
-	if err := sm.HandleEvent(ev2); err != nil {
+	if err := sm.HandleEvent(context.Background(),ev2); err != nil {
 		t.Fatalf("HandleEvent 2: %v", err)
 	}
 
@@ -227,7 +229,7 @@ func TestRetryLimitFailed(t *testing.T) {
 	//   This IS a back-edge. developing→reviewing count becomes 2. 2 >= max_retries=2 → FAILED.
 
 	// Step 1: developing → reviewing (not a back-edge)
-	if err := sm.HandleEvent(ChangeEvent{
+	if err := sm.HandleEvent(context.Background(),ChangeEvent{
 		Type: poller.EventLabelAdded, Repo: repo, IssueNum: issueNum,
 		Labels: []string{"workbuddy", "status:developing"}, Detail: "status:reviewing",
 	}); err != nil {
@@ -240,7 +242,7 @@ func TestRetryLimitFailed(t *testing.T) {
 	// Step 2: reviewing → developing (back-edge: "developing" was a source, but
 	// not yet a target. Actually, let's check: is there any prior transition TO developing?
 	// No — step 1 was TO reviewing. So this is NOT a back-edge.)
-	if err := sm.HandleEvent(ChangeEvent{
+	if err := sm.HandleEvent(context.Background(),ChangeEvent{
 		Type: poller.EventLabelAdded, Repo: repo, IssueNum: issueNum,
 		Labels: []string{"workbuddy", "status:reviewing"}, Detail: "status:developing",
 	}); err != nil {
@@ -253,7 +255,7 @@ func TestRetryLimitFailed(t *testing.T) {
 	// Step 3: developing → reviewing. "reviewing" already appeared as target in step 1.
 	// This IS a back-edge. Count for developing→reviewing: was 1, increment to 2.
 	// 2 >= max_retries (2) → cycle_limit_reached → transition to failed.
-	err := sm.HandleEvent(ChangeEvent{
+	err := sm.HandleEvent(context.Background(),ChangeEvent{
 		Type: poller.EventLabelAdded, Repo: repo, IssueNum: issueNum,
 		Labels: []string{"workbuddy", "status:developing"}, Detail: "status:reviewing",
 	})
@@ -282,7 +284,7 @@ func TestRetryLimitFailed(t *testing.T) {
 func TestNoMatchSkip(t *testing.T) {
 	sm, rec, _ := newTestSM(t)
 
-	err := sm.HandleEvent(ChangeEvent{
+	err := sm.HandleEvent(context.Background(),ChangeEvent{
 		Type:     poller.EventLabelAdded,
 		Repo:     "test/repo",
 		IssueNum: 99,
@@ -321,7 +323,7 @@ func TestMultiWorkflowReject(t *testing.T) {
 		rec,
 	)
 
-	err := sm.HandleEvent(ChangeEvent{
+	err := sm.HandleEvent(context.Background(),ChangeEvent{
 		Type:     poller.EventLabelAdded,
 		Repo:     "test/repo",
 		IssueNum: 10,
@@ -349,13 +351,13 @@ func TestIdempotent(t *testing.T) {
 		Detail:   "status:reviewing",
 	}
 
-	if err := sm.HandleEvent(event); err != nil {
+	if err := sm.HandleEvent(context.Background(),event); err != nil {
 		t.Fatalf("HandleEvent 1: %v", err)
 	}
 	<-dispatch // drain first dispatch
 
 	// Same event again.
-	if err := sm.HandleEvent(event); err != nil {
+	if err := sm.HandleEvent(context.Background(),event); err != nil {
 		t.Fatalf("HandleEvent 2: %v", err)
 	}
 
@@ -379,7 +381,7 @@ func TestExecutionMutex(t *testing.T) {
 	sm, rec, dispatch := newTestSM(t)
 
 	// First event triggers dispatch (developing → reviewing, dispatches review-agent).
-	if err := sm.HandleEvent(ChangeEvent{
+	if err := sm.HandleEvent(context.Background(),ChangeEvent{
 		Type: poller.EventLabelAdded, Repo: "r", IssueNum: 7,
 		Labels: []string{"workbuddy", "status:developing"}, Detail: "status:reviewing",
 	}); err != nil {
@@ -391,7 +393,7 @@ func TestExecutionMutex(t *testing.T) {
 	sm.ResetDedup() // simulate new poll cycle
 
 	// Now try reviewing → developing (which would dispatch dev-agent).
-	if err := sm.HandleEvent(ChangeEvent{
+	if err := sm.HandleEvent(context.Background(),ChangeEvent{
 		Type: poller.EventLabelAdded, Repo: "r", IssueNum: 7,
 		Labels: []string{"workbuddy", "status:reviewing"}, Detail: "status:developing",
 	}); err != nil {
@@ -418,7 +420,7 @@ func TestStuckDetection(t *testing.T) {
 	sm.SetStuckTimeout(1 * time.Millisecond)
 
 	// Trigger a transition.
-	if err := sm.HandleEvent(ChangeEvent{
+	if err := sm.HandleEvent(context.Background(),ChangeEvent{
 		Type: poller.EventLabelAdded, Repo: "test/repo", IssueNum: 8,
 		Labels: []string{"workbuddy", "status:developing"}, Detail: "status:reviewing",
 	}); err != nil {
@@ -563,6 +565,69 @@ func TestConditionEmpty(t *testing.T) {
 	if EvaluateCondition("", ctx) {
 		t.Error("empty condition should return false")
 	}
+}
+
+// Test 9: Context cancellation prevents blocking on dispatch channel
+func TestDispatchRespectsContext(t *testing.T) {
+	st := newTestStore(t)
+	rec := &fakeRecorder{}
+	// Unbuffered channel — will block if nobody reads.
+	dispatch := make(chan DispatchRequest)
+	wf := testWorkflow()
+	sm := NewStateMachine(
+		map[string]*config.WorkflowConfig{"dev-flow": wf},
+		st,
+		dispatch,
+		rec,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	err := sm.HandleEvent(ctx, ChangeEvent{
+		Type:     poller.EventLabelAdded,
+		Repo:     "test/repo",
+		IssueNum: 50,
+		Labels:   []string{"workbuddy", "status:developing"},
+		Detail:   "status:reviewing",
+	})
+
+	// The dispatch should fail due to cancelled context.
+	if err == nil {
+		t.Error("expected error from cancelled context, got nil")
+	}
+
+	// The inflight flag should have been cleaned up.
+	if sm.IsInflight("test/repo", 50) {
+		t.Error("inflight flag should be cleared after context cancellation")
+	}
+}
+
+// Test 10: ResetDedup is safe for concurrent access
+func TestResetDedupConcurrent(t *testing.T) {
+	sm, _, _ := newTestSM(t)
+
+	// Populate some entries.
+	for i := 0; i < 100; i++ {
+		sm.processedEvents.Store(fmt.Sprintf("key-%d", i), struct{}{})
+	}
+
+	var wg sync.WaitGroup
+	// Concurrently call ResetDedup and LoadOrStore.
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			sm.ResetDedup()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			sm.processedEvents.LoadOrStore(fmt.Sprintf("concurrent-%d", i), struct{}{})
+		}
+	}()
+	wg.Wait()
 }
 
 func TestMain(m *testing.M) {

--- a/internal/statemachine/statemachine_test.go
+++ b/internal/statemachine/statemachine_test.go
@@ -124,7 +124,7 @@ func TestNormalTransition(t *testing.T) {
 		Detail:   "status:reviewing",
 	}
 
-	if err := sm.HandleEvent(context.Background(),event); err != nil {
+	if err := sm.HandleEvent(context.Background(), event); err != nil {
 		t.Fatalf("HandleEvent: %v", err)
 	}
 
@@ -160,7 +160,7 @@ func TestBackEdgeCount(t *testing.T) {
 		Labels:   []string{"workbuddy", "status:developing"},
 		Detail:   "status:reviewing",
 	}
-	if err := sm.HandleEvent(context.Background(),ev1); err != nil {
+	if err := sm.HandleEvent(context.Background(), ev1); err != nil {
 		t.Fatalf("HandleEvent 1: %v", err)
 	}
 	<-dispatch // drain
@@ -177,7 +177,7 @@ func TestBackEdgeCount(t *testing.T) {
 		Labels:   []string{"workbuddy", "status:reviewing"},
 		Detail:   "status:developing",
 	}
-	if err := sm.HandleEvent(context.Background(),ev2); err != nil {
+	if err := sm.HandleEvent(context.Background(), ev2); err != nil {
 		t.Fatalf("HandleEvent 2: %v", err)
 	}
 
@@ -229,7 +229,7 @@ func TestRetryLimitFailed(t *testing.T) {
 	//   This IS a back-edge. developing→reviewing count becomes 2. 2 >= max_retries=2 → FAILED.
 
 	// Step 1: developing → reviewing (not a back-edge)
-	if err := sm.HandleEvent(context.Background(),ChangeEvent{
+	if err := sm.HandleEvent(context.Background(), ChangeEvent{
 		Type: poller.EventLabelAdded, Repo: repo, IssueNum: issueNum,
 		Labels: []string{"workbuddy", "status:developing"}, Detail: "status:reviewing",
 	}); err != nil {
@@ -242,7 +242,7 @@ func TestRetryLimitFailed(t *testing.T) {
 	// Step 2: reviewing → developing (back-edge: "developing" was a source, but
 	// not yet a target. Actually, let's check: is there any prior transition TO developing?
 	// No — step 1 was TO reviewing. So this is NOT a back-edge.)
-	if err := sm.HandleEvent(context.Background(),ChangeEvent{
+	if err := sm.HandleEvent(context.Background(), ChangeEvent{
 		Type: poller.EventLabelAdded, Repo: repo, IssueNum: issueNum,
 		Labels: []string{"workbuddy", "status:reviewing"}, Detail: "status:developing",
 	}); err != nil {
@@ -255,7 +255,7 @@ func TestRetryLimitFailed(t *testing.T) {
 	// Step 3: developing → reviewing. "reviewing" already appeared as target in step 1.
 	// This IS a back-edge. Count for developing→reviewing: was 1, increment to 2.
 	// 2 >= max_retries (2) → cycle_limit_reached → transition to failed.
-	err := sm.HandleEvent(context.Background(),ChangeEvent{
+	err := sm.HandleEvent(context.Background(), ChangeEvent{
 		Type: poller.EventLabelAdded, Repo: repo, IssueNum: issueNum,
 		Labels: []string{"workbuddy", "status:developing"}, Detail: "status:reviewing",
 	})
@@ -284,7 +284,7 @@ func TestRetryLimitFailed(t *testing.T) {
 func TestNoMatchSkip(t *testing.T) {
 	sm, rec, _ := newTestSM(t)
 
-	err := sm.HandleEvent(context.Background(),ChangeEvent{
+	err := sm.HandleEvent(context.Background(), ChangeEvent{
 		Type:     poller.EventLabelAdded,
 		Repo:     "test/repo",
 		IssueNum: 99,
@@ -323,7 +323,7 @@ func TestMultiWorkflowReject(t *testing.T) {
 		rec,
 	)
 
-	err := sm.HandleEvent(context.Background(),ChangeEvent{
+	err := sm.HandleEvent(context.Background(), ChangeEvent{
 		Type:     poller.EventLabelAdded,
 		Repo:     "test/repo",
 		IssueNum: 10,
@@ -351,13 +351,13 @@ func TestIdempotent(t *testing.T) {
 		Detail:   "status:reviewing",
 	}
 
-	if err := sm.HandleEvent(context.Background(),event); err != nil {
+	if err := sm.HandleEvent(context.Background(), event); err != nil {
 		t.Fatalf("HandleEvent 1: %v", err)
 	}
 	<-dispatch // drain first dispatch
 
 	// Same event again.
-	if err := sm.HandleEvent(context.Background(),event); err != nil {
+	if err := sm.HandleEvent(context.Background(), event); err != nil {
 		t.Fatalf("HandleEvent 2: %v", err)
 	}
 
@@ -381,7 +381,7 @@ func TestExecutionMutex(t *testing.T) {
 	sm, rec, dispatch := newTestSM(t)
 
 	// First event triggers dispatch (developing → reviewing, dispatches review-agent).
-	if err := sm.HandleEvent(context.Background(),ChangeEvent{
+	if err := sm.HandleEvent(context.Background(), ChangeEvent{
 		Type: poller.EventLabelAdded, Repo: "r", IssueNum: 7,
 		Labels: []string{"workbuddy", "status:developing"}, Detail: "status:reviewing",
 	}); err != nil {
@@ -393,7 +393,7 @@ func TestExecutionMutex(t *testing.T) {
 	sm.ResetDedup() // simulate new poll cycle
 
 	// Now try reviewing → developing (which would dispatch dev-agent).
-	if err := sm.HandleEvent(context.Background(),ChangeEvent{
+	if err := sm.HandleEvent(context.Background(), ChangeEvent{
 		Type: poller.EventLabelAdded, Repo: "r", IssueNum: 7,
 		Labels: []string{"workbuddy", "status:reviewing"}, Detail: "status:developing",
 	}); err != nil {
@@ -420,7 +420,7 @@ func TestStuckDetection(t *testing.T) {
 	sm.SetStuckTimeout(1 * time.Millisecond)
 
 	// Trigger a transition.
-	if err := sm.HandleEvent(context.Background(),ChangeEvent{
+	if err := sm.HandleEvent(context.Background(), ChangeEvent{
 		Type: poller.EventLabelAdded, Repo: "test/repo", IssueNum: 8,
 		Labels: []string{"workbuddy", "status:developing"}, Detail: "status:reviewing",
 	}); err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -377,6 +377,41 @@ func (s *Store) UpsertIssueCache(ic IssueCache) error {
 	return nil
 }
 
+// ListCachedIssueNums returns all issue numbers in the cache for a repo,
+// excluding PR entries (those with state starting with "pr:").
+func (s *Store) ListCachedIssueNums(repo string) ([]int, error) {
+	rows, err := s.db.Query(
+		`SELECT issue_num FROM issue_cache WHERE repo = ? AND (state IS NULL OR state NOT LIKE 'pr:%')`,
+		repo,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("store: list cached issue nums: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var nums []int
+	for rows.Next() {
+		var n int
+		if err := rows.Scan(&n); err != nil {
+			return nil, fmt.Errorf("store: scan issue num: %w", err)
+		}
+		nums = append(nums, n)
+	}
+	return nums, rows.Err()
+}
+
+// DeleteIssueCache removes a cached issue entry.
+func (s *Store) DeleteIssueCache(repo string, issueNum int) error {
+	_, err := s.db.Exec(
+		`DELETE FROM issue_cache WHERE repo = ? AND issue_num = ?`,
+		repo, issueNum,
+	)
+	if err != nil {
+		return fmt.Errorf("store: delete issue cache: %w", err)
+	}
+	return nil
+}
+
 // QueryIssueCache returns the cached issue, or nil if not found.
 func (s *Store) QueryIssueCache(repo string, issueNum int) (*IssueCache, error) {
 	var ic IssueCache

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4,12 +4,32 @@ package store
 import (
 	"database/sql"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"time"
 
 	_ "modernc.org/sqlite" // sqlite driver
 )
+
+// parseTimestamp attempts to parse a SQLite timestamp string using common formats.
+// Returns the parsed time and true on success, or zero time and false on failure
+// (with a warning logged including the field name for debugging).
+func parseTimestamp(raw, fieldName string) (time.Time, bool) {
+	// SQLite CURRENT_TIMESTAMP may return different formats depending on driver.
+	for _, layout := range []string{
+		"2006-01-02 15:04:05",
+		time.RFC3339,
+		"2006-01-02T15:04:05Z",
+		"2006-01-02T15:04:05",
+	} {
+		if t, err := time.Parse(layout, raw); err == nil {
+			return t, true
+		}
+	}
+	log.Printf("[store] warning: failed to parse %s timestamp %q", fieldName, raw)
+	return time.Time{}, false
+}
 
 // Task status constants.
 const (
@@ -165,7 +185,7 @@ func (s *Store) QueryEvents(repo string) ([]Event, error) {
 		if err := rows.Scan(&ev.ID, &ts, &ev.Type, &ev.Repo, &ev.IssueNum, &ev.Payload); err != nil {
 			return nil, fmt.Errorf("store: scan event: %w", err)
 		}
-		ev.TS, _ = time.Parse("2006-01-02 15:04:05", ts)
+		ev.TS, _ = parseTimestamp(ts, "event.ts")
 		out = append(out, ev)
 	}
 	return out, rows.Err()
@@ -208,8 +228,8 @@ func (s *Store) QueryTasks(status string) ([]TaskRecord, error) {
 		if err := rows.Scan(&t.ID, &t.Repo, &t.IssueNum, &t.AgentName, &t.WorkerID, &t.Status, &createdAt, &updatedAt); err != nil {
 			return nil, fmt.Errorf("store: scan task: %w", err)
 		}
-		t.CreatedAt, _ = time.Parse("2006-01-02 15:04:05", createdAt)
-		t.UpdatedAt, _ = time.Parse("2006-01-02 15:04:05", updatedAt)
+		t.CreatedAt, _ = parseTimestamp(createdAt, "task.created_at")
+		t.UpdatedAt, _ = parseTimestamp(updatedAt, "task.updated_at")
 		out = append(out, t)
 	}
 	return out, rows.Err()
@@ -268,8 +288,8 @@ func (s *Store) QueryWorkers(repo string) ([]WorkerRecord, error) {
 		if err := rows.Scan(&w.ID, &w.Repo, &w.Roles, &w.Hostname, &w.Status, &hb, &ra); err != nil {
 			return nil, fmt.Errorf("store: scan worker: %w", err)
 		}
-		w.LastHeartbeat, _ = time.Parse("2006-01-02 15:04:05", hb)
-		w.RegisteredAt, _ = time.Parse("2006-01-02 15:04:05", ra)
+		w.LastHeartbeat, _ = parseTimestamp(hb, "worker.last_heartbeat")
+		w.RegisteredAt, _ = parseTimestamp(ra, "worker.registered_at")
 		out = append(out, w)
 	}
 	return out, rows.Err()
@@ -313,25 +333,20 @@ func (s *Store) UpdateWorkerStatus(workerID, status string) error {
 
 // IncrementTransition increments the counter for a state transition,
 // inserting the row if it does not exist. Returns the new count.
+// The upsert and read are performed in a single statement using RETURNING
+// to avoid a race where another goroutine increments between the two.
 func (s *Store) IncrementTransition(repo string, issueNum int, fromState, toState string) (int, error) {
-	_, err := s.db.Exec(
+	var count int
+	err := s.db.QueryRow(
 		`INSERT INTO transition_counts (repo, issue_num, from_state, to_state, count)
 		 VALUES (?, ?, ?, ?, 1)
 		 ON CONFLICT (repo, issue_num, from_state, to_state)
-		 DO UPDATE SET count = count + 1`,
-		repo, issueNum, fromState, toState,
-	)
-	if err != nil {
-		return 0, fmt.Errorf("store: increment transition: %w", err)
-	}
-
-	var count int
-	err = s.db.QueryRow(
-		`SELECT count FROM transition_counts WHERE repo = ? AND issue_num = ? AND from_state = ? AND to_state = ?`,
+		 DO UPDATE SET count = count + 1
+		 RETURNING count`,
 		repo, issueNum, fromState, toState,
 	).Scan(&count)
 	if err != nil {
-		return 0, fmt.Errorf("store: read transition count: %w", err)
+		return 0, fmt.Errorf("store: increment transition: %w", err)
 	}
 	return count, nil
 }
@@ -391,7 +406,7 @@ func (s *Store) QueryIssueCache(repo string, issueNum int) (*IssueCache, error) 
 	if err != nil {
 		return nil, fmt.Errorf("store: query issue cache: %w", err)
 	}
-	ic.UpdatedAt, _ = time.Parse("2006-01-02 15:04:05", updatedAt)
+	ic.UpdatedAt, _ = parseTimestamp(updatedAt, "issue_cache.updated_at")
 	return &ic, nil
 }
 
@@ -445,7 +460,7 @@ func (s *Store) QueryAgentSessions(repo string, issueNum int) ([]AgentSession, e
 			&sess.AgentName, &sess.Summary, &sess.RawPath, &createdAt); err != nil {
 			return nil, fmt.Errorf("store: scan agent session: %w", err)
 		}
-		sess.CreatedAt, _ = time.Parse("2006-01-02 15:04:05", createdAt)
+		sess.CreatedAt, _ = parseTimestamp(createdAt, "agent_session.created_at")
 		out = append(out, sess)
 	}
 	return out, rows.Err()
@@ -494,7 +509,7 @@ func (s *Store) ListAgentSessions(f SessionFilter) ([]AgentSession, error) {
 			&sess.AgentName, &sess.Summary, &sess.RawPath, &createdAt); err != nil {
 			return nil, fmt.Errorf("store: scan agent session: %w", err)
 		}
-		sess.CreatedAt, _ = time.Parse("2006-01-02 15:04:05", createdAt)
+		sess.CreatedAt, _ = parseTimestamp(createdAt, "agent_session.created_at")
 		out = append(out, sess)
 	}
 	return out, rows.Err()
@@ -516,6 +531,6 @@ func (s *Store) GetAgentSession(sessionID string) (*AgentSession, error) {
 	if err != nil {
 		return nil, fmt.Errorf("store: get agent session: %w", err)
 	}
-	sess.CreatedAt, _ = time.Parse("2006-01-02 15:04:05", createdAt)
+	sess.CreatedAt, _ = parseTimestamp(createdAt, "agent_session.created_at")
 	return &sess, nil
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -166,6 +166,82 @@ func TestCreateAndReadWrite(t *testing.T) {
 	}
 }
 
+// TestIncrementTransitionAtomic verifies that concurrent IncrementTransition
+// calls produce the correct final count (no lost updates).
+func TestIncrementTransitionAtomic(t *testing.T) {
+	s := newTestStore(t)
+
+	const n = 50
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	counts := make(chan int, n)
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cnt, err := s.IncrementTransition("org/repo", 1, "dev", "review")
+			if err != nil {
+				errs <- err
+				return
+			}
+			counts <- cnt
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	close(counts)
+
+	for err := range errs {
+		t.Fatalf("concurrent IncrementTransition failed: %v", err)
+	}
+
+	// Final count must be exactly n.
+	tcs, err := s.QueryTransitionCounts("org/repo", 1)
+	if err != nil {
+		t.Fatalf("QueryTransitionCounts: %v", err)
+	}
+	if len(tcs) != 1 || tcs[0].Count != n {
+		t.Fatalf("expected final count %d, got %+v", n, tcs)
+	}
+
+	// Every returned count should be unique (1..n) if truly atomic.
+	seen := make(map[int]bool)
+	for c := range counts {
+		if c < 1 || c > n {
+			t.Errorf("count %d out of range [1, %d]", c, n)
+		}
+		seen[c] = true
+	}
+	if len(seen) != n {
+		t.Errorf("expected %d unique counts, got %d (some increments were not atomic)", n, len(seen))
+	}
+}
+
+// TestParseTimestamp verifies the multi-format timestamp parser.
+func TestParseTimestamp(t *testing.T) {
+	tests := []struct {
+		input string
+		ok    bool
+	}{
+		{"2026-04-14 13:00:05", true},
+		{"2026-04-14T13:00:05Z", true},
+		{"2026-04-14T13:00:05+08:00", true},
+		{"2026-04-14T13:00:05", true},
+		{"not-a-date", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		parsed, ok := parseTimestamp(tt.input, "test")
+		if ok != tt.ok {
+			t.Errorf("parseTimestamp(%q): ok=%v, want %v", tt.input, ok, tt.ok)
+		}
+		if ok && parsed.IsZero() {
+			t.Errorf("parseTimestamp(%q): returned zero time but ok=true", tt.input)
+		}
+	}
+}
+
 // TestConcurrentWrites verifies that concurrent inserts do not fail or corrupt data.
 func TestConcurrentWrites(t *testing.T) {
 	s := newTestStore(t)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -246,6 +246,72 @@ func TestRestartRetention(t *testing.T) {
 	}
 }
 
+// TestListCachedIssueNums verifies filtering of issues vs PRs.
+func TestListCachedIssueNums(t *testing.T) {
+	s := newTestStore(t)
+
+	// Insert issues and PRs into cache.
+	for _, ic := range []IssueCache{
+		{Repo: "org/repo", IssueNum: 1, Labels: `["bug"]`, State: "open"},
+		{Repo: "org/repo", IssueNum: 2, Labels: `["feature"]`, State: "open"},
+		{Repo: "org/repo", IssueNum: 10, Labels: "", State: "pr:open"},   // PR — should be excluded
+		{Repo: "org/repo", IssueNum: 11, Labels: "", State: "pr:merged"}, // PR — should be excluded
+		{Repo: "other/repo", IssueNum: 3, Labels: `[]`, State: "open"},   // different repo
+	} {
+		if err := s.UpsertIssueCache(ic); err != nil {
+			t.Fatalf("UpsertIssueCache: %v", err)
+		}
+	}
+
+	nums, err := s.ListCachedIssueNums("org/repo")
+	if err != nil {
+		t.Fatalf("ListCachedIssueNums: %v", err)
+	}
+	if len(nums) != 2 {
+		t.Fatalf("expected 2 issue nums, got %d: %v", len(nums), nums)
+	}
+	numSet := map[int]bool{}
+	for _, n := range nums {
+		numSet[n] = true
+	}
+	if !numSet[1] || !numSet[2] {
+		t.Errorf("expected issues 1 and 2, got %v", nums)
+	}
+}
+
+// TestDeleteIssueCache verifies cache deletion.
+func TestDeleteIssueCache(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.UpsertIssueCache(IssueCache{Repo: "org/repo", IssueNum: 5, Labels: `["bug"]`, State: "open"}); err != nil {
+		t.Fatal(err)
+	}
+	// Verify it exists.
+	ic, _ := s.QueryIssueCache("org/repo", 5)
+	if ic == nil {
+		t.Fatal("expected cached issue to exist")
+	}
+
+	// Delete it.
+	if err := s.DeleteIssueCache("org/repo", 5); err != nil {
+		t.Fatalf("DeleteIssueCache: %v", err)
+	}
+
+	// Verify it's gone.
+	ic, err := s.QueryIssueCache("org/repo", 5)
+	if err != nil {
+		t.Fatalf("QueryIssueCache after delete: %v", err)
+	}
+	if ic != nil {
+		t.Fatalf("expected nil after delete, got %+v", ic)
+	}
+
+	// Deleting a non-existent entry should not error.
+	if err := s.DeleteIssueCache("org/repo", 999); err != nil {
+		t.Fatalf("DeleteIssueCache non-existent: %v", err)
+	}
+}
+
 // TestWALMode verifies that WAL mode is enabled.
 func TestWALMode(t *testing.T) {
 	s := newTestStore(t)

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -58,7 +58,9 @@ func (m *Manager) Create(issueNum int, taskID string) (string, error) {
 }
 
 // Remove cleans up a worktree and its associated branch.
-// Returns a combined error if worktree removal or branch deletion fails.
+// Best-effort: if worktree removal fails but prune succeeds, no error is returned.
+// Returns a combined error only when cleanup truly fails (both remove+prune fail,
+// or branch deletion fails).
 func (m *Manager) Remove(wtPath string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -95,8 +97,13 @@ func (m *Manager) Remove(wtPath string) error {
 		}
 	}
 
-	log.Printf("[workspace] removed worktree %s", wtPath)
-	return errors.Join(errs...)
+	combined := errors.Join(errs...)
+	if combined != nil {
+		log.Printf("[workspace] partial cleanup for worktree %s: %v", wtPath, combined)
+	} else {
+		log.Printf("[workspace] removed worktree %s", wtPath)
+	}
+	return combined
 }
 
 // worktreeBranch returns the branch checked out in the given worktree path.

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -4,6 +4,7 @@
 package workspace
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -57,9 +58,12 @@ func (m *Manager) Create(issueNum int, taskID string) (string, error) {
 }
 
 // Remove cleans up a worktree and its associated branch.
+// Returns a combined error if worktree removal or branch deletion fails.
 func (m *Manager) Remove(wtPath string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	var errs []error
 
 	// Get the branch name before removing the worktree.
 	branchName := worktreeBranch(m.baseDir, wtPath)
@@ -72,7 +76,13 @@ func (m *Manager) Remove(wtPath string) error {
 		log.Printf("[workspace] worktree remove warning: %s: %v", strings.TrimSpace(string(out)), err)
 		pruneCmd := exec.Command("git", "worktree", "prune")
 		pruneCmd.Dir = m.baseDir
-		_ = pruneCmd.Run()
+		if pruneErr := pruneCmd.Run(); pruneErr != nil {
+			errs = append(errs, fmt.Errorf("workspace: worktree remove %s: %s: %w; prune also failed: %v",
+				wtPath, strings.TrimSpace(string(out)), err, pruneErr))
+		} else {
+			// Prune succeeded, so the worktree is cleaned up; not a hard error.
+			log.Printf("[workspace] worktree pruned successfully after remove failure")
+		}
 	}
 
 	// Delete the temporary branch.
@@ -80,13 +90,13 @@ func (m *Manager) Remove(wtPath string) error {
 		delCmd := exec.Command("git", "branch", "-D", branchName)
 		delCmd.Dir = m.baseDir
 		if out, err := delCmd.CombinedOutput(); err != nil {
-			log.Printf("[workspace] branch delete warning (%s): %s: %v",
-				branchName, strings.TrimSpace(string(out)), err)
+			errs = append(errs, fmt.Errorf("workspace: branch delete %s: %s: %w",
+				branchName, strings.TrimSpace(string(out)), err))
 		}
 	}
 
 	log.Printf("[workspace] removed worktree %s", wtPath)
-	return nil
+	return errors.Join(errs...)
 }
 
 // worktreeBranch returns the branch checked out in the given worktree path.

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -113,7 +113,9 @@ func TestMultipleWorktrees(t *testing.T) {
 	}
 
 	// Changes in one worktree should not affect the other.
-	os.WriteFile(filepath.Join(wt1, "file1.txt"), []byte("hello"), 0644)
+	if err := os.WriteFile(filepath.Join(wt1, "file1.txt"), []byte("hello"), 0644); err != nil {
+		t.Fatalf("write file in wt1: %v", err)
+	}
 	if _, err := os.Stat(filepath.Join(wt2, "file1.txt")); !os.IsNotExist(err) {
 		t.Error("file created in wt1 should not appear in wt2")
 	}


### PR DESCRIPTION
## Summary

- **Fix command injection** — shell-escape user-controlled fields (issue title/body) in agent command templates to prevent arbitrary code execution via malicious issue content
- **Fix event payload corruption** — replace `fmt.Sprintf` JSON construction with proper `map[string]string` in statemachine, eliminating double-escaping by `json.Marshal` in eventlog
- **Fix data race in ResetDedup** — clear `sync.Map` in-place instead of replacing the struct field
- **Fix dispatch goroutine leak** — wrap channel send in `select` with `ctx.Done()` so shutdown doesn't hang
- **Fix store atomicity** — use `INSERT...RETURNING` for `IncrementTransition` to prevent TOCTOU race
- **Fix nil labels in MarkAgentCompleted** — fetch labels from issue cache so stuck detection works
- **Fix workspace.Remove** — return actual errors instead of always nil
- **Fix silent time.Parse errors** — log warnings and support multiple timestamp formats
- **New: cancel running agents on issue close** — poller detects closed issues, per-task cancellable context registry kills the agent subprocess within one poll interval

## Changes

| Area | Files | What |
|------|-------|------|
| Security | `launcher/template.go` | `shellEscape()` + `safeTaskContext()` auto-escapes user input |
| Statemachine | `statemachine/statemachine.go` | 3 fixes: ResetDedup race, JSON payloads, dispatch ctx |
| Store | `store/store.go` | Atomic increment, timestamp parsing, cache list/delete |
| Serve | `cmd/serve.go` | `RunningTasks` registry, per-task ctx, close event handler, cached labels |
| Poller | `poller/poller.go` | `EventIssueClosed` detection via cache diff |
| Workspace | `workspace/workspace.go` | `Remove()` returns real errors |

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1 -race` — all 14 packages pass
- [x] New tests: shell injection (2 e2e + 2 unit), concurrent ResetDedup, dispatch cancellation, issue close detection, PR-not-affected, RunningTasks concurrency, atomic increment, timestamp formats
- [ ] Manual: create issue → agent starts → close issue → verify agent killed within poll interval


🤖 Generated with [Claude Code](https://claude.com/claude-code)