### PR TITLE
Implement codex-exec runtime adapter under Runtime/Session abstraction

### DIFF
--- a/.github/workbuddy/agents/codex-dev-agent.md
+++ b/.github/workbuddy/agents/codex-dev-agent.md
@@ -6,13 +6,12 @@ triggers:
     event: labeled
 role: dev
 runtime: codex
-command: >
-  codex exec
-  --skip-git-repo-check
-  --sandbox danger-full-access
-  --json
-  --output-last-message .workbuddy/codex-last-{{.Issue.Number}}.txt
-  "You are a development agent for repo {{.Repo}}.
+policy:
+  sandbox: danger-full-access
+  approval: never
+  timeout: 30m
+prompt: |
+  You are a development agent for repo {{.Repo}}.
 
   ## Task
   Read the issue below and implement the requested change.
@@ -28,8 +27,9 @@ command: >
   - If implementation is complete and PR is opened:
     Run: gh issue edit {{.Issue.Number}} --repo {{.Repo}} --remove-label status:developing --add-label status:testing
   - If the task is ambiguous or blocked:
-    Comment on the issue asking for clarification. Do NOT change labels."
-timeout: 30m
+    Comment on the issue asking for clarification. Do NOT change labels.
+command: |
+  codex exec --skip-git-repo-check --sandbox danger-full-access --json "legacy compatibility shim"
 ---
 
 ## Codex Dev Agent
@@ -38,23 +38,20 @@ Same contract as `dev-agent` but runs on the Codex CLI (`codex exec`) instead of
 
 ### Runtime notes
 
-- `--sandbox danger-full-access` — required so codex can edit files, run `git`,
+- `policy.sandbox: danger-full-access` - required so codex can edit files, run `git`,
   and invoke `gh issue edit` to route the state machine. Workbuddy already
   runs inside its own host/worktree boundary, so codex's internal sandbox
   is redundant.
-- `--json` — emits structured JSONL events to stdout. The Go launcher still
-  captures the whole stdout buffer, so this makes downstream parsing easier
-  without changing the launcher.
-- `--output-last-message` — writes the final agent message to a file so the
-  reporter / audit pipeline can surface a clean summary without scraping
-  JSONL events.
-- No `-a / --ask-for-approval` flag: `codex exec` defaults to `approval: never`,
-  which is what we want for unattended runs.
+- `policy.approval: never` - unattended runs should not stop for confirmation.
+- `prompt` is the canonical runtime input; `command` stays only as a temporary
+  compatibility shim while the schema migrates.
+- `--json` and `--output-last-message` are now injected by the launcher, so the
+  runtime can stream Event Schema v1 and persist the final assistant message.
 
 ### Wiring
 
 To actually use this agent, point a workflow at it by name. Either:
 
 1. Edit `.github/workbuddy/workflows/feature-dev.md` and change
-   `agent: dev-agent` → `agent: codex-dev-agent` in the `developing` state, or
+   `agent: dev-agent` -> `agent: codex-dev-agent` in the `developing` state, or
 2. Keep both and switch per-repo via a dedicated workflow file.

--- a/.github/workbuddy/agents/codex-review-agent.md
+++ b/.github/workbuddy/agents/codex-review-agent.md
@@ -1,0 +1,50 @@
+---
+name: codex-review-agent
+description: Review agent (Codex runtime) - performs code review on PRs
+triggers:
+  - label: "status:reviewing"
+    event: labeled
+role: review
+runtime: codex
+policy:
+  sandbox: danger-full-access
+  approval: never
+  timeout: 15m
+prompt: |
+  You are a code review agent for repo {{.Repo}}.
+
+  ## Task
+  Review the PR linked to issue #{{.Issue.Number}}.
+  Check for correctness, style, and alignment with project conventions.
+
+  ## Issue
+  Title: {{.Issue.Title}}
+  Number: #{{.Issue.Number}}
+  PR: {{.PR.URL}}
+
+  ## Steps
+  1. Read the PR diff
+  2. Check against project conventions
+  3. Verify tests cover the change
+  4. Post a PR review (approve or request changes)
+
+  ## When done
+  - If approved (code is good):
+    Run: gh issue edit {{.Issue.Number}} --repo {{.Repo}} --remove-label status:reviewing --add-label status:done
+    Then close the issue: gh issue close {{.Issue.Number}} --repo {{.Repo}}
+  - If changes requested:
+    Run: gh issue edit {{.Issue.Number}} --repo {{.Repo}} --remove-label status:reviewing --add-label status:developing
+    Post a PR review with request-changes explaining what needs fixing.
+command: |
+  codex exec --skip-git-repo-check --sandbox danger-full-access --json "legacy compatibility shim"
+---
+
+## Codex Review Agent
+
+Same contract as `review-agent` but runs on the Codex CLI (`codex exec`) instead of Claude Code.
+
+### Runtime notes
+
+- `prompt` is the canonical runtime input; `command` stays only as a temporary compatibility shim.
+- `policy.sandbox: danger-full-access` lets codex inspect git state, PR context, and local files during review.
+- `policy.approval: never` keeps automated review runs unattended.

--- a/.github/workbuddy/agents/codex-test-agent.md
+++ b/.github/workbuddy/agents/codex-test-agent.md
@@ -1,0 +1,49 @@
+---
+name: codex-test-agent
+description: Test agent (Codex runtime) - runs test suites and reports results
+triggers:
+  - label: "status:testing"
+    event: labeled
+role: test
+runtime: codex
+policy:
+  sandbox: danger-full-access
+  approval: never
+  timeout: 15m
+prompt: |
+  You are a test agent for repo {{.Repo}}.
+
+  ## Task
+  Run the full test suite for the PR linked to issue #{{.Issue.Number}}.
+  Report results as a comment on the issue.
+
+  ## Issue
+  Title: {{.Issue.Title}}
+  Number: #{{.Issue.Number}}
+  PR: {{.PR.URL}}
+
+  ## Steps
+  1. Check out the PR branch
+  2. Run the full test suite (go test ./... -v -count=1)
+  3. Run go vet ./...
+  4. Collect test results and coverage
+
+  ## When done
+  - If ALL tests pass:
+    Run: gh issue edit {{.Issue.Number}} --repo {{.Repo}} --remove-label status:testing --add-label status:reviewing
+  - If ANY test fails:
+    Run: gh issue edit {{.Issue.Number}} --repo {{.Repo}} --remove-label status:testing --add-label status:developing
+    Comment the failure details on the issue so the dev agent knows what to fix.
+command: |
+  codex exec --skip-git-repo-check --sandbox danger-full-access --json "legacy compatibility shim"
+---
+
+## Codex Test Agent
+
+Same contract as `test-agent` but runs on the Codex CLI (`codex exec`) instead of Claude Code.
+
+### Runtime notes
+
+- `prompt` is the canonical runtime input; `command` stays only as a temporary compatibility shim.
+- `policy.sandbox: danger-full-access` lets codex run the local test and vet commands that gate workflow progress.
+- `policy.approval: never` keeps automated test runs unattended.

--- a/.github/workbuddy/workflows/bugfix.md
+++ b/.github/workbuddy/workflows/bugfix.md
@@ -15,14 +15,14 @@ Agents decide transitions by modifying labels.
 states:
   developing:
     enter_label: "status:developing"
-    agent: dev-agent
+    agent: codex-dev-agent
     transitions:
       - to: testing
         when: labeled "status:testing"
 
   testing:
     enter_label: "status:testing"
-    agent: test-agent
+    agent: codex-test-agent
     transitions:
       - to: reviewing
         when: labeled "status:reviewing"
@@ -31,7 +31,7 @@ states:
 
   reviewing:
     enter_label: "status:reviewing"
-    agent: review-agent
+    agent: codex-review-agent
     transitions:
       - to: done
         when: labeled "status:done"

--- a/.github/workbuddy/workflows/feature-dev.md
+++ b/.github/workbuddy/workflows/feature-dev.md
@@ -24,14 +24,14 @@ states:
 
   developing:
     enter_label: "status:developing"
-    agent: dev-agent
+    agent: codex-dev-agent
     transitions:
       - to: testing
         when: labeled "status:testing"
 
   testing:
     enter_label: "status:testing"
-    agent: test-agent
+    agent: codex-test-agent
     transitions:
       - to: reviewing
         when: labeled "status:reviewing"
@@ -40,7 +40,7 @@ states:
 
   reviewing:
     enter_label: "status:reviewing"
-    agent: review-agent
+    agent: codex-review-agent
     transitions:
       - to: done
         when: labeled "status:done"

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,0 +1,137 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Lincyaw/workbuddy/internal/config"
+	"github.com/Lincyaw/workbuddy/internal/launcher"
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+)
+
+type runOpts struct {
+	runtime    string
+	prompt     string
+	promptFile string
+	workdir    string
+	sandbox    string
+	approval   string
+	model      string
+	timeout    time.Duration
+}
+
+var runCmd = &cobra.Command{
+	Use:   "run",
+	Short: "Run a runtime directly through workbuddy",
+	Long:  "Start a workbuddy runtime session directly, optionally asking Codex to review current repository changes.",
+	RunE:  runRuntimeCmd,
+}
+
+func init() {
+	runCmd.Flags().String("runtime", config.RuntimeCodexExec, "Runtime to start (e.g. codex, codex-exec, claude-code)")
+	runCmd.Flags().StringP("prompt", "p", "", "Prompt to send to the runtime")
+	runCmd.Flags().String("prompt-file", "", "Read prompt from file")
+	runCmd.Flags().String("workdir", ".", "Working directory for the runtime session")
+	runCmd.Flags().String("sandbox", "danger-full-access", "Runtime sandbox policy")
+	runCmd.Flags().String("approval", "never", "Runtime approval policy")
+	runCmd.Flags().String("model", "", "Optional runtime model override")
+	runCmd.Flags().Duration("timeout", 30*time.Minute, "Runtime timeout")
+	rootCmd.AddCommand(runCmd)
+}
+
+func runRuntimeCmd(cmd *cobra.Command, _ []string) error {
+	opts, err := parseRunFlags(cmd)
+	if err != nil {
+		return err
+	}
+	return runRuntimeWithOpts(cmd.Context(), opts, launcher.NewLauncher(), os.Stdout, os.Stderr)
+}
+
+func parseRunFlags(cmd *cobra.Command) (*runOpts, error) {
+	runtimeName, _ := cmd.Flags().GetString("runtime")
+	prompt, _ := cmd.Flags().GetString("prompt")
+	promptFile, _ := cmd.Flags().GetString("prompt-file")
+	workdir, _ := cmd.Flags().GetString("workdir")
+	sandbox, _ := cmd.Flags().GetString("sandbox")
+	approval, _ := cmd.Flags().GetString("approval")
+	model, _ := cmd.Flags().GetString("model")
+	timeout, _ := cmd.Flags().GetDuration("timeout")
+
+	if prompt != "" && promptFile != "" {
+		return nil, fmt.Errorf("run: specify only one of --prompt or --prompt-file")
+	}
+	if strings.TrimSpace(runtimeName) == "" {
+		return nil, fmt.Errorf("run: --runtime is required")
+	}
+	if workdir == "" {
+		workdir = "."
+	}
+	return &runOpts{runtime: runtimeName, prompt: prompt, promptFile: promptFile, workdir: workdir, sandbox: sandbox, approval: approval, model: model, timeout: timeout}, nil
+}
+
+func runRuntimeWithOpts(ctx context.Context, opts *runOpts, lnch *launcher.Launcher, stdout, stderr io.Writer) error {
+	workdir, err := filepath.Abs(opts.workdir)
+	if err != nil {
+		return fmt.Errorf("run: resolve workdir: %w", err)
+	}
+	prompt, err := resolveRunPrompt(opts)
+	if err != nil {
+		return err
+	}
+
+	agent := &config.AgentConfig{
+		Name:    "cli-runtime",
+		Runtime: opts.runtime,
+		Prompt:  prompt,
+		Policy: config.PolicyConfig{
+			Sandbox:  opts.sandbox,
+			Approval: opts.approval,
+			Model:    opts.model,
+			Timeout:  opts.timeout,
+		},
+		Timeout: opts.timeout,
+	}
+	if _, err := config.NormalizeAgentConfig(agent); err != nil {
+		return err
+	}
+
+	task := &launcher.TaskContext{
+		Repo:    filepath.Base(workdir),
+		WorkDir: workdir,
+		Session: launcher.SessionContext{ID: "session-" + uuid.NewString()},
+	}
+	result, err := lnch.Launch(ctx, agent, task)
+	if err != nil {
+		return err
+	}
+	if result.LastMessage != "" {
+		_, _ = fmt.Fprintln(stdout, result.LastMessage)
+	} else if result.Stdout != "" {
+		_, _ = fmt.Fprintln(stdout, result.Stdout)
+	}
+	_, _ = fmt.Fprintf(stderr, "session=%s\nruntime=%s\nartifact=%s\n", task.Session.ID, agent.Runtime, result.SessionPath)
+	if result.ExitCode != 0 {
+		return fmt.Errorf("run: runtime exited with code %d", result.ExitCode)
+	}
+	return nil
+}
+
+func resolveRunPrompt(opts *runOpts) (string, error) {
+	if opts.promptFile != "" {
+		data, err := os.ReadFile(opts.promptFile)
+		if err != nil {
+			return "", fmt.Errorf("run: read prompt file: %w", err)
+		}
+		return strings.TrimSpace(string(data)), nil
+	}
+	if strings.TrimSpace(opts.prompt) != "" {
+		return strings.TrimSpace(opts.prompt), nil
+	}
+	return "", fmt.Errorf("run: provide --prompt or --prompt-file")
+}

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,0 +1,151 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Lincyaw/workbuddy/internal/config"
+	"github.com/Lincyaw/workbuddy/internal/launcher"
+	"github.com/spf13/cobra"
+)
+
+func TestParseRunFlags(t *testing.T) {
+	cmd := &cobra.Command{Use: "run"}
+	cmd.Flags().String("runtime", config.RuntimeCodexExec, "")
+	cmd.Flags().StringP("prompt", "p", "", "")
+	cmd.Flags().String("prompt-file", "", "")
+	cmd.Flags().String("workdir", ".", "")
+	cmd.Flags().String("sandbox", "danger-full-access", "")
+	cmd.Flags().String("approval", "never", "")
+	cmd.Flags().String("model", "", "")
+	cmd.Flags().Duration("timeout", 30*time.Minute, "")
+	if err := cmd.Flags().Set("runtime", "codex"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("prompt", "hello"); err != nil {
+		t.Fatal(err)
+	}
+	opts, err := parseRunFlags(cmd)
+	if err != nil {
+		t.Fatalf("parseRunFlags: %v", err)
+	}
+	if opts.runtime != "codex" || opts.prompt != "hello" {
+		t.Fatalf("unexpected opts: %+v", opts)
+	}
+}
+
+func TestRunRuntimeWithOpts_UsesLauncher(t *testing.T) {
+	mockRT := &mockRuntime{name: config.RuntimeClaudeShot, resultFn: func(ctx context.Context, agent *config.AgentConfig, task *launcher.TaskContext) (*launcher.Result, error) {
+		return &launcher.Result{ExitCode: 0, LastMessage: "review complete", SessionPath: filepath.Join(task.WorkDir, "artifact.jsonl")}, nil
+	}}
+	lnch := launcher.NewLauncher()
+	lnch.Register(mockRT, config.RuntimeClaudeCode, config.RuntimeClaudeShot)
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	err := runRuntimeWithOpts(context.Background(), &runOpts{
+		runtime:  config.RuntimeClaudeCode,
+		prompt:   "review this",
+		workdir:  t.TempDir(),
+		sandbox:  "danger-full-access",
+		approval: "never",
+		timeout:  time.Minute,
+	}, lnch, &out, &errOut)
+	if err != nil {
+		t.Fatalf("runRuntimeWithOpts: %v", err)
+	}
+	if got := strings.TrimSpace(out.String()); got != "review complete" {
+		t.Fatalf("stdout = %q", got)
+	}
+	if !strings.Contains(errOut.String(), "artifact=") {
+		t.Fatalf("stderr missing artifact info: %q", errOut.String())
+	}
+	if mockRT.CallCount() != 1 {
+		t.Fatalf("call count = %d", mockRT.CallCount())
+	}
+}
+
+func TestRunRuntimeWithOpts_FailsOnNonZeroExit(t *testing.T) {
+	mockRT := &mockRuntime{name: config.RuntimeCodexExec, resultFn: func(ctx context.Context, agent *config.AgentConfig, task *launcher.TaskContext) (*launcher.Result, error) {
+		return &launcher.Result{ExitCode: 23, LastMessage: "review failed", SessionPath: filepath.Join(task.WorkDir, "artifact.jsonl")}, nil
+	}}
+	lnch := launcher.NewLauncher()
+	lnch.Register(mockRT, config.RuntimeCodex, config.RuntimeCodexExec)
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	err := runRuntimeWithOpts(context.Background(), &runOpts{
+		runtime:  config.RuntimeCodexExec,
+		prompt:   "review this",
+		workdir:  t.TempDir(),
+		sandbox:  "danger-full-access",
+		approval: "never",
+		timeout:  time.Minute,
+	}, lnch, &out, &errOut)
+	if err == nil {
+		t.Fatal("expected non-zero exit error")
+	}
+	if !strings.Contains(err.Error(), "runtime exited with code 23") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := strings.TrimSpace(out.String()); got != "review failed" {
+		t.Fatalf("stdout = %q", got)
+	}
+}
+
+func TestRunRuntime_CodexPromptE2E(t *testing.T) {
+	if os.Getenv("CODEX_E2E") != "1" {
+		t.Skip("set CODEX_E2E=1 to run codex CLI review e2e")
+	}
+	if _, err := exec.LookPath("codex"); err != nil {
+		t.Skip("codex not installed")
+	}
+	repo := t.TempDir()
+	run := func(name string, args ...string) {
+		t.Helper()
+		cmd := exec.Command(name, args...)
+		cmd.Dir = repo
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%s %v failed: %v\n%s", name, args, err, string(out))
+		}
+	}
+	run("git", "init")
+	run("git", "config", "user.email", "test@example.com")
+	run("git", "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(repo, "hello.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("git", "add", "hello.txt")
+	run("git", "commit", "-m", "init")
+	if err := os.WriteFile(filepath.Join(repo, "hello.txt"), []byte("hello\nworld\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lnch := launcher.NewLauncher()
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	err := runRuntimeWithOpts(context.Background(), &runOpts{
+		runtime:  config.RuntimeCodexExec,
+		prompt:   "Review the current repository changes in this working directory. Start your reply with REVIEW_OK and then provide a concise review.",
+		workdir:  repo,
+		sandbox:  "danger-full-access",
+		approval: "never",
+		timeout:  2 * time.Minute,
+	}, lnch, &out, &errOut)
+	if err != nil {
+		t.Fatalf("runRuntimeWithOpts: %v", err)
+	}
+	if got := strings.TrimSpace(out.String()); got == "" || !strings.Contains(got, "REVIEW_OK") {
+		t.Fatalf("unexpected stdout: %q", got)
+	}
+	if !strings.Contains(errOut.String(), "artifact=") {
+		t.Fatalf("stderr missing artifact info: %q", errOut.String())
+	}
+}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -18,6 +19,7 @@ import (
 	"github.com/Lincyaw/workbuddy/internal/config"
 	"github.com/Lincyaw/workbuddy/internal/eventlog"
 	"github.com/Lincyaw/workbuddy/internal/launcher"
+	launcherevents "github.com/Lincyaw/workbuddy/internal/launcher/events"
 	"github.com/Lincyaw/workbuddy/internal/poller"
 	"github.com/Lincyaw/workbuddy/internal/registry"
 	"github.com/Lincyaw/workbuddy/internal/reporter"
@@ -536,7 +538,24 @@ func executeTask(ctx context.Context, task router.WorkerTask, deps *workerDeps) 
 		log.Printf("[worker] report started failed: %v", err)
 	}
 
-	result, err := deps.launcher.Launch(taskCtx, task.Agent, task.Context)
+	session, err := deps.launcher.Start(taskCtx, task.Agent, task.Context)
+	if err != nil {
+		log.Printf("[worker] failed to start agent %s: %v", task.AgentName, err)
+		if err := deps.store.UpdateTaskStatus(task.TaskID, store.TaskStatusFailed); err != nil {
+			log.Printf("[worker] failed to update task status: %v", err)
+		}
+		deps.sm.MarkAgentCompleted(task.Repo, task.IssueNum, fetchCachedLabels(deps.store, task.Repo, task.IssueNum))
+		return
+	}
+	defer func() { _ = session.Close() }()
+
+	eventsCh := make(chan launcherevents.Event, 64)
+	eventsPath, waitEvents := streamSessionEvents(task.Context, eventsCh)
+	result, err := session.Run(taskCtx, eventsCh)
+	close(eventsCh)
+	if waitErr := waitEvents(); waitErr != nil {
+		log.Printf("[worker] event capture failed: %v", waitErr)
+	}
 	if err != nil {
 		log.Printf("[worker] agent %s failed: %v", task.AgentName, err)
 		if err := deps.store.UpdateTaskStatus(task.TaskID, store.TaskStatusFailed); err != nil {
@@ -544,6 +563,10 @@ func executeTask(ctx context.Context, task router.WorkerTask, deps *workerDeps) 
 		}
 		deps.sm.MarkAgentCompleted(task.Repo, task.IssueNum, fetchCachedLabels(deps.store, task.Repo, task.IssueNum))
 		return
+	}
+
+	if result != nil && result.SessionPath == "" && eventsPath != "" {
+		result.SessionPath = eventsPath
 	}
 
 	// Determine task status
@@ -589,6 +612,41 @@ func executeTask(ctx context.Context, task router.WorkerTask, deps *workerDeps) 
 
 	// Mark agent completed in state machine
 	deps.sm.MarkAgentCompleted(task.Repo, task.IssueNum, fetchCachedLabels(deps.store, task.Repo, task.IssueNum))
+}
+
+func streamSessionEvents(taskCtx *launcher.TaskContext, eventsCh <-chan launcherevents.Event) (string, func() error) {
+	baseDir := taskCtx.WorkDir
+	if baseDir == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			baseDir = "."
+		} else {
+			baseDir = cwd
+		}
+	}
+	path := filepath.Join(baseDir, ".workbuddy", "sessions", taskCtx.Session.ID, "events-v1.jsonl")
+	errCh := make(chan error, 1)
+	go func() {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			errCh <- err
+			return
+		}
+		f, err := os.Create(path)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		defer func() { _ = f.Close() }()
+		enc := json.NewEncoder(f)
+		for evt := range eventsCh {
+			if err := enc.Encode(evt); err != nil {
+				errCh <- err
+				return
+			}
+		}
+		errCh <- nil
+	}()
+	return path, func() error { return <-errCh }
 }
 
 // addClaimReaction adds an eyes reaction to the issue to signal an agent claimed it.

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Lincyaw/workbuddy/internal/config"
 	"github.com/Lincyaw/workbuddy/internal/launcher"
+	launcherevents "github.com/Lincyaw/workbuddy/internal/launcher/events"
 	"github.com/Lincyaw/workbuddy/internal/poller"
 	"github.com/Lincyaw/workbuddy/internal/store"
 )
@@ -122,6 +123,23 @@ type mockRuntime struct {
 }
 
 func (m *mockRuntime) Name() string { return m.name }
+
+type mockSession struct {
+	rt    *mockRuntime
+	agent *config.AgentConfig
+	task  *launcher.TaskContext
+}
+
+func (s *mockSession) Run(ctx context.Context, _ chan<- launcherevents.Event) (*launcher.Result, error) {
+	return s.rt.Launch(ctx, s.agent, s.task)
+}
+
+func (s *mockSession) SetApprover(launcher.Approver) error { return launcher.ErrNotSupported }
+func (s *mockSession) Close() error                        { return nil }
+
+func (m *mockRuntime) Start(ctx context.Context, agent *config.AgentConfig, task *launcher.TaskContext) (launcher.Session, error) {
+	return &mockSession{rt: m, agent: agent, task: task}, nil
+}
 
 func (m *mockRuntime) Launch(ctx context.Context, agent *config.AgentConfig, task *launcher.TaskContext) (*launcher.Result, error) {
 	m.mu.Lock()

--- a/docs/mismatch/codex-runtime-drift.md
+++ b/docs/mismatch/codex-runtime-drift.md
@@ -1,54 +1,13 @@
 # Codex Runtime Drift
 
-状态：mismatch
+状态：archived
 
-## 现象
+该 drift 已由 issue #8 收敛：
 
-`.github/workbuddy/agents/codex-dev-agent.md` 已经把 Codex 描述成一个更结构化的 runtime：
+- `internal/launcher` 已升级为 `Runtime.Start -> Session.Run`
+- `internal/launcher/events/` 已落地 Event Schema v1
+- `internal/launcher/codex.go` 已按 `codex exec --json` 实时映射事件
+- `Result.LastMessage` / `Result.SessionRef` / `Result.TokenUsage` 已接入 reporter / audit
+- session 事件已写入 `.workbuddy/sessions/<session>/` 下的 artifact
 
-- 使用 `codex exec --json`
-- 通过 `--output-last-message` 产出更干净的最终消息
-- 暗示 reporter / audit 可以更好地消费这些结构化产物
-
-但当前执行链路还没有真正把这些能力升级成统一 runtime 语义。
-
-## 当前代码事实
-
-当前 Codex runtime 仍然属于 one-shot `Launch(...)`：
-
-- 执行 `command`
-- 把 stdout/stderr 作为整体缓冲读取
-- 返回 `launcher.Result`
-- reporter 仍按最终结果格式化 issue comment
-- audit 会做摘要，但不是 Event v1 级别结构化消费
-
-代码：
-
-- `internal/launcher/codex.go`
-- `internal/launcher/process.go`
-- `internal/reporter/reporter.go`
-- `internal/audit/audit.go`
-
-## 差异点
-
-### 1. `--json` 已经写进 agent 文档，但平台层还没有统一解析协议
-
-目前只是“命令本身可能输出 JSONL”，不是“系统已经消费 JSONL event stream”。
-
-### 2. `--output-last-message` 已经写进命令，但 reporter 没有把它当成统一主字段
-
-这类信息还没有提升成 planned 文档里的 `Result.LastMessage`。
-
-### 3. Codex app-server 仍然完全是规划能力
-
-当前仓库里没有 app-server runtime，也没有 per-repo session pool。
-
-## 建议收敛方式
-
-- 如果短期不做统一结构化消费，就把 codex agent 文档表述收窄成“当前只是运行参数建议”。
-- 如果要兑现这条路线，就按 `docs/planned/runtime-session-architecture.md` 和 `docs/planned/event-schema-v1.md` 继续实现。
-
-## 依赖关系
-
-- 兑现路线 blocked by：`docs/planned/event-schema-v1.md`、`docs/planned/runtime-session-architecture.md`
-- 这条 drift 与 planned 中的 Codex app-server 设计同源；planned 文档落地后此 drift 自动消除。
+因此这份 mismatch 文档只保留作归档说明，不再代表当前代码现状。

--- a/docs/mismatch/index.md
+++ b/docs/mismatch/index.md
@@ -9,7 +9,7 @@
 | `docs/mismatch/config-schema-drift.md` | `config.yaml` 展示字段和真实 loader 支持字段不一致 | `.github/workbuddy/config.yaml`, `internal/config/types.go` |
 | `docs/mismatch/poller-and-state-machine-drift.md` | Poller、StateMachine 的职责边界和旧设计不一致 | `internal/poller/poller.go`, `internal/statemachine/statemachine.go` |
 | `docs/mismatch/retry-and-failure-drift.md` | `max_retries`、failed 状态和自动回退能力没有旧文档说得那么完整 | `internal/statemachine/statemachine.go`, `internal/store/store.go` |
-| `docs/mismatch/codex-runtime-drift.md` | Codex agent 文档对结构化输出消费的表述超前于当前 launcher/reporter | `.github/workbuddy/agents/codex-dev-agent.md`, `internal/launcher/codex.go` |
+| `docs/mismatch/codex-runtime-drift.md` | 已归档：issue #8 已补齐 Codex 结构化 runtime 接入 | `.github/workbuddy/agents/codex-dev-agent.md`, `internal/launcher/codex.go` |
 | `docs/mismatch/roadmap-structure-drift.md` | 旧 roadmap 中的模块命名、命令清单、分阶段产出与当前代码布局不一致 | `cmd/`, `internal/` |
 
 ## 使用规则

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -66,7 +66,7 @@ func (a *Auditor) Capture(sessionID, taskID, repo string, issueNum int, agentNam
 			// Generate summary based on runtime.
 			switch {
 			case strings.Contains(strings.ToLower(agentName), "codex"):
-				summary = summarizeCodex(string(data))
+				summary = summarizeCodex(result, string(data))
 			default: // claude-code or unknown — try JSON parse
 				summary = summarizeClaude(data)
 			}
@@ -238,9 +238,13 @@ func summarizeClaude(data []byte) string {
 // Codex session parsing
 // ---------------------------------------------------------------------------
 
-func summarizeCodex(data string) string {
+func summarizeCodex(result *launcher.Result, data string) string {
 	var b strings.Builder
 	b.WriteString("## Codex Session Summary\n\n")
+	if result != nil && result.LastMessage != "" {
+		b.WriteString("### Final Message\n")
+		fmt.Fprintf(&b, "> %s\n\n", truncate(result.LastMessage, 500))
+	}
 
 	lines := strings.Split(data, "\n")
 	var keyLines []string
@@ -266,7 +270,6 @@ func summarizeCodex(data string) string {
 			fmt.Fprintf(&b, "- %s\n", l)
 		}
 	} else {
-		// Fallback: first 20 lines.
 		b.WriteString("### Log Excerpt\n```\n")
 		limit := 20
 		if len(lines) < limit {
@@ -291,6 +294,11 @@ func buildMinimalSummary(result *launcher.Result) string {
 	b.WriteString("## Session Summary (no session file)\n\n")
 	fmt.Fprintf(&b, "- Exit code: %d\n", result.ExitCode)
 	fmt.Fprintf(&b, "- Duration: %s\n", result.Duration)
+	if result.LastMessage != "" {
+		b.WriteString("\n### Final Message\n```\n")
+		b.WriteString(truncate(result.LastMessage, 500))
+		b.WriteString("\n```\n")
+	}
 	if result.Stdout != "" {
 		b.WriteString("\n### Stdout (excerpt)\n```\n")
 		b.WriteString(truncate(result.Stdout, 500))

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -20,11 +21,22 @@ func (w Warning) String() string {
 	return w.Message
 }
 
-// validRuntimes enumerates allowed agent runtime values.
+const (
+	RuntimeClaudeCode  = "claude-code"
+	RuntimeClaudeShot  = "claude-oneshot"
+	RuntimeCodex       = "codex"
+	RuntimeCodexExec   = "codex-exec"
+	RuntimeCodexServer = "codex-appserver"
+)
+
 var validRuntimes = map[string]bool{
-	"claude-code": true,
-	"codex":       true,
+	RuntimeClaudeCode: true,
+	RuntimeClaudeShot: true,
+	RuntimeCodex:      true,
+	RuntimeCodexExec:  true,
 }
+
+var publicRuntimes = []string{RuntimeClaudeCode, RuntimeCodex}
 
 // LoadConfig loads the full configuration from the given config directory.
 // It returns the parsed config, a list of non-fatal warnings, and any error.
@@ -43,7 +55,6 @@ func LoadConfig(configDir string) (*FullConfig, []Warning, error) {
 	}
 	var warnings []Warning
 
-	// Load global config.yaml (optional — if present).
 	globalPath := filepath.Join(configDir, "config.yaml")
 	if data, err := os.ReadFile(globalPath); err == nil {
 		if err := yaml.Unmarshal(data, &cfg.Global); err != nil {
@@ -51,7 +62,6 @@ func LoadConfig(configDir string) (*FullConfig, []Warning, error) {
 		}
 	}
 
-	// Load agents.
 	agentsDir := filepath.Join(configDir, "agents")
 	if entries, err := os.ReadDir(agentsDir); err == nil {
 		for _, e := range entries {
@@ -59,15 +69,15 @@ func LoadConfig(configDir string) (*FullConfig, []Warning, error) {
 				continue
 			}
 			path := filepath.Join(agentsDir, e.Name())
-			agent, err := parseAgentFile(path)
+			agent, agentWarnings, err := parseAgentFile(path)
 			if err != nil {
 				return nil, nil, err
 			}
 			cfg.Agents[agent.Name] = agent
+			warnings = append(warnings, agentWarnings...)
 		}
 	}
 
-	// Load workflows.
 	workflowsDir := filepath.Join(configDir, "workflows")
 	if entries, err := os.ReadDir(workflowsDir); err == nil {
 		for _, e := range entries {
@@ -83,7 +93,6 @@ func LoadConfig(configDir string) (*FullConfig, []Warning, error) {
 		}
 	}
 
-	// Cross-config validations.
 	if err := validateWorkflowTriggerConflicts(cfg.Workflows); err != nil {
 		return nil, nil, err
 	}
@@ -105,57 +114,133 @@ func parseFrontmatter(data []byte) (frontmatter []byte, body string, err error) 
 		return nil, "", fmt.Errorf("missing closing YAML frontmatter delimiter")
 	}
 	fm := rest[:idx]
-	body = rest[idx+4:] // skip "\n---"
+	body = rest[idx+4:]
 	return []byte(fm), body, nil
 }
 
-// yamlCodeBlockRe matches the first ```yaml ... ``` code block.
 var yamlCodeBlockRe = regexp.MustCompile("(?s)```yaml\\s*\n(.*?)```")
 
-// parseAgentFile parses an agent Markdown file with YAML frontmatter.
-func parseAgentFile(path string) (*AgentConfig, error) {
+func parseAgentFile(path string) (*AgentConfig, []Warning, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("config: %s: %w", path, err)
+		return nil, nil, fmt.Errorf("config: %s: %w", path, err)
 	}
 	fm, _, err := parseFrontmatter(data)
 	if err != nil {
-		return nil, fmt.Errorf("config: %s: %w", path, err)
+		return nil, nil, fmt.Errorf("config: %s: %w", path, err)
 	}
 
 	var agent AgentConfig
 	if err := yaml.Unmarshal(fm, &agent); err != nil {
-		return nil, fmt.Errorf("config: %s: %w", path, err)
+		return nil, nil, fmt.Errorf("config: %s: %w", path, err)
 	}
 
-	// Validate required fields.
 	fname := filepath.Base(path)
 	if agent.Name == "" {
-		return nil, fmt.Errorf("config: %s: missing required field \"name\"", fname)
+		return nil, nil, fmt.Errorf("config: %s: missing required field \"name\"", fname)
 	}
 	if len(agent.Triggers) == 0 {
-		return nil, fmt.Errorf("config: %s: missing required field \"triggers\"", fname)
+		return nil, nil, fmt.Errorf("config: %s: missing required field \"triggers\"", fname)
 	}
 	if agent.Role == "" {
-		return nil, fmt.Errorf("config: %s: missing required field \"role\"", fname)
+		return nil, nil, fmt.Errorf("config: %s: missing required field \"role\"", fname)
 	}
-	if agent.Command == "" {
-		return nil, fmt.Errorf("config: %s: missing required field \"command\"", fname)
+	if agent.Command == "" && strings.TrimSpace(agent.Prompt) == "" {
+		return nil, nil, fmt.Errorf("config: %s: missing required field \"command\" or \"prompt\"", fname)
 	}
 
-	// Default runtime.
 	if agent.Runtime == "" {
-		agent.Runtime = "claude-code"
+		agent.Runtime = RuntimeClaudeCode
 	}
 	if !validRuntimes[agent.Runtime] {
-		return nil, fmt.Errorf("config: %s: invalid runtime %q (valid: claude-code, codex)", fname, agent.Runtime)
+		return nil, nil, fmt.Errorf("config: %s: invalid runtime %q (valid: %s)", fname, agent.Runtime, strings.Join(publicRuntimes, ", "))
 	}
 
-	return &agent, nil
+	warnings, err := normalizeAgentConfig(&agent)
+	if err != nil {
+		return nil, nil, fmt.Errorf("config: %s: %w", fname, err)
+	}
+	return &agent, warnings, nil
 }
 
-// parseWorkflowFile parses a workflow Markdown file with YAML frontmatter
-// and an embedded YAML code block for states.
+// NormalizeAgentConfig applies runtime aliases/defaults and validates the
+// runtime/policy matrix for an ad hoc agent config.
+func NormalizeAgentConfig(agent *AgentConfig) ([]Warning, error) {
+	return normalizeAgentConfig(agent)
+}
+
+func normalizeAgentConfig(agent *AgentConfig) ([]Warning, error) {
+	var warnings []Warning
+
+	switch agent.Runtime {
+	case RuntimeCodex:
+		agent.Runtime = RuntimeCodexExec
+	}
+
+	if agent.Policy.Timeout > 0 {
+		agent.Timeout = agent.Policy.Timeout
+	}
+
+	if agent.Policy.Sandbox == "" {
+		agent.Policy.Sandbox = defaultSandboxForRuntime(agent.Runtime)
+	}
+	if agent.Policy.Approval == "" {
+		agent.Policy.Approval = defaultApprovalForRuntime(agent.Runtime)
+	}
+
+	if agent.Policy.Sandbox == "" {
+		return warnings, fmt.Errorf("policy.sandbox is required for runtime %q", agent.Runtime)
+	}
+	if agent.Policy.Approval == "" {
+		return warnings, fmt.Errorf("policy.approval is required for runtime %q", agent.Runtime)
+	}
+
+	switch agent.Runtime {
+	case RuntimeClaudeCode, RuntimeClaudeShot:
+		if agent.Policy.Sandbox != "danger-full-access" {
+			return warnings, fmt.Errorf("unsupported policy.sandbox %q for runtime %q", agent.Policy.Sandbox, agent.Runtime)
+		}
+		if agent.Policy.Approval != "never" {
+			return warnings, fmt.Errorf("unsupported policy.approval %q for runtime %q", agent.Policy.Approval, agent.Runtime)
+		}
+	case RuntimeCodexExec:
+		switch agent.Policy.Sandbox {
+		case "read-only", "workspace-write", "danger-full-access":
+		default:
+			return warnings, fmt.Errorf("unsupported policy.sandbox %q for runtime %q", agent.Policy.Sandbox, agent.Runtime)
+		}
+		switch agent.Policy.Approval {
+		case "never", "on-failure", "on-request":
+		default:
+			return warnings, fmt.Errorf("unsupported policy.approval %q for runtime %q", agent.Policy.Approval, agent.Runtime)
+		}
+	default:
+		return warnings, fmt.Errorf("unsupported runtime %q", agent.Runtime)
+	}
+
+	return warnings, nil
+}
+
+func defaultSandboxForRuntime(runtime string) string {
+	switch runtime {
+	case RuntimeClaudeCode, RuntimeClaudeShot:
+		return "danger-full-access"
+	case RuntimeCodexExec:
+		return "read-only"
+	default:
+		return ""
+	}
+}
+
+func defaultApprovalForRuntime(runtime string) string {
+	switch runtime {
+	case RuntimeClaudeCode, RuntimeClaudeShot, RuntimeCodexExec:
+		return "never"
+	default:
+		return ""
+	}
+}
+
 func parseWorkflowFile(path string) (*WorkflowConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -171,12 +256,10 @@ func parseWorkflowFile(path string) (*WorkflowConfig, error) {
 		return nil, fmt.Errorf("config: %s: %w", path, err)
 	}
 
-	// Default max_retries.
 	if wf.MaxRetries == 0 {
 		wf.MaxRetries = 3
 	}
 
-	// Extract states from the first ```yaml code block.
 	fname := filepath.Base(path)
 	match := yamlCodeBlockRe.FindStringSubmatch(body)
 	if match == nil {
@@ -189,18 +272,14 @@ func parseWorkflowFile(path string) (*WorkflowConfig, error) {
 	}
 	wf.States = block.States
 
-	// Validate states and edges.
 	if err := validateStates(fname, &wf); err != nil {
 		return nil, err
 	}
 
-	// Auto-add failed state if workflow has back-edges but no failed state.
 	autoAddFailedState(&wf)
-
 	return &wf, nil
 }
 
-// validateStates checks the single-edge constraint on workflow states.
 func validateStates(fname string, wf *WorkflowConfig) error {
 	for stateName, state := range wf.States {
 		seen := make(map[string]bool)
@@ -215,41 +294,22 @@ func validateStates(fname string, wf *WorkflowConfig) error {
 	return nil
 }
 
-// autoAddFailedState adds a "failed" state if the workflow has back-edges
-// (a transition where To references a state that appears earlier or the same
-// state, indicating a cycle/retry) but no explicit "failed" state.
 func autoAddFailedState(wf *WorkflowConfig) {
 	if _, exists := wf.States[StateNameFailed]; exists {
 		return
 	}
-	// Check for back-edges: any transition whose To target is a state that
-	// also has outgoing transitions (i.e., not a terminal state), creating a cycle.
-	hasBackEdge := false
 	for _, state := range wf.States {
 		for _, t := range state.Transitions {
-			if target, ok := wf.States[t.To]; ok {
-				if len(target.Transitions) > 0 {
-					hasBackEdge = true
-					break
-				}
+			if target, ok := wf.States[t.To]; ok && len(target.Transitions) > 0 {
+				wf.States[StateNameFailed] = &State{EnterLabel: LabelFailed}
+				return
 			}
-		}
-		if hasBackEdge {
-			break
-		}
-	}
-
-	if hasBackEdge {
-		wf.States[StateNameFailed] = &State{
-			EnterLabel: LabelFailed,
 		}
 	}
 }
 
-// validateWorkflowTriggerConflicts checks that no two workflows share the
-// same trigger.issue_label.
 func validateWorkflowTriggerConflicts(workflows map[string]*WorkflowConfig) error {
-	seen := make(map[string]string) // label -> workflow name
+	seen := make(map[string]string)
 	for _, wf := range workflows {
 		label := wf.Trigger.IssueLabel
 		if label == "" {
@@ -263,10 +323,7 @@ func validateWorkflowTriggerConflicts(workflows map[string]*WorkflowConfig) erro
 	return nil
 }
 
-// checkAgentLabelConsistency returns warnings for agent trigger labels that
-// don't appear as enter_label in any workflow state.
 func checkAgentLabelConsistency(cfg *FullConfig) []Warning {
-	// Collect all enter_labels from workflows.
 	enterLabels := make(map[string]bool)
 	for _, wf := range cfg.Workflows {
 		for _, state := range wf.States {
@@ -277,12 +334,16 @@ func checkAgentLabelConsistency(cfg *FullConfig) []Warning {
 	}
 
 	var warnings []Warning
-	for _, agent := range cfg.Agents {
+	names := make([]string, 0, len(cfg.Agents))
+	for name := range cfg.Agents {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		agent := cfg.Agents[name]
 		for _, trigger := range agent.Triggers {
 			if trigger.Label != "" && !enterLabels[trigger.Label] {
-				warnings = append(warnings, Warning{
-					Message: fmt.Sprintf("agent %q trigger label %q does not match any workflow state enter_label", agent.Name, trigger.Label),
-				})
+				warnings = append(warnings, Warning{Message: fmt.Sprintf("agent %q trigger label %q does not match any workflow state enter_label", agent.Name, trigger.Label)})
 			}
 		}
 	}

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // helper to create a temp config directory with files.
@@ -538,5 +539,96 @@ states:
 	}
 	if failedState.EnterLabel != LabelFailed {
 		t.Errorf("failed state enter_label = %q, want %q", failedState.EnterLabel, LabelFailed)
+	}
+}
+
+func TestLoadConfig_CodexPolicyNormalize(t *testing.T) {
+	agent := `---
+name: codex-agent
+description: Codex agent
+triggers:
+  - label: "status:developing"
+    event: labeled
+role: dev
+runtime: codex
+policy:
+  sandbox: danger-full-access
+  approval: on-request
+  model: gpt-5.4
+  timeout: 45m
+prompt: |
+  implement issue {{.Issue.Number}}
+command: |
+  codex exec "compat"
+---
+## Agent
+`
+	dir := setupConfigDir(t, map[string]string{"agents/codex.md": agent, "workflows/feature-dev.md": validWorkflow})
+	cfg, warnings, err := LoadConfig(dir)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", warnings)
+	}
+	got := cfg.Agents["codex-agent"]
+	if got.Runtime != RuntimeCodexExec {
+		t.Fatalf("runtime = %q", got.Runtime)
+	}
+	if got.Policy.Model != "gpt-5.4" || got.Policy.Approval != "on-request" || got.Policy.Sandbox != "danger-full-access" {
+		t.Fatalf("unexpected policy: %+v", got.Policy)
+	}
+	if got.Timeout != 45*time.Minute {
+		t.Fatalf("timeout = %s", got.Timeout)
+	}
+}
+
+func TestLoadConfig_UnsupportedPolicyMatrix(t *testing.T) {
+	agent := `---
+name: bad-agent
+description: Bad agent
+triggers:
+  - label: "status:developing"
+    event: labeled
+role: dev
+runtime: claude-code
+policy:
+  sandbox: read-only
+  approval: on-request
+command: "claude -p 'do stuff'"
+---
+## Agent
+`
+	dir := setupConfigDir(t, map[string]string{"agents/bad.md": agent})
+	_, _, err := LoadConfig(dir)
+	if err == nil {
+		t.Fatal("expected policy validation error")
+	}
+	if !strings.Contains(err.Error(), "unsupported policy.sandbox") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfig_CodexAppServerRejectedUntilImplemented(t *testing.T) {
+	agent := `---
+name: future-agent
+description: Future agent
+triggers:
+  - label: "status:developing"
+    event: labeled
+role: dev
+runtime: codex-appserver
+prompt: |
+  implement issue {{.Issue.Number}}
+---
+## Agent
+`
+	dir := setupConfigDir(t, map[string]string{"agents/future.md": agent})
+	_, _, err := LoadConfig(dir)
+	if err == nil {
+		t.Fatal("expected unsupported runtime error")
+	}
+	if !strings.Contains(err.Error(), "invalid runtime") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -4,8 +4,8 @@ import "time"
 
 // Well-known state names.
 const (
-	StateNameFailed  = "failed"
-	LabelFailed      = "status:failed"
+	StateNameFailed = "failed"
+	LabelFailed     = "status:failed"
 )
 
 // GlobalConfig is the top-level configuration loaded from config.yaml.
@@ -16,14 +16,24 @@ type GlobalConfig struct {
 	Port         int           `yaml:"port"`
 }
 
+// PolicyConfig defines runtime-neutral execution policy knobs.
+type PolicyConfig struct {
+	Sandbox  string        `yaml:"sandbox"`
+	Approval string        `yaml:"approval"`
+	Model    string        `yaml:"model"`
+	Timeout  time.Duration `yaml:"timeout"`
+}
+
 // AgentConfig defines an agent loaded from .github/workbuddy/agents/*.md.
 type AgentConfig struct {
 	Name        string        `yaml:"name"`
 	Description string        `yaml:"description"`
 	Triggers    []TriggerRule `yaml:"triggers"`
 	Role        string        `yaml:"role"`
-	Runtime     string        `yaml:"runtime"` // "claude-code" (default) or "codex"
+	Runtime     string        `yaml:"runtime"`
 	Command     string        `yaml:"command"`
+	Prompt      string        `yaml:"prompt"`
+	Policy      PolicyConfig  `yaml:"policy"`
 	Timeout     time.Duration `yaml:"timeout"`
 }
 

--- a/internal/launcher/claude.go
+++ b/internal/launcher/claude.go
@@ -10,18 +10,23 @@ import (
 	"github.com/Lincyaw/workbuddy/internal/config"
 )
 
-// ClaudeRuntime implements Runtime for claude-code (claude -p mode).
 type ClaudeRuntime struct{}
 
-// Name returns the runtime identifier.
-func (r *ClaudeRuntime) Name() string { return "claude-code" }
+func (r *ClaudeRuntime) Name() string { return config.RuntimeClaudeShot }
 
-// Launch executes an agent using the claude-code runtime.
-func (r *ClaudeRuntime) Launch(ctx context.Context, agent *config.AgentConfig, task *TaskContext) (*Result, error) {
-	return launchProcess(ctx, "claude-code", agent, task, findClaudeSessionPath)
+func (r *ClaudeRuntime) Start(_ context.Context, agent *config.AgentConfig, task *TaskContext) (Session, error) {
+	return newProcessSession(r.Name(), agent, task, findClaudeSessionPath), nil
 }
 
-// findClaudeSessionPath attempts to locate the claude session directory.
+func (r *ClaudeRuntime) Launch(ctx context.Context, agent *config.AgentConfig, task *TaskContext) (*Result, error) {
+	sess, err := r.Start(ctx, agent, task)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = sess.Close() }()
+	return sess.Run(ctx, nil)
+}
+
 func findClaudeSessionPath(repoPath string) string {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -49,11 +54,9 @@ func findClaudeSessionPath(repoPath string) string {
 			return filepath.Join(claudeProjectsDir, entry.Name())
 		}
 	}
-
 	return ""
 }
 
-// buildEnvVars creates the WORKBUDDY_* environment variables for agent execution.
 func buildEnvVars(task *TaskContext) []string {
 	return []string{
 		"WORKBUDDY_ISSUE_NUMBER=" + strconv.Itoa(task.Issue.Number),

--- a/internal/launcher/codex.go
+++ b/internal/launcher/codex.go
@@ -1,41 +1,384 @@
 package launcher
 
 import (
+	"bufio"
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
 
 	"github.com/Lincyaw/workbuddy/internal/config"
+	launcherevents "github.com/Lincyaw/workbuddy/internal/launcher/events"
 )
 
-// CodexRuntime implements Runtime for codex (codex exec mode).
 type CodexRuntime struct{}
 
-// Name returns the runtime identifier.
-func (r *CodexRuntime) Name() string { return "codex" }
+func (r *CodexRuntime) Name() string { return config.RuntimeCodexExec }
 
-// Launch executes an agent using the codex runtime.
-func (r *CodexRuntime) Launch(ctx context.Context, agent *config.AgentConfig, task *TaskContext) (*Result, error) {
-	return launchProcess(ctx, "codex", agent, task, findCodexLogPath)
+func (r *CodexRuntime) Start(_ context.Context, agent *config.AgentConfig, task *TaskContext) (Session, error) {
+	prompt, err := codexPrompt(agent, task)
+	if err != nil {
+		return nil, err
+	}
+	return newCodexSession(agent, task, prompt), nil
 }
 
-// findCodexLogPath attempts to locate the codex output log directory.
-func findCodexLogPath(repoPath string) string {
-	home, err := os.UserHomeDir()
+func (r *CodexRuntime) Launch(ctx context.Context, agent *config.AgentConfig, task *TaskContext) (*Result, error) {
+	sess, err := r.Start(ctx, agent, task)
 	if err != nil {
-		return ""
+		return nil, err
+	}
+	defer func() { _ = sess.Close() }()
+	return sess.Run(ctx, nil)
+}
+
+type codexSession struct {
+	agent        *config.AgentConfig
+	task         *TaskContext
+	prompt       string
+	lastMsgPath  string
+	stdoutPath   string
+	cachedResult *Result
+}
+
+func newCodexSession(agent *config.AgentConfig, task *TaskContext, prompt string) *codexSession {
+	baseDir := task.WorkDir
+	if baseDir == "" {
+		baseDir = "."
+	}
+	artifactDir := filepath.Join(baseDir, ".workbuddy", "sessions", task.Session.ID)
+	return &codexSession{
+		agent:       agent,
+		task:        task,
+		prompt:      prompt,
+		lastMsgPath: filepath.Join(artifactDir, "codex-last-message.txt"),
+		stdoutPath:  filepath.Join(artifactDir, "codex-events.jsonl"),
+	}
+}
+
+func (s *codexSession) Run(ctx context.Context, events chan<- launcherevents.Event) (*Result, error) {
+	if s.cachedResult != nil {
+		return s.cachedResult, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(s.stdoutPath), 0o755); err != nil {
+		return nil, fmt.Errorf("launcher: codex-exec: create artifact dir: %w", err)
 	}
 
-	candidates := []string{
-		filepath.Join(repoPath, ".codex", "logs"),
-		filepath.Join(home, ".codex", "logs"),
+	timeout := s.agent.Timeout
+	if timeout == 0 {
+		timeout = 30 * time.Minute
+	}
+	execCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	args := s.buildArgs()
+	cmd := exec.CommandContext(execCtx, "codex", args...)
+	if s.task.WorkDir != "" {
+		cmd.Dir = s.task.WorkDir
+	}
+	cmd.Env = append(os.Environ(), buildEnvVars(s.task)...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error { return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL) }
+
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("launcher: codex-exec: stdout pipe: %w", err)
+	}
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("launcher: codex-exec: stderr pipe: %w", err)
 	}
 
-	for _, candidate := range candidates {
-		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
-			return candidate
+	stdoutFile, err := os.Create(s.stdoutPath)
+	if err != nil {
+		return nil, fmt.Errorf("launcher: codex-exec: create stdout artifact: %w", err)
+	}
+	defer func() { _ = stdoutFile.Close() }()
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("launcher: codex-exec: start: %w", err)
+	}
+	start := time.Now()
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	var seq uint64
+	mapper := newCodexEventMapper(s.task.Session.ID)
+	var wg sync.WaitGroup
+	var scanErr error
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		scanner := bufio.NewScanner(stdoutPipe)
+		buf := make([]byte, 0, 64*1024)
+		scanner.Buffer(buf, 4*1024*1024)
+		for scanner.Scan() {
+			line := scanner.Text()
+			stdoutBuf.WriteString(line)
+			stdoutBuf.WriteByte('\n')
+			_, _ = stdoutFile.WriteString(line + "\n")
+			for _, evt := range mapper.Map([]byte(line), &seq) {
+				if events != nil {
+					events <- evt
+				}
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			scanErr = err
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = stderrBuf.ReadFrom(stderrPipe)
+	}()
+
+	runErr := cmd.Wait()
+	wg.Wait()
+	duration := time.Since(start)
+	if scanErr != nil && !strings.Contains(scanErr.Error(), "file already closed") {
+		return nil, fmt.Errorf("launcher: codex-exec: read stdout: %w", scanErr)
+	}
+
+	exitCode := 0
+	if runErr != nil {
+		if execCtx.Err() == context.DeadlineExceeded {
+			result := &Result{ExitCode: -1, Stdout: stdoutBuf.String(), Stderr: stderrBuf.String(), Duration: duration, Meta: map[string]string{"timeout": "true"}, SessionPath: s.stdoutPath, SessionRef: mapper.sessionRef, TokenUsage: mapper.tokenUsage}
+			if events != nil {
+				emitEvent(events, &seq, s.task.Session.ID, mapper.turnID, launcherevents.KindError, launcherevents.ErrorPayload{Code: "timeout", Message: execCtx.Err().Error(), Recoverable: false}, nil)
+				emitEvent(events, &seq, s.task.Session.ID, mapper.turnID, launcherevents.KindTurnCompleted, launcherevents.TurnCompletedPayload{TurnID: mapper.effectiveTurnID(), Status: "error"}, nil)
+			}
+			return result, fmt.Errorf("launcher: codex-exec: timeout after %s: %w", timeout, execCtx.Err())
+		}
+		if ctx.Err() != nil {
+			result := &Result{ExitCode: -1, Stdout: stdoutBuf.String(), Stderr: stderrBuf.String(), Duration: duration, SessionPath: s.stdoutPath, SessionRef: mapper.sessionRef, TokenUsage: mapper.tokenUsage}
+			if events != nil {
+				emitEvent(events, &seq, s.task.Session.ID, mapper.turnID, launcherevents.KindError, launcherevents.ErrorPayload{Code: "cancelled", Message: ctx.Err().Error(), Recoverable: false}, nil)
+				emitEvent(events, &seq, s.task.Session.ID, mapper.turnID, launcherevents.KindTurnCompleted, launcherevents.TurnCompletedPayload{TurnID: mapper.effectiveTurnID(), Status: "interrupted"}, nil)
+			}
+			return result, fmt.Errorf("launcher: codex-exec: cancelled: %w", ctx.Err())
+		}
+		if exitErr, ok := runErr.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			return nil, fmt.Errorf("launcher: codex-exec: wait: %w", runErr)
 		}
 	}
 
-	return ""
+	lastMessage := readOptionalFile(s.lastMsgPath)
+	result := &Result{ExitCode: exitCode, Stdout: stdoutBuf.String(), Stderr: stderrBuf.String(), Duration: duration, SessionPath: s.stdoutPath, LastMessage: lastMessage, SessionRef: mapper.sessionRef, TokenUsage: mapper.tokenUsage}
+	s.cachedResult = result
+	if events != nil && stderrBuf.Len() > 0 {
+		emitEvent(events, &seq, s.task.Session.ID, mapper.turnID, launcherevents.KindLog, launcherevents.LogPayload{Stream: "stderr", Line: strings.TrimRight(stderrBuf.String(), "\n")}, nil)
+	}
+	return result, nil
+}
+
+func (s *codexSession) SetApprover(Approver) error { return ErrNotSupported }
+func (s *codexSession) Close() error               { return nil }
+
+func (s *codexSession) buildArgs() []string {
+	args := []string{"exec", "--skip-git-repo-check", "--json", "--output-last-message", s.lastMsgPath}
+	if s.task.WorkDir != "" {
+		args = append(args, "--cd", s.task.WorkDir)
+	}
+	if sandbox := s.agent.Policy.Sandbox; sandbox != "" {
+		args = append(args, "--sandbox", sandbox)
+	}
+	for _, cfg := range s.approvalConfigArgs() {
+		args = append(args, "-c", cfg)
+	}
+	if model := strings.TrimSpace(s.agent.Policy.Model); model != "" {
+		args = append(args, "--model", model)
+	}
+	args = append(args, s.prompt)
+	return args
+}
+
+func (s *codexSession) approvalConfigArgs() []string {
+	switch s.agent.Policy.Approval {
+	case "never":
+		return []string{"approval_policy=\"never\""}
+	case "on-failure":
+		return []string{"approval_policy=\"on-failure\""}
+	case "on-request":
+		return []string{"approval_policy=\"on-request\""}
+	default:
+		return nil
+	}
+}
+
+func codexPrompt(agent *config.AgentConfig, task *TaskContext) (string, error) {
+	if strings.TrimSpace(agent.Prompt) != "" {
+		return renderCommandRaw(agent.Prompt, task)
+	}
+	if strings.TrimSpace(agent.Command) == "" {
+		return "", fmt.Errorf("launcher: codex-exec: missing prompt/command")
+	}
+	rendered, err := renderCommandRaw(agent.Command, task)
+	if err != nil {
+		return "", err
+	}
+	trimmed := strings.TrimSpace(rendered)
+	if len(trimmed) == 0 {
+		return "", fmt.Errorf("launcher: codex-exec: cannot derive prompt from command")
+	}
+	quote := trimmed[len(trimmed)-1]
+	if quote != '\'' && quote != '"' {
+		return "", fmt.Errorf("launcher: codex-exec: cannot derive prompt from command")
+	}
+	start := strings.LastIndexByte(trimmed[:len(trimmed)-1], quote)
+	if start < 0 {
+		return "", fmt.Errorf("launcher: codex-exec: cannot derive prompt from command")
+	}
+	return trimmed[start+1 : len(trimmed)-1], nil
+}
+
+func readOptionalFile(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+type codexNativeEvent struct {
+	Type   string          `json:"type"`
+	Thread string          `json:"thread_id"`
+	Usage  *codexUsage     `json:"usage,omitempty"`
+	Item   *codexEventItem `json:"item,omitempty"`
+	Error  string          `json:"error,omitempty"`
+}
+
+type codexUsage struct {
+	InputTokens       int `json:"input_tokens"`
+	CachedInputTokens int `json:"cached_input_tokens"`
+	OutputTokens      int `json:"output_tokens"`
+}
+
+type codexEventItem struct {
+	ID               string `json:"id"`
+	Type             string `json:"type"`
+	Text             string `json:"text,omitempty"`
+	Command          string `json:"command,omitempty"`
+	AggregatedOutput string `json:"aggregated_output,omitempty"`
+	ExitCode         *int   `json:"exit_code,omitempty"`
+	Status           string `json:"status,omitempty"`
+	Title            string `json:"title,omitempty"`
+	Args             any    `json:"arguments,omitempty"`
+}
+
+type codexEventMapper struct {
+	sessionID  string
+	sessionRef SessionRef
+	turnID     string
+	turnCount  int
+	tokenUsage *launcherevents.TokenUsagePayload
+}
+
+func newCodexEventMapper(sessionID string) *codexEventMapper {
+	return &codexEventMapper{sessionID: sessionID}
+}
+
+func (m *codexEventMapper) effectiveTurnID() string {
+	if m.turnID != "" {
+		return m.turnID
+	}
+	return m.sessionID
+}
+
+func (m *codexEventMapper) Map(line []byte, seq *uint64) []launcherevents.Event {
+	var msg codexNativeEvent
+	if err := json.Unmarshal(line, &msg); err != nil {
+		return []launcherevents.Event{m.makeEvent(seq, m.effectiveTurnID(), launcherevents.KindLog, launcherevents.LogPayload{Stream: "stdout", Line: string(line)}, line)}
+	}
+
+	switch msg.Type {
+	case "thread.started":
+		m.sessionRef = SessionRef{ID: msg.Thread, Kind: "codex-thread"}
+		return nil
+	case "turn.started":
+		m.turnCount++
+		m.turnID = fmt.Sprintf("%s-turn-%d", m.sessionID, m.turnCount)
+		return []launcherevents.Event{m.makeEvent(seq, m.turnID, launcherevents.KindTurnStarted, launcherevents.TurnStartedPayload{TurnID: m.turnID}, line)}
+	case "turn.completed":
+		var out []launcherevents.Event
+		if msg.Usage != nil {
+			payload := launcherevents.TokenUsagePayload{Input: msg.Usage.InputTokens, Output: msg.Usage.OutputTokens, Cached: msg.Usage.CachedInputTokens, Total: msg.Usage.InputTokens + msg.Usage.OutputTokens}
+			m.tokenUsage = &payload
+			out = append(out, m.makeEvent(seq, m.effectiveTurnID(), launcherevents.KindTokenUsage, payload, line))
+		}
+		out = append(out, m.makeEvent(seq, m.effectiveTurnID(), launcherevents.KindTurnCompleted, launcherevents.TurnCompletedPayload{TurnID: m.effectiveTurnID(), Status: "ok"}, line))
+		return out
+	case "item.started":
+		return m.mapItemStarted(msg.Item, line, seq)
+	case "item.completed":
+		return m.mapItemCompleted(msg.Item, line, seq)
+	case "error":
+		message := msg.Error
+		if message == "" {
+			message = string(line)
+		}
+		return []launcherevents.Event{m.makeEvent(seq, m.effectiveTurnID(), launcherevents.KindError, launcherevents.ErrorPayload{Code: "unknown", Message: message, Recoverable: false}, line)}
+	default:
+		return []launcherevents.Event{m.makeEvent(seq, m.effectiveTurnID(), launcherevents.KindLog, launcherevents.LogPayload{Stream: "stdout", Line: string(line)}, line)}
+	}
+}
+
+func (m *codexEventMapper) mapItemStarted(item *codexEventItem, raw []byte, seq *uint64) []launcherevents.Event {
+	if item == nil {
+		return []launcherevents.Event{m.makeEvent(seq, m.effectiveTurnID(), launcherevents.KindLog, launcherevents.LogPayload{Stream: "stdout", Line: string(raw)}, raw)}
+	}
+	switch item.Type {
+	case "command_execution":
+		return []launcherevents.Event{m.makeEvent(seq, m.effectiveTurnID(), launcherevents.KindCommandExec, launcherevents.CommandExecPayload{Cmd: []string{item.Command}, CallID: item.ID}, raw)}
+	case "mcp_tool_call":
+		args, _ := json.Marshal(item.Args)
+		return []launcherevents.Event{m.makeEvent(seq, m.effectiveTurnID(), launcherevents.KindToolCall, launcherevents.ToolCallPayload{Name: item.Title, CallID: item.ID, Args: args}, raw)}
+	default:
+		return []launcherevents.Event{m.makeEvent(seq, m.effectiveTurnID(), launcherevents.KindLog, launcherevents.LogPayload{Stream: "stdout", Line: string(raw)}, raw)}
+	}
+}
+
+func (m *codexEventMapper) mapItemCompleted(item *codexEventItem, raw []byte, seq *uint64) []launcherevents.Event {
+	if item == nil {
+		return []launcherevents.Event{m.makeEvent(seq, m.effectiveTurnID(), launcherevents.KindLog, launcherevents.LogPayload{Stream: "stdout", Line: string(raw)}, raw)}
+	}
+	switch item.Type {
+	case "agent_message":
+		return []launcherevents.Event{m.makeEvent(seq, m.effectiveTurnID(), launcherevents.KindAgentMessage, launcherevents.AgentMessagePayload{Text: item.Text, Delta: false, Final: true}, raw)}
+	case "reasoning":
+		return []launcherevents.Event{m.makeEvent(seq, m.effectiveTurnID(), launcherevents.KindReasoning, launcherevents.ReasoningPayload{Text: item.Text, Delta: false}, raw)}
+	case "command_execution":
+		var out []launcherevents.Event
+		if item.AggregatedOutput != "" {
+			out = append(out, m.makeEvent(seq, m.effectiveTurnID(), launcherevents.KindCommandOutput, launcherevents.CommandOutputPayload{CallID: item.ID, Stream: "stdout", Data: item.AggregatedOutput}, raw))
+		}
+		itemResult, _ := json.Marshal(item)
+		ok := item.ExitCode != nil && *item.ExitCode == 0
+		out = append(out, m.makeEvent(seq, m.effectiveTurnID(), launcherevents.KindToolResult, launcherevents.ToolResultPayload{CallID: item.ID, OK: ok, Result: itemResult}, raw))
+		return out
+	case "mcp_tool_call":
+		itemResult, _ := json.Marshal(item)
+		return []launcherevents.Event{m.makeEvent(seq, m.effectiveTurnID(), launcherevents.KindToolResult, launcherevents.ToolResultPayload{CallID: item.ID, OK: item.Status == "completed", Result: itemResult}, raw)}
+	default:
+		return []launcherevents.Event{m.makeEvent(seq, m.effectiveTurnID(), launcherevents.KindLog, launcherevents.LogPayload{Stream: "stdout", Line: string(raw)}, raw)}
+	}
+}
+
+func (m *codexEventMapper) makeEvent(seq *uint64, turnID string, kind launcherevents.EventKind, payload any, raw []byte) launcherevents.Event {
+	*seq = *seq + 1
+	var rawMsg []byte
+	if len(raw) > 0 {
+		rawMsg = append(rawMsg, raw...)
+	}
+	return launcherevents.Event{Kind: kind, Timestamp: time.Now().UTC(), SessionID: m.sessionID, TurnID: turnID, Seq: *seq, Payload: launcherevents.MustPayload(payload), Raw: rawMsg}
 }

--- a/internal/launcher/codex_test.go
+++ b/internal/launcher/codex_test.go
@@ -1,0 +1,166 @@
+package launcher
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Lincyaw/workbuddy/internal/config"
+	launcherevents "github.com/Lincyaw/workbuddy/internal/launcher/events"
+)
+
+func TestCodexEventMapper(t *testing.T) {
+	mapper := newCodexEventMapper("session-1")
+	var seq uint64
+	lines := [][]byte{
+		[]byte(`{"type":"thread.started","thread_id":"thread-abc"}`),
+		[]byte(`{"type":"turn.started"}`),
+		[]byte(`{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"PONG"}}`),
+		[]byte(`{"type":"item.started","item":{"id":"item_1","type":"command_execution","command":"/bin/bash -lc 'echo PONG'","status":"in_progress"}}`),
+		[]byte(`{"type":"item.completed","item":{"id":"item_1","type":"command_execution","command":"/bin/bash -lc 'echo PONG'","aggregated_output":"PONG\n","exit_code":0,"status":"completed"}}`),
+		[]byte(`{"type":"turn.completed","usage":{"input_tokens":12,"cached_input_tokens":3,"output_tokens":4}}`),
+	}
+	var got []launcherevents.Event
+	for _, line := range lines {
+		got = append(got, mapper.Map(line, &seq)...)
+	}
+	if mapper.sessionRef.ID != "thread-abc" {
+		t.Fatalf("session ref = %+v", mapper.sessionRef)
+	}
+	if len(got) != 7 {
+		t.Fatalf("got %d events, want 7", len(got))
+	}
+	if got[0].Kind != launcherevents.KindTurnStarted {
+		t.Fatalf("first kind = %s", got[0].Kind)
+	}
+	if got[1].Kind != launcherevents.KindAgentMessage {
+		t.Fatalf("second kind = %s", got[1].Kind)
+	}
+	if got[2].Kind != launcherevents.KindCommandExec {
+		t.Fatalf("third kind = %s", got[2].Kind)
+	}
+	if got[3].Kind != launcherevents.KindCommandOutput || got[4].Kind != launcherevents.KindToolResult {
+		t.Fatalf("command events mismatch: %s %s", got[3].Kind, got[4].Kind)
+	}
+	if got[5].Kind != launcherevents.KindTokenUsage || got[6].Kind != launcherevents.KindTurnCompleted {
+		t.Fatalf("tail kinds = %s %s", got[5].Kind, got[6].Kind)
+	}
+	var usage launcherevents.TokenUsagePayload
+	if err := json.Unmarshal(got[5].Payload, &usage); err != nil {
+		t.Fatalf("usage payload: %v", err)
+	}
+	if usage.Total != 16 || usage.Cached != 3 {
+		t.Fatalf("unexpected usage: %+v", usage)
+	}
+}
+
+func TestCodexPromptPrefersPromptField(t *testing.T) {
+	task := newTestTask(t)
+	agent := &config.AgentConfig{Prompt: "issue {{.Issue.Number}}", Command: `codex exec "ignored"`}
+	prompt, err := codexPrompt(agent, task)
+	if err != nil {
+		t.Fatalf("codexPrompt: %v", err)
+	}
+	if prompt != "issue 42" {
+		t.Fatalf("prompt = %q", prompt)
+	}
+}
+
+func TestLaunch_CodexRuntimeUsesPrompt(t *testing.T) {
+	if _, err := exec.LookPath("codex"); err != nil {
+		t.Skip("codex not installed")
+	}
+	launcher := NewLauncher()
+	task := newTestTask(t)
+	agent := &config.AgentConfig{
+		Name:    "codex-agent",
+		Runtime: config.RuntimeCodexExec,
+		Prompt:  "Reply with exactly PONG",
+		Policy: config.PolicyConfig{
+			Sandbox:  "read-only",
+			Approval: "never",
+		},
+		Timeout: 60 * time.Second,
+	}
+	result, err := launcher.Launch(context.Background(), agent, task)
+	if err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	if result.LastMessage != "PONG" {
+		t.Fatalf("last message = %q", result.LastMessage)
+	}
+	if result.SessionRef.ID == "" {
+		t.Fatal("expected session ref from thread.started")
+	}
+	if result.TokenUsage == nil || result.TokenUsage.Total == 0 {
+		t.Fatalf("expected token usage, got %+v", result.TokenUsage)
+	}
+	if result.SessionPath == "" {
+		t.Fatal("expected session path")
+	}
+	data, err := os.ReadFile(result.SessionPath)
+	if err != nil {
+		t.Fatalf("read session path: %v", err)
+	}
+	if !strings.Contains(string(data), `"type":"turn.completed"`) {
+		t.Fatalf("expected codex jsonl artifact, got: %s", string(data))
+	}
+}
+
+func TestCodexSessionRunEmitsEventsAndArtifact(t *testing.T) {
+	if os.Getenv("CODEX_E2E") != "1" {
+		t.Skip("set CODEX_E2E=1 to run codex runtime integration test")
+	}
+	if _, err := exec.LookPath("codex"); err != nil {
+		t.Skip("codex not installed")
+	}
+	launcher := NewLauncher()
+	task := newTestTask(t)
+	agent := &config.AgentConfig{
+		Name:    "codex-agent",
+		Runtime: config.RuntimeCodexExec,
+		Prompt:  "Run `echo PONG` and then reply DONE.",
+		Policy:  config.PolicyConfig{Sandbox: "danger-full-access", Approval: "never"},
+		Timeout: 90 * time.Second,
+	}
+	session, err := launcher.Start(context.Background(), agent, task)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer func() { _ = session.Close() }()
+	ch := make(chan launcherevents.Event, 32)
+	var collected []launcherevents.Event
+	done := make(chan struct{})
+	go func() {
+		for evt := range ch {
+			collected = append(collected, evt)
+		}
+		close(done)
+	}()
+	result, err := session.Run(context.Background(), ch)
+	close(ch)
+	<-done
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if result.LastMessage != "DONE" {
+		t.Fatalf("last message = %q", result.LastMessage)
+	}
+	kinds := map[launcherevents.EventKind]bool{}
+	for _, evt := range collected {
+		kinds[evt.Kind] = true
+	}
+	for _, want := range []launcherevents.EventKind{launcherevents.KindTurnStarted, launcherevents.KindCommandExec, launcherevents.KindCommandOutput, launcherevents.KindToolResult, launcherevents.KindAgentMessage, launcherevents.KindTokenUsage, launcherevents.KindTurnCompleted} {
+		if !kinds[want] {
+			t.Fatalf("missing event kind %s in %v", want, kinds)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(filepath.Dir(result.SessionPath), "codex-last-message.txt")); err != nil {
+		t.Fatalf("expected last message file: %v", err)
+	}
+}

--- a/internal/launcher/events/agent_message.go
+++ b/internal/launcher/events/agent_message.go
@@ -1,0 +1,7 @@
+package events
+
+type AgentMessagePayload struct {
+	Text  string `json:"text"`
+	Delta bool   `json:"delta"`
+	Final bool   `json:"final"`
+}

--- a/internal/launcher/events/command_exec.go
+++ b/internal/launcher/events/command_exec.go
@@ -1,0 +1,7 @@
+package events
+
+type CommandExecPayload struct {
+	Cmd    []string `json:"cmd"`
+	CWD    string   `json:"cwd,omitempty"`
+	CallID string   `json:"call_id"`
+}

--- a/internal/launcher/events/command_output.go
+++ b/internal/launcher/events/command_output.go
@@ -1,0 +1,7 @@
+package events
+
+type CommandOutputPayload struct {
+	CallID string `json:"call_id"`
+	Stream string `json:"stream"`
+	Data   string `json:"data"`
+}

--- a/internal/launcher/events/error.go
+++ b/internal/launcher/events/error.go
@@ -1,0 +1,7 @@
+package events
+
+type ErrorPayload struct {
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Recoverable bool   `json:"recoverable"`
+}

--- a/internal/launcher/events/event.go
+++ b/internal/launcher/events/event.go
@@ -1,0 +1,41 @@
+package events
+
+import (
+	"encoding/json"
+	"time"
+)
+
+type EventKind string
+
+const (
+	KindTurnStarted   EventKind = "turn.started"
+	KindTurnCompleted EventKind = "turn.completed"
+	KindAgentMessage  EventKind = "agent.message"
+	KindReasoning     EventKind = "reasoning"
+	KindToolCall      EventKind = "tool.call"
+	KindToolResult    EventKind = "tool.result"
+	KindCommandExec   EventKind = "command.exec"
+	KindCommandOutput EventKind = "command.output"
+	KindFileChange    EventKind = "file.change"
+	KindTokenUsage    EventKind = "token.usage"
+	KindError         EventKind = "error"
+	KindLog           EventKind = "log"
+)
+
+type Event struct {
+	Kind      EventKind       `json:"kind"`
+	Timestamp time.Time       `json:"ts"`
+	SessionID string          `json:"session_id"`
+	TurnID    string          `json:"turn_id,omitempty"`
+	Seq       uint64          `json:"seq"`
+	Payload   json.RawMessage `json:"payload"`
+	Raw       json.RawMessage `json:"raw,omitempty"`
+}
+
+func MustPayload(v any) json.RawMessage {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}

--- a/internal/launcher/events/events_test.go
+++ b/internal/launcher/events/events_test.go
@@ -1,0 +1,37 @@
+package events
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestEventJSONRoundTrip(t *testing.T) {
+	evt := Event{
+		Kind:      KindAgentMessage,
+		Timestamp: time.Unix(1710000000, 0).UTC(),
+		SessionID: "session-123",
+		TurnID:    "turn-1",
+		Seq:       7,
+		Payload:   MustPayload(AgentMessagePayload{Text: "hello", Delta: false, Final: true}),
+		Raw:       json.RawMessage(`{"type":"item.completed"}`),
+	}
+	data, err := json.Marshal(evt)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded Event
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.Kind != evt.Kind || decoded.SessionID != evt.SessionID || decoded.TurnID != evt.TurnID || decoded.Seq != evt.Seq {
+		t.Fatalf("decoded mismatch: %+v", decoded)
+	}
+	var payload AgentMessagePayload
+	if err := json.Unmarshal(decoded.Payload, &payload); err != nil {
+		t.Fatalf("payload unmarshal: %v", err)
+	}
+	if payload.Text != "hello" || !payload.Final || payload.Delta {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+}

--- a/internal/launcher/events/file_change.go
+++ b/internal/launcher/events/file_change.go
@@ -1,0 +1,7 @@
+package events
+
+type FileChangePayload struct {
+	Path       string `json:"path"`
+	ChangeKind string `json:"change_kind"`
+	Diff       string `json:"diff,omitempty"`
+}

--- a/internal/launcher/events/log.go
+++ b/internal/launcher/events/log.go
@@ -1,0 +1,6 @@
+package events
+
+type LogPayload struct {
+	Stream string `json:"stream"`
+	Line   string `json:"line"`
+}

--- a/internal/launcher/events/reasoning.go
+++ b/internal/launcher/events/reasoning.go
@@ -1,0 +1,6 @@
+package events
+
+type ReasoningPayload struct {
+	Text  string `json:"text"`
+	Delta bool   `json:"delta"`
+}

--- a/internal/launcher/events/token_usage.go
+++ b/internal/launcher/events/token_usage.go
@@ -1,0 +1,8 @@
+package events
+
+type TokenUsagePayload struct {
+	Input  int `json:"input"`
+	Output int `json:"output"`
+	Cached int `json:"cached"`
+	Total  int `json:"total"`
+}

--- a/internal/launcher/events/tool_call.go
+++ b/internal/launcher/events/tool_call.go
@@ -1,0 +1,9 @@
+package events
+
+import "encoding/json"
+
+type ToolCallPayload struct {
+	Name   string          `json:"name"`
+	CallID string          `json:"call_id"`
+	Args   json.RawMessage `json:"args,omitempty"`
+}

--- a/internal/launcher/events/tool_result.go
+++ b/internal/launcher/events/tool_result.go
@@ -1,0 +1,9 @@
+package events
+
+import "encoding/json"
+
+type ToolResultPayload struct {
+	CallID string          `json:"call_id"`
+	OK     bool            `json:"ok"`
+	Result json.RawMessage `json:"result,omitempty"`
+}

--- a/internal/launcher/events/turn_completed.go
+++ b/internal/launcher/events/turn_completed.go
@@ -1,0 +1,6 @@
+package events
+
+type TurnCompletedPayload struct {
+	TurnID string `json:"turn_id"`
+	Status string `json:"status"`
+}

--- a/internal/launcher/events/turn_started.go
+++ b/internal/launcher/events/turn_started.go
@@ -1,0 +1,5 @@
+package events
+
+type TurnStartedPayload struct {
+	TurnID string `json:"turn_id"`
+}

--- a/internal/launcher/launcher.go
+++ b/internal/launcher/launcher.go
@@ -3,9 +3,11 @@ package launcher
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/Lincyaw/workbuddy/internal/config"
+	launcherevents "github.com/Lincyaw/workbuddy/internal/launcher/events"
 )
 
 // Launcher dispatches agent execution to the appropriate Runtime implementation.
@@ -13,42 +15,62 @@ type Launcher struct {
 	runtimes map[string]Runtime
 }
 
-// NewLauncher creates a Launcher with built-in runtimes registered.
 func NewLauncher() *Launcher {
-	l := &Launcher{
-		runtimes: make(map[string]Runtime),
-	}
-	l.Register(&ClaudeRuntime{})
-	l.Register(&CodexRuntime{})
+	l := &Launcher{runtimes: make(map[string]Runtime)}
+	l.Register(&ClaudeRuntime{}, config.RuntimeClaudeCode, config.RuntimeClaudeShot)
+	l.Register(&CodexRuntime{}, config.RuntimeCodex, config.RuntimeCodexExec)
 	return l
 }
 
-// Register adds a Runtime implementation to the launcher.
-func (l *Launcher) Register(rt Runtime) {
+func (l *Launcher) Register(rt Runtime, aliases ...string) {
 	l.runtimes[rt.Name()] = rt
+	for _, alias := range aliases {
+		l.runtimes[alias] = rt
+	}
 }
 
-// Launch selects the appropriate runtime and executes the agent.
-func (l *Launcher) Launch(ctx context.Context, agent *config.AgentConfig, task *TaskContext) (*Result, error) {
+func (l *Launcher) Start(ctx context.Context, agent *config.AgentConfig, task *TaskContext) (Session, error) {
 	runtimeName := agent.Runtime
 	if runtimeName == "" {
-		runtimeName = "claude-code" // default runtime
+		runtimeName = config.RuntimeClaudeCode
 	}
-
 	rt, ok := l.runtimes[runtimeName]
 	if !ok {
-		supported := l.supportedRuntimes()
-		return nil, fmt.Errorf("launcher: unsupported runtime: %s, supported: %s", runtimeName, supported)
+		return nil, fmt.Errorf("launcher: unsupported runtime: %s, supported: %s", runtimeName, l.supportedRuntimes())
 	}
-
-	return rt.Launch(ctx, agent, task)
+	return rt.Start(ctx, agent, task)
 }
 
-// supportedRuntimes returns a comma-separated list of registered runtime names.
+func (l *Launcher) Launch(ctx context.Context, agent *config.AgentConfig, task *TaskContext) (*Result, error) {
+	sess, err := l.Start(ctx, agent, task)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = sess.Close() }()
+
+	ch := make(chan launcherevents.Event, 32)
+	done := make(chan struct{})
+	go func() {
+		for range ch {
+		}
+		close(done)
+	}()
+	result, runErr := sess.Run(ctx, ch)
+	close(ch)
+	<-done
+	return result, runErr
+}
+
 func (l *Launcher) supportedRuntimes() string {
-	names := make([]string, 0, len(l.runtimes))
+	seen := map[string]bool{}
+	var names []string
 	for name := range l.runtimes {
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
 		names = append(names, name)
 	}
+	sort.Strings(names)
 	return strings.Join(names, ", ")
 }

--- a/internal/launcher/launcher_test.go
+++ b/internal/launcher/launcher_test.go
@@ -225,16 +225,20 @@ func TestLaunch_CodexRuntime(t *testing.T) {
 	agent := &config.AgentConfig{
 		Name:    "codex-agent",
 		Runtime: "codex",
-		Command: `echo "codex output"`,
-		Timeout: 10 * time.Second,
+		Prompt:  "Reply with exactly codex output",
+		Policy: config.PolicyConfig{
+			Sandbox:  "read-only",
+			Approval: "never",
+		},
+		Timeout: 30 * time.Second,
 	}
 
 	result, err := launcher.Launch(context.Background(), agent, task)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(result.Stdout, "codex output") {
-		t.Errorf("expected 'codex output' in stdout, got: %q", result.Stdout)
+	if result.LastMessage != "codex output" {
+		t.Errorf("expected last message 'codex output', got: %q", result.LastMessage)
 	}
 }
 
@@ -554,7 +558,7 @@ func TestRenderCommand_AutoEscapesIssueFields(t *testing.T) {
 			Body:   "$(evil command)",
 			Labels: []string{"label; whoami"},
 		},
-		Repo: "owner/repo",
+		Repo:    "owner/repo",
 		Session: SessionContext{ID: "s1"},
 	}
 

--- a/internal/launcher/process.go
+++ b/internal/launcher/process.go
@@ -11,106 +11,154 @@ import (
 	"time"
 
 	"github.com/Lincyaw/workbuddy/internal/config"
+	launcherevents "github.com/Lincyaw/workbuddy/internal/launcher/events"
 )
 
-// sessionFinder locates session/log artifacts for a given runtime after execution.
 type sessionFinder func(repoPath string) string
 
-// launchProcess is the shared execution logic for all runtimes.
-// It renders the command template, builds the subprocess, runs it, and
-// returns a Result. The runtimeName is used in error messages, and
-// findSession locates runtime-specific session artifacts.
-func launchProcess(
-	ctx context.Context,
-	runtimeName string,
-	agent *config.AgentConfig,
-	task *TaskContext,
-	findSession sessionFinder,
-) (*Result, error) {
-	rendered, err := renderCommand(agent.Command, task)
-	if err != nil {
-		return nil, err
-	}
+type processSession struct {
+	runtimeName string
+	agent       *config.AgentConfig
+	task        *TaskContext
+	findSession sessionFinder
+}
 
-	timeout := agent.Timeout
+func newProcessSession(runtimeName string, agent *config.AgentConfig, task *TaskContext, findSession sessionFinder) Session {
+	return &processSession{runtimeName: runtimeName, agent: agent, task: task, findSession: findSession}
+}
+
+func (s *processSession) Run(ctx context.Context, events chan<- launcherevents.Event) (*Result, error) {
+	timeout := s.agent.Timeout
 	if timeout == 0 {
 		timeout = 30 * time.Minute
 	}
-
 	execCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	// If the command is "claude -p '...'" or similar, extract the prompt and
-	// pass it via stdin to avoid shell quoting issues with issue bodies.
-	// Preserve any extra flags (e.g., --print) from the original command.
-	// Use a raw (unescaped) render for the stdin prompt — shell escaping would
-	// corrupt the content when it's not going through sh -c.
-	var cmd *exec.Cmd
-	if _, args, ok := extractPrompt(rendered); ok {
-		// Re-render without shell escaping to get the raw prompt for stdin.
-		rawRendered, rawErr := renderCommandRaw(agent.Command, task)
-		if rawErr != nil {
-			return nil, rawErr
-		}
-		rawPrompt, _, _ := extractPrompt(rawRendered)
-		cmdArgs := append(args, "-p")
-		cmd = exec.CommandContext(execCtx, "claude", cmdArgs...)
-		cmd.Stdin = strings.NewReader(rawPrompt)
-	} else {
-		cmd = exec.CommandContext(execCtx, "sh", "-c", rendered)
+	cmd, err := s.buildCommand(execCtx)
+	if err != nil {
+		return nil, err
 	}
-	if task.WorkDir != "" {
-		cmd.Dir = task.WorkDir
+	if s.task.WorkDir != "" {
+		cmd.Dir = s.task.WorkDir
 	}
-	cmd.Env = append(os.Environ(), buildEnvVars(task)...)
+	cmd.Env = append(os.Environ(), buildEnvVars(s.task)...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	cmd.Cancel = func() error {
-		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-	}
+	cmd.Cancel = func() error { return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL) }
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
 	start := time.Now()
+	var seq uint64
+	emitEvent(events, &seq, s.task.Session.ID, s.task.Session.ID, launcherevents.KindTurnStarted, launcherevents.TurnStartedPayload{TurnID: s.task.Session.ID}, nil)
 	runErr := cmd.Run()
 	duration := time.Since(start)
-
 	exitCode := 0
+	status := "ok"
 	if runErr != nil {
+		status = "error"
 		if execCtx.Err() == context.DeadlineExceeded {
-			return &Result{
-				ExitCode: -1,
-				Stdout:   stdout.String(),
-				Stderr:   stderr.String(),
-				Duration: duration,
-			}, fmt.Errorf("launcher: %s: timeout after %s: %w", runtimeName, timeout, execCtx.Err())
-		} else if ctx.Err() != nil {
-			return &Result{
-				ExitCode: -1,
-				Stdout:   stdout.String(),
-				Stderr:   stderr.String(),
-				Duration: duration,
-			}, fmt.Errorf("launcher: %s: cancelled: %w", runtimeName, ctx.Err())
-		} else if exitErr, ok := runErr.(*exec.ExitError); ok {
+			result := &Result{ExitCode: -1, Stdout: stdout.String(), Stderr: stderr.String(), Duration: duration, Meta: map[string]string{"timeout": "true"}}
+			emitEvent(events, &seq, s.task.Session.ID, s.task.Session.ID, launcherevents.KindError, launcherevents.ErrorPayload{Code: "timeout", Message: execCtx.Err().Error(), Recoverable: false}, nil)
+			emitEvent(events, &seq, s.task.Session.ID, s.task.Session.ID, launcherevents.KindTurnCompleted, launcherevents.TurnCompletedPayload{TurnID: s.task.Session.ID, Status: "error"}, nil)
+			return result, fmt.Errorf("launcher: %s: timeout after %s: %w", s.runtimeName, timeout, execCtx.Err())
+		}
+		if ctx.Err() != nil {
+			result := &Result{ExitCode: -1, Stdout: stdout.String(), Stderr: stderr.String(), Duration: duration}
+			emitEvent(events, &seq, s.task.Session.ID, s.task.Session.ID, launcherevents.KindError, launcherevents.ErrorPayload{Code: "cancelled", Message: ctx.Err().Error(), Recoverable: false}, nil)
+			emitEvent(events, &seq, s.task.Session.ID, s.task.Session.ID, launcherevents.KindTurnCompleted, launcherevents.TurnCompletedPayload{TurnID: s.task.Session.ID, Status: "interrupted"}, nil)
+			return result, fmt.Errorf("launcher: %s: cancelled: %w", s.runtimeName, ctx.Err())
+		}
+		if exitErr, ok := runErr.(*exec.ExitError); ok {
 			exitCode = exitErr.ExitCode()
 		} else {
-			return nil, fmt.Errorf("launcher: %s: exec: %w", runtimeName, runErr)
+			emitEvent(events, &seq, s.task.Session.ID, s.task.Session.ID, launcherevents.KindError, launcherevents.ErrorPayload{Code: "exec", Message: runErr.Error(), Recoverable: false}, nil)
+			emitEvent(events, &seq, s.task.Session.ID, s.task.Session.ID, launcherevents.KindTurnCompleted, launcherevents.TurnCompletedPayload{TurnID: s.task.Session.ID, Status: "error"}, nil)
+			return nil, fmt.Errorf("launcher: %s: exec: %w", s.runtimeName, runErr)
 		}
 	}
 
 	meta := parseMeta(stdout.String())
 	var sessionPath string
-	if findSession != nil {
-		sessionPath = findSession(task.Repo)
+	if s.findSession != nil {
+		sessionPath = s.findSession(s.sessionLookupPath())
+	}
+	if stderr.Len() > 0 {
+		emitEvent(events, &seq, s.task.Session.ID, s.task.Session.ID, launcherevents.KindLog, launcherevents.LogPayload{Stream: "stderr", Line: strings.TrimRight(stderr.String(), "\n")}, nil)
+	}
+	emitEvent(events, &seq, s.task.Session.ID, s.task.Session.ID, launcherevents.KindTurnCompleted, launcherevents.TurnCompletedPayload{TurnID: s.task.Session.ID, Status: status}, nil)
+
+	return &Result{ExitCode: exitCode, Stdout: stdout.String(), Stderr: stderr.String(), Duration: duration, Meta: meta, SessionPath: sessionPath}, nil
+}
+
+func (s *processSession) buildCommand(execCtx context.Context) (*exec.Cmd, error) {
+	if isClaudeRuntime(s.runtimeName) && strings.TrimSpace(s.agent.Prompt) != "" {
+		prompt, err := renderCommandRaw(s.agent.Prompt, s.task)
+		if err != nil {
+			return nil, err
+		}
+		return newClaudePromptCommand(execCtx, prompt, nil, s.agent.Policy), nil
 	}
 
-	return &Result{
-		ExitCode:    exitCode,
-		Stdout:      stdout.String(),
-		Stderr:      stderr.String(),
-		Duration:    duration,
-		Meta:        meta,
-		SessionPath: sessionPath,
-	}, nil
+	rendered, err := renderCommand(s.agent.Command, s.task)
+	if err != nil {
+		return nil, err
+	}
+	if isClaudeRuntime(s.runtimeName) {
+		if _, args, ok := extractPrompt(rendered); ok {
+			rawRendered, rawErr := renderCommandRaw(s.agent.Command, s.task)
+			if rawErr != nil {
+				return nil, rawErr
+			}
+			rawPrompt, _, _ := extractPrompt(rawRendered)
+			return newClaudePromptCommand(execCtx, rawPrompt, args, s.agent.Policy), nil
+		}
+	}
+	return exec.CommandContext(execCtx, "sh", "-c", rendered), nil
+}
+
+func newClaudePromptCommand(execCtx context.Context, prompt string, extraArgs []string, policy config.PolicyConfig) *exec.Cmd {
+	args := append([]string{}, extraArgs...)
+	args = append(args, claudePolicyArgs(policy)...)
+	args = append(args, "--print")
+	cmd := exec.CommandContext(execCtx, "claude", args...)
+	cmd.Stdin = strings.NewReader(prompt)
+	return cmd
+}
+
+func claudePolicyArgs(policy config.PolicyConfig) []string {
+	args := []string{"--dangerously-skip-permissions"}
+	if policy.Model != "" {
+		args = append(args, "--model", policy.Model)
+	}
+	return args
+}
+
+func isClaudeRuntime(runtimeName string) bool {
+	return runtimeName == config.RuntimeClaudeCode || runtimeName == config.RuntimeClaudeShot
+}
+
+func (s *processSession) sessionLookupPath() string {
+	if s.task.WorkDir != "" {
+		return s.task.WorkDir
+	}
+	return s.task.Repo
+}
+
+func (s *processSession) SetApprover(Approver) error { return ErrNotSupported }
+
+func (s *processSession) Close() error { return nil }
+
+func emitEvent(ch chan<- launcherevents.Event, seq *uint64, sessionID, turnID string, kind launcherevents.EventKind, payload any, raw []byte) {
+	if ch == nil {
+		return
+	}
+	*seq = *seq + 1
+	var rawMsg []byte
+	if len(raw) > 0 {
+		rawMsg = append(rawMsg, raw...)
+	}
+	ch <- launcherevents.Event{Kind: kind, Timestamp: time.Now().UTC(), SessionID: sessionID, TurnID: turnID, Seq: *seq, Payload: launcherevents.MustPayload(payload), Raw: rawMsg}
 }

--- a/internal/launcher/process_test.go
+++ b/internal/launcher/process_test.go
@@ -1,0 +1,57 @@
+package launcher
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/Lincyaw/workbuddy/internal/config"
+)
+
+func TestProcessSessionBuildCommand_UsesPromptForClaude(t *testing.T) {
+	task := newTestTask(t)
+	sess := &processSession{
+		runtimeName: config.RuntimeClaudeCode,
+		agent: &config.AgentConfig{
+			Runtime: config.RuntimeClaudeCode,
+			Prompt:  "review issue {{.Issue.Number}}",
+			Policy: config.PolicyConfig{
+				Sandbox:  "danger-full-access",
+				Approval: "never",
+				Model:    "sonnet",
+			},
+		},
+		task: task,
+	}
+
+	cmd, err := sess.buildCommand(context.Background())
+	if err != nil {
+		t.Fatalf("buildCommand: %v", err)
+	}
+	if got := cmd.Args[0]; got != "claude" && !strings.HasSuffix(got, "/claude") {
+		t.Fatalf("command path = %q", got)
+	}
+	joined := strings.Join(cmd.Args[1:], " ")
+	for _, want := range []string{"--dangerously-skip-permissions", "--model sonnet", "--print"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("args %q missing %q", joined, want)
+		}
+	}
+	data, err := io.ReadAll(cmd.Stdin)
+	if err != nil {
+		t.Fatalf("read stdin: %v", err)
+	}
+	if got := string(data); got != "review issue 42" {
+		t.Fatalf("stdin = %q", got)
+	}
+}
+
+func TestProcessSessionSessionLookupPathPrefersWorkDir(t *testing.T) {
+	task := newTestTask(t)
+	task.Repo = "owner/repo"
+	sess := &processSession{task: task}
+	if got := sess.sessionLookupPath(); got != task.WorkDir {
+		t.Fatalf("lookup path = %q, want %q", got, task.WorkDir)
+	}
+}

--- a/internal/launcher/types.go
+++ b/internal/launcher/types.go
@@ -2,17 +2,66 @@ package launcher
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"time"
 
 	"github.com/Lincyaw/workbuddy/internal/config"
+	launcherevents "github.com/Lincyaw/workbuddy/internal/launcher/events"
 )
 
-// Runtime is the interface for agent execution backends.
+var ErrNotSupported = errors.New("launcher: not supported")
+
 type Runtime interface {
-	// Name returns the runtime identifier (e.g., "claude-code", "codex").
 	Name() string
-	// Launch executes an agent and returns the result.
+	Start(ctx context.Context, agent *config.AgentConfig, task *TaskContext) (Session, error)
 	Launch(ctx context.Context, agent *config.AgentConfig, task *TaskContext) (*Result, error)
+}
+
+type Session interface {
+	Run(ctx context.Context, events chan<- launcherevents.Event) (*Result, error)
+	SetApprover(Approver) error
+	Close() error
+}
+
+type Approver interface {
+	Approve(ctx context.Context, req ApprovalRequest) ApprovalDecision
+}
+
+type ApprovalRequest struct {
+	Kind   ApprovalKind    `json:"kind"`
+	Detail json.RawMessage `json:"detail,omitempty"`
+	Source SessionRef      `json:"source"`
+}
+
+type ApprovalKind string
+
+const (
+	ApprovalExec        ApprovalKind = "exec"
+	ApprovalPatch       ApprovalKind = "patch"
+	ApprovalPermissions ApprovalKind = "permissions"
+	ApprovalToolInput   ApprovalKind = "tool_input"
+	ApprovalMCPElicit   ApprovalKind = "mcp_elicit"
+)
+
+type ApprovalDecision struct {
+	Allow  bool          `json:"allow"`
+	Scope  ApprovalScope `json:"scope"`
+	Reason string        `json:"reason,omitempty"`
+}
+
+type ApprovalScope string
+
+const (
+	ScopeOnce    ApprovalScope = "once"
+	ScopeSession ApprovalScope = "session"
+	ScopeForever ApprovalScope = "forever"
+)
+
+type AlwaysAllow struct{}
+
+func (AlwaysAllow) Approve(context.Context, ApprovalRequest) ApprovalDecision {
+	return ApprovalDecision{Allow: true, Scope: ScopeSession, Reason: "always allow"}
 }
 
 // TaskContext provides the context for template rendering and agent execution.
@@ -20,11 +69,10 @@ type TaskContext struct {
 	Issue   IssueContext
 	PR      PRContext
 	Repo    string
-	WorkDir string // filesystem path for agent execution; empty = inherit CWD
+	WorkDir string
 	Session SessionContext
 }
 
-// IssueContext holds GitHub issue information.
 type IssueContext struct {
 	Number int
 	Title  string
@@ -32,23 +80,28 @@ type IssueContext struct {
 	Labels []string
 }
 
-// PRContext holds GitHub PR information.
 type PRContext struct {
 	URL    string
 	Branch string
 }
 
-// SessionContext holds session metadata.
 type SessionContext struct {
 	ID string
 }
 
-// Result holds the outcome of an agent execution.
+type SessionRef struct {
+	ID   string `json:"id,omitempty"`
+	Kind string `json:"kind,omitempty"`
+}
+
 type Result struct {
 	ExitCode    int
 	Stdout      string
 	Stderr      string
 	Duration    time.Duration
-	Meta        map[string]string // parsed from WORKBUDDY_META block
-	SessionPath string            // path to session artifacts
+	Meta        map[string]string
+	SessionPath string
+	LastMessage string
+	TokenUsage  *launcherevents.TokenUsagePayload
+	SessionRef  SessionRef
 }

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -85,7 +85,10 @@ func (r *Reporter) Report(repo string, issueNum int, agentName string, result *l
 		prLink = result.Meta["pr_url"]
 	}
 
-	output := result.Stdout
+	output := result.LastMessage
+	if output == "" {
+		output = result.Stdout
+	}
 	if output == "" && result.Stderr != "" {
 		output = result.Stderr
 	}

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -96,33 +96,37 @@ documentation:
 
     - path: docs/planned/runtime-session-architecture.md
       bucket: planned
-      status: proposed
+      status: implemented
       related_code:
         - internal/launcher/types.go
         - internal/launcher/launcher.go
+        - internal/launcher/events/
+        - internal/launcher/codex.go
         - internal/audit/audit.go
         - internal/reporter/reporter.go
         - internal/webui/handler.go
-      notes: Target Runtime -> Session architecture and result/approver evolution.
+      notes: Runtime/Session abstraction, one-shot codex-exec session execution, and Result evolution are now implemented; long-lived runtime pooling remains planned.
 
     - path: docs/planned/agent-schema-vnext.md
       bucket: planned
-      status: proposed
+      status: implemented
       related_code:
         - internal/config/types.go
         - internal/config/loader.go
         - .github/workbuddy/agents/dev-agent.md
         - .github/workbuddy/agents/codex-dev-agent.md
-      notes: Planned agent schema evolution with policy, prompt, and output contract.
+      notes: policy/prompt minimal set is implemented; output_contract and longer-term deprecation steps remain planned.
 
     - path: docs/planned/event-schema-v1.md
       bucket: planned
-      status: proposed
+      status: tested
       related_code:
         - internal/launcher/types.go
+        - internal/launcher/events/
+        - internal/launcher/codex.go
         - internal/audit/audit.go
         - internal/webui/handler.go
-      notes: Planned normalized runtime event schema.
+      notes: Event Schema v1 core types, codex mapping, serialization tests, and session artifact persistence are implemented and locally exercised.
 
     - path: docs/planned/distributed-topology-and-cli.md
       bucket: planned
@@ -194,14 +198,14 @@ documentation:
 
     - path: docs/mismatch/codex-runtime-drift.md
       bucket: mismatch
-      status: maintained
+      status: archived
       related_code:
         - .github/workbuddy/agents/codex-dev-agent.md
         - internal/launcher/codex.go
         - internal/launcher/process.go
         - internal/reporter/reporter.go
         - internal/audit/audit.go
-      notes: Codex agent documentation currently overstates structured runtime integration.
+      notes: Historical drift resolved by the Runtime/Session and Event Schema v1 codex-exec implementation; keep only as archive context.
 
     - path: docs/mismatch/roadmap-structure-drift.md
       bucket: mismatch


### PR DESCRIPTION
## Summary
- implement the unified Runtime/Session launcher flow and add Event Schema v1 with codex JSONL mapping
- add `workbuddy run`, codex-exec runtime tests, and align config/runtime validation with actual supported policies
- wire Codex dev/test/review agents into the default workflows and update audit/reporter/docs metadata

## Testing
- go test ./...
- go vet ./...
- go build ./...

Closes #8