### PR TITLE
Agent multi-PR awareness + richer TaskContext

### DIFF
--- a/.codex/skills/dev-loop/SKILL.md
+++ b/.codex/skills/dev-loop/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: dev-loop
+description: Use when implementing a feature, fix, refactor, or content change that should go through a complete delivery loop: implement, test, vibe-check, AI review, and measurement before keeping or discarding the change. Trigger when the user asks to build something, fix a bug, write or revise content, improve quality, or when you need to decide whether a change is actually ready to ship. 中文触发：开发、实现、修复、写代码、改一下、做这个功能、加个功能、修个 bug、帮我写、帮我改、重构。
+---
+
+# Dev Loop
+
+Run a complete development loop instead of stopping at "tests pass". The loop is:
+
+`implement -> test -> vibe-check -> AI review -> measure -> keep or discard`
+
+Use it for code, docs, papers, content, and other artifacts where correctness alone is not enough. The goal is to catch regressions early, verify real-world quality, and make keep/discard decisions using explicit observations rather than gut feel alone.
+
+## Modes
+
+Choose the mode that matches the task:
+
+- **Metric-driven mode**: use when the project already has measurable targets or observable indicators. The agent can iterate semi-autonomously and keep/discard changes based on measurements.
+- **Human-in-the-loop mode**: use when subjective quality is important, such as UX, writing, or API ergonomics. The user vibe-checks each meaningful iteration before you proceed.
+
+Both modes use the same stages. The difference is who gates progression.
+
+## The stages
+
+### 1. Implement
+
+- Make the change following local conventions.
+- Before making a risky change, create a clean rollback point with git.
+- Keep the project's goals or north-star targets in mind while designing the change.
+
+### 2. Test
+
+- Run the relevant automated checks.
+- If the change is not covered, add or update tests.
+- Do not move on with broken tests.
+
+Tests answer: "Does it do what I intended?"
+
+### 3. Vibe-check
+
+Experience the change like a user or consumer would. This catches unspecified but obvious problems.
+
+Examples:
+
+- Frontend: open the flow, click through, resize, try keyboard navigation.
+- Backend/API: hit real endpoints, inspect response shapes, try malformed input.
+- CLI: run real commands with both valid and invalid inputs.
+- Library: write a small consumer example and judge ergonomics.
+- Docs/paper: read it cold and check flow and clarity.
+- Data pipeline: run sample data and inspect outputs.
+
+Guidance:
+
+- In metric-driven mode, self-verify where possible and ask for human spot checks periodically.
+- In human-in-the-loop mode, explicitly tell the user what to check once tests pass.
+
+### 4. AI review
+
+Do an objective alignment pass, not just a style review.
+
+Check:
+
+- **Consistency**: naming, patterns, structure, style
+- **Scope**: minimal change, no speculative abstractions
+- **Trade-offs**: does the change improve or preserve the project's key goals?
+- **Simplicity**: all else equal, prefer the simpler implementation
+
+### 5. Measure
+
+Run the project's observations and compare against a baseline or the previous successful iteration.
+
+Typical observation types:
+
+- **Script observations**: run every iteration when cheap and deterministic
+- **Agent observations**: run periodically for qualitative aspects
+- **Human observations**: use at milestones or when uncertainty remains
+
+Possible outcomes:
+
+- **Keep**: indicators improved or held steady and no stage found blocking issues
+- **Discard**: indicators regressed without a stronger compensating gain
+- **Investigate**: mixed results or the signal is too weak to call
+
+If you discard, revert to the pre-change snapshot and try a different approach instead of patching blindly.
+
+## Intensity guide
+
+Adjust how heavy the loop is based on the change:
+
+- **Trivial change**: test and measure only
+- **Bug fix**: full loop
+- **New feature**: full loop, usually human-in-the-loop
+- **Refactor**: test, AI review, and measure; lighter vibe-check unless UX changes
+- **Performance work**: full loop plus benchmark-style measurement
+- **Docs/paper section**: vibe-check, AI review, and whatever quality measurement exists
+
+## Loop-back rules
+
+- Test failure -> go back to testing after the fix
+- Cosmetic vibe issue -> fix and re-check vibe
+- Structural issue -> return to implementation and then re-test
+- AI review concern -> fix and re-review
+- Metric regression -> usually discard and rethink the approach
+- Too many iterations on the same problem -> step back and reconsider the strategy
+
+## Logging and tracking
+
+When the project uses iteration tracking, keep a simple progress log such as `progress.tsv` with:
+
+- date
+- commit or snapshot id
+- status (`baseline`, `keep`, `discard`, `investigate`)
+- key indicators
+- short description
+
+Use a human-readable location in the repo root unless the project specifies another path.
+
+If your environment includes telemetry tooling such as skill-evolve, log the keep/discard result as a best-effort step after measurement. Do not let telemetry block the actual work.
+
+## How this skill connects to others
+
+- `north-star`: defines the goals or indicators that measurement should check
+- `long-horizon`: governs how to make autonomous decisions during extended loops
+- `notify`: can report flagged decisions or iteration outcomes without blocking the work
+
+## Migration notes
+
+This Codex version keeps the procedural guidance from the Claude skill but removes Claude-specific frontmatter fields such as `category`. Any project-specific commands should live in the repo's own instructions or adjacent references, not hard-coded into this skill.

--- a/.codex/skills/dev-loop/agents/openai.yaml
+++ b/.codex/skills/dev-loop/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Dev Loop"
+  short_description: "Run a full implement-test-measure loop"
+  default_prompt: "Use $dev-loop to drive this task through implementation, testing, vibe-checking, review, and keep/discard measurement."

--- a/.codex/skills/long-horizon/SKILL.md
+++ b/.codex/skills/long-horizon/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: long-horizon
+description: Use when the agent should operate autonomously for an extended task and make reasonable decisions without interrupting the user for every choice. Trigger when the user says to just do it, work independently, run for a long time, avoid asking constant questions, or when configuring autonomous sub-workflows. 中文触发：自主执行、别问我、自己做、长时间运行、自动跑、不用问我、自己决定、后台跑。
+---
+
+# Long Horizon
+
+Framework for autonomous decision-making during extended work. The core rule is:
+
+`exhaust your own judgment before consuming the user's attention`
+
+Use this skill when progress matters more than constant confirmation and the task can tolerate well-reasoned autonomous decisions.
+
+## The escalation ladder
+
+Work through uncertainty from lowest-cost resolution to highest-cost resolution. Only escalate when the current level does not resolve the issue.
+
+1. **Convention check** -> decide silently when the codebase already answers it
+2. **Codebase research** -> decide and log
+3. **External research** -> decide and log with reasoning
+4. **North-star reasoning** -> decide, log, and flag for later review
+5. **Ask the user** -> last resort; batch questions together
+
+## Level 1: Convention check
+
+First ask: does the repository already answer this?
+
+Check:
+
+- project instruction files such as `AGENTS.md`, `CLAUDE.md`, or repo-specific docs
+- existing code in the same subsystem
+- config such as linters, formatters, CI, and generators
+- recent git history if it clarifies an established pattern
+
+If a clear convention exists, follow it without stopping to discuss it.
+
+Typical examples:
+
+- quote style
+- test framework choice
+- file placement
+- naming conventions
+
+## Level 2: Codebase research
+
+If the answer is not obvious, spend a short bounded period reading nearby files, related modules, READMEs, comments, or commit history.
+
+Use this level for questions like:
+
+- how errors are usually handled
+- how transactions or side effects are structured
+- what endpoint naming pattern is already in use
+
+At this level and above, leave a decision trail the user can review later.
+
+Example log entry:
+
+`Used repository pattern for new data access (L2: consistent with adjacent modules)`
+
+## Level 3: External research
+
+If the repository is not enough, research outside it:
+
+- official docs
+- primary library/framework docs
+- issue trackers
+- source code of dependencies
+- comparable open-source implementations
+
+Use this for technical choices where the answer is discoverable but not already encoded in the project.
+
+Example log entry:
+
+`Chose zod over joi (L3: better TypeScript inference, aligns with maintainability)`
+
+## Level 4: North-star reasoning
+
+When multiple options remain viable, use the project's objectives as the tie-breaker.
+
+For each option, evaluate how it affects the project's top goals, such as:
+
+- maintainability
+- simplicity
+- reliability
+- performance
+- clarity
+
+Then choose the best trade-off, continue the work, and flag the decision for later review rather than blocking on approval.
+
+Example:
+
+`[flagged] Kept duplication over extracting a base class (L4: simpler and easier to maintain)`
+
+## Level 5: Ask the user
+
+Only ask after exhausting Levels 1-4, and only when the user is genuinely required.
+
+Legitimate reasons include:
+
+- strategic scope or direction changes
+- missing access, secrets, or credentials
+- ambiguous requirements that research could not clarify
+- high-risk irreversible actions
+- conflicting signals that materially affect the outcome
+
+When you ask, batch all unresolved questions together and include the reasoning you already did so the user can answer quickly.
+
+## Decision logging
+
+For any Level 2+ decision, keep a lightweight decision log in a repo-visible place such as `decisions.md` unless the project already has a preferred path.
+
+Useful fields:
+
+- date
+- decision
+- level (`L2`, `L3`, `L4`)
+- short reasoning
+- whether it was flagged for later review
+
+The log helps with:
+
+- session continuity
+- user review
+- future calibration of autonomous behavior
+
+## Anti-patterns
+
+Avoid:
+
+- asking too early
+- making significant decisions with no trail
+- shallow "research" that never compared options
+- spending too long on low-level decisions
+- interrupting the user repeatedly instead of batching questions
+
+## Autonomy tuning
+
+Different tasks need different autonomy levels:
+
+- **High autonomy**: decide through L4 and only ask for credentials, irreversible actions, or major strategic changes
+- **Medium autonomy**: decide through L3, flag L4, ask for L5
+- **Low autonomy**: decide through L2, ask earlier on subjective trade-offs
+
+If the project tracks autonomy preferences, respect them. Otherwise default to medium and bias toward progress.
+
+## Integration notes
+
+- `dev-loop` uses this skill for the non-metric decisions that happen during repeated iterations
+- `notify` can surface flagged L4 decisions asynchronously instead of blocking execution
+- any optional telemetry or correction logging is best-effort and should not interrupt delivery
+
+## Migration notes
+
+This Codex version preserves the decision ladder from the Claude skill but removes Claude-specific frontmatter fields such as `category`. Logging paths and command details should be adapted to the current repository instead of assuming a Claude-specific runtime.

--- a/.codex/skills/long-horizon/agents/openai.yaml
+++ b/.codex/skills/long-horizon/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Long Horizon"
+  short_description: "Decide autonomously before asking"
+  default_prompt: "Use $long-horizon to handle this task autonomously, following a convention -> research -> reasoning -> ask escalation ladder."

--- a/.github/workbuddy/agents/codex-dev-agent.md
+++ b/.github/workbuddy/agents/codex-dev-agent.md
@@ -14,14 +14,50 @@ prompt: |
   You are a development agent for repo {{.Repo}}.
 
   ## Task
-  Read the issue below and implement the requested change.
-  Create a feature branch, write code with tests, and open a draft PR.
+  Read the full issue + PR history below and continue the development work.
+  Either open a new draft PR (if none exists) or push follow-up commits onto
+  the existing PR branch. Always include or update tests.
+
+  ## Context (read first, before touching code)
+  Agents run stateless; fetch the full history before acting.
+  1. Read every comment on this issue (prior agent reports from the coordinator are authoritative):
+     gh issue view {{.Issue.Number}} --repo {{.Repo}} --comments
+  2. Find every PR linked to this issue (open or merged):
+     gh pr list --repo {{.Repo}} --state all --search '{{.Issue.Number}} in:title,body' --json number,state,headRefName,baseRefName,url,isDraft
+  3. For any relevant PR:
+     gh pr view <N> --repo {{.Repo}} --comments
+     gh pr diff <N> --repo {{.Repo}}
+     gh pr view <N> --repo {{.Repo}} --json reviews,reviewThreads
+  4. Carefully address the latest test/review feedback. Do not redo work that was already accepted.
+
+  ## Handling existing PRs
+  Invariant: one issue should have exactly one open PR. Before writing code,
+  reconcile the PR landscape based on `Related PRs` below:
+  - If NO open PR targets this issue: create a new draft PR at the end.
+  - If exactly ONE open PR targets this issue: check out its head branch
+    (`git fetch origin <headRefName> && git checkout <headRefName>`) and push
+    follow-up commits that address outstanding review/test feedback.
+  - If MULTIPLE open PRs target this issue: you decide which one to keep.
+    Typically prefer the PR that (a) contains commits addressing the most
+    recent review feedback, (b) has larger/more complete changes, or
+    (c) was most recently updated — but use your judgment. Continue work on
+    the kept PR's branch. Close the others with
+    `gh pr close <N> --repo {{.Repo}} --comment "superseded by #<keep>, consolidating to one PR per issue"`.
+    State your pick and rationale in the final agent report.
+  - Reply to each blocking review thread so reviewers can see the response.
 
   ## Issue
   Title: {{.Issue.Title}}
   Number: #{{.Issue.Number}}
   Body:
   {{.Issue.Body}}
+
+  ## Prefetched context (injected by workbuddy)
+  Comments (oldest → newest):
+  {{.Issue.CommentsText}}
+
+  Related PRs:
+  {{.RelatedPRsText}}
 
   ## When done
   - If implementation is complete and PR is opened:

--- a/.github/workbuddy/agents/codex-review-agent.md
+++ b/.github/workbuddy/agents/codex-review-agent.md
@@ -17,10 +17,37 @@ prompt: |
   Review the PR linked to issue #{{.Issue.Number}}.
   Check for correctness, style, and alignment with project conventions.
 
+  ## Context (read first, before reviewing)
+  Agents run stateless; fetch the full history before acting.
+  1. gh issue view {{.Issue.Number}} --repo {{.Repo}} --comments
+  2. gh pr list --repo {{.Repo}} --state all --search '{{.Issue.Number}} in:title,body' --json number,state,headRefName,baseRefName,url,isDraft
+  3. gh pr view <N> --repo {{.Repo}} --comments
+     gh pr diff <N> --repo {{.Repo}}
+     gh pr view <N> --repo {{.Repo}} --json reviews,reviewThreads
+  Read prior review findings — do NOT repeat issues that were already addressed in later commits.
+  Reference exact files/lines/commits.
+
+  ## Handling multiple open PRs
+  Invariant: one issue should have exactly one open PR. If `Related PRs` shows
+  multiple open PRs targeting this issue, you decide which one to review:
+  - Compare them on completeness (which addresses the latest review feedback),
+    freshness (most recently updated), and test coverage. Pick the best one.
+  - Close the others with
+    `gh pr close <N> --repo {{.Repo}} --comment "superseded by #<keep>, consolidating to one PR per issue"`.
+  - State your pick and rationale in the final agent report, then review the kept PR.
+  If exactly one open PR exists, review that one.
+
   ## Issue
   Title: {{.Issue.Title}}
   Number: #{{.Issue.Number}}
   PR: {{.PR.URL}}
+
+  ## Prefetched context (injected by workbuddy)
+  Comments (oldest → newest):
+  {{.Issue.CommentsText}}
+
+  Related PRs:
+  {{.RelatedPRsText}}
 
   ## Steps
   1. Read the PR diff

--- a/.github/workbuddy/agents/codex-test-agent.md
+++ b/.github/workbuddy/agents/codex-test-agent.md
@@ -17,10 +17,26 @@ prompt: |
   Run the full test suite for the PR linked to issue #{{.Issue.Number}}.
   Report results as a comment on the issue.
 
+  ## Context (read first, before running tests)
+  Agents run stateless; fetch the full history before acting.
+  1. gh issue view {{.Issue.Number}} --repo {{.Repo}} --comments
+  2. gh pr list --repo {{.Repo}} --state all --search '{{.Issue.Number}} in:title,body' --json number,state,headRefName,baseRefName,url,isDraft
+  3. gh pr view <N> --repo {{.Repo}} --comments   and   gh pr diff <N> --repo {{.Repo}}
+  Use prior dev/test/review reports to understand what changed and what to retest.
+  If multiple PRs match, test the latest open one.
+  If no PR exists, comment on the issue saying the PR is missing and do NOT change labels.
+
   ## Issue
   Title: {{.Issue.Title}}
   Number: #{{.Issue.Number}}
   PR: {{.PR.URL}}
+
+  ## Prefetched context (injected by workbuddy)
+  Comments (oldest → newest):
+  {{.Issue.CommentsText}}
+
+  Related PRs:
+  {{.RelatedPRsText}}
 
   ## Steps
   1. Check out the PR branch

--- a/.github/workbuddy/agents/dev-agent.md
+++ b/.github/workbuddy/agents/dev-agent.md
@@ -32,7 +32,7 @@ command: >
   - If NO open PR targets this issue: create a new draft PR at the end.
   - If exactly ONE open PR targets this issue: check out its head branch
     (`git fetch origin <headRefName> && git checkout <headRefName>`) and push
-  follow-up commits that address outstanding review/test feedback.
+    follow-up commits that address outstanding review/test feedback.
   - If MULTIPLE open PRs target this issue: you decide which one to keep.
     Typically prefer the PR that (a) contains commits addressing the most
     recent review feedback, (b) has larger/more complete changes, or

--- a/.github/workbuddy/agents/dev-agent.md
+++ b/.github/workbuddy/agents/dev-agent.md
@@ -10,14 +10,50 @@ command: >
   claude -p "You are a development agent for repo {{.Repo}}.
 
   ## Task
-  Read the issue below and implement the requested change.
-  Create a feature branch, write code with tests, and open a draft PR.
+  Read the full issue + PR history below and continue the development work.
+  Either open a new draft PR (if none exists) or push follow-up commits onto
+  the existing PR branch. Always include or update tests.
+
+  ## Context (read first, before touching code)
+  Agents run stateless; fetch the full history before acting.
+  1. Read every comment on this issue (prior agent reports from the coordinator are authoritative):
+     gh issue view {{.Issue.Number}} --repo {{.Repo}} --comments
+  2. Find every PR linked to this issue (open or merged):
+     gh pr list --repo {{.Repo}} --state all --search '{{.Issue.Number}} in:title,body' --json number,state,headRefName,baseRefName,url,isDraft
+  3. For any relevant PR:
+     gh pr view <N> --repo {{.Repo}} --comments
+     gh pr diff <N> --repo {{.Repo}}
+     gh pr view <N> --repo {{.Repo}} --json reviews,reviewThreads
+  4. Carefully address the latest test/review feedback. Do not redo work that was already accepted.
+
+  ## Handling existing PRs
+  Invariant: one issue should have exactly one open PR. Before writing code,
+  reconcile the PR landscape based on `Related PRs` below:
+  - If NO open PR targets this issue: create a new draft PR at the end.
+  - If exactly ONE open PR targets this issue: check out its head branch
+    (`git fetch origin <headRefName> && git checkout <headRefName>`) and push
+  follow-up commits that address outstanding review/test feedback.
+  - If MULTIPLE open PRs target this issue: you decide which one to keep.
+    Typically prefer the PR that (a) contains commits addressing the most
+    recent review feedback, (b) has larger/more complete changes, or
+    (c) was most recently updated — but use your judgment. Continue work on
+    the kept PR's branch. Close the others with
+    `gh pr close <N> --repo {{.Repo}} --comment "superseded by #<keep>, consolidating to one PR per issue"`.
+    State your pick and rationale in the final agent report.
+  - Reply to each blocking review thread so reviewers can see the response.
 
   ## Issue
   Title: {{.Issue.Title}}
   Number: #{{.Issue.Number}}
   Body:
   {{.Issue.Body}}
+
+  ## Prefetched context (injected by workbuddy)
+  Comments (oldest → newest):
+  {{.Issue.CommentsText}}
+
+  Related PRs:
+  {{.RelatedPRsText}}
 
   ## When done
   - If implementation is complete and PR is opened:

--- a/.github/workbuddy/agents/review-agent.md
+++ b/.github/workbuddy/agents/review-agent.md
@@ -13,10 +13,37 @@ command: >
   Review the PR linked to issue #{{.Issue.Number}}.
   Check for correctness, style, and alignment with project conventions.
 
+  ## Context (read first, before reviewing)
+  Agents run stateless; fetch the full history before acting.
+  1. gh issue view {{.Issue.Number}} --repo {{.Repo}} --comments
+  2. gh pr list --repo {{.Repo}} --state all --search '{{.Issue.Number}} in:title,body' --json number,state,headRefName,baseRefName,url,isDraft
+  3. gh pr view <N> --repo {{.Repo}} --comments
+     gh pr diff <N> --repo {{.Repo}}
+     gh pr view <N> --repo {{.Repo}} --json reviews,reviewThreads
+  Read prior review findings — do NOT repeat issues that were already addressed in later commits.
+  Reference exact files/lines/commits.
+
+  ## Handling multiple open PRs
+  Invariant: one issue should have exactly one open PR. If `Related PRs` shows
+  multiple open PRs targeting this issue, you decide which one to review:
+  - Compare them on completeness (which addresses the latest review feedback),
+    freshness (most recently updated), and test coverage. Pick the best one.
+  - Close the others with
+    `gh pr close <N> --repo {{.Repo}} --comment "superseded by #<keep>, consolidating to one PR per issue"`.
+  - State your pick and rationale in the final agent report, then review the kept PR.
+  If exactly one open PR exists, review that one.
+
   ## Issue
   Title: {{.Issue.Title}}
   Number: #{{.Issue.Number}}
   PR: {{.PR.URL}}
+
+  ## Prefetched context (injected by workbuddy)
+  Comments (oldest → newest):
+  {{.Issue.CommentsText}}
+
+  Related PRs:
+  {{.RelatedPRsText}}
 
   ## Steps
   1. Read the PR diff

--- a/.github/workbuddy/agents/test-agent.md
+++ b/.github/workbuddy/agents/test-agent.md
@@ -13,10 +13,26 @@ command: >
   Run the full test suite for the PR linked to issue #{{.Issue.Number}}.
   Report results as a comment on the issue.
 
+  ## Context (read first, before running tests)
+  Agents run stateless; fetch the full history before acting.
+  1. gh issue view {{.Issue.Number}} --repo {{.Repo}} --comments
+  2. gh pr list --repo {{.Repo}} --state all --search '{{.Issue.Number}} in:title,body' --json number,state,headRefName,baseRefName,url,isDraft
+  3. gh pr view <N> --repo {{.Repo}} --comments   and   gh pr diff <N> --repo {{.Repo}}
+  Use prior dev/test/review reports to understand what changed and what to retest.
+  If multiple PRs match, test the latest open one.
+  If no PR exists, comment on the issue saying the PR is missing and do NOT change labels.
+
   ## Issue
   Title: {{.Issue.Title}}
   Number: #{{.Issue.Number}}
   PR: {{.PR.URL}}
+
+  ## Prefetched context (injected by workbuddy)
+  Comments (oldest → newest):
+  {{.Issue.CommentsText}}
+
+  Related PRs:
+  {{.RelatedPRsText}}
 
   ## Steps
   1. Check out the PR branch

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -278,7 +278,8 @@ func runServeWithOpts(opts *serveOpts, ghReader poller.GHReader, launcherOverrid
 	// 4. Init components
 	evlog := eventlog.NewEventLogger(st)
 	reg := registry.NewRegistry(st, cfg.Global.PollInterval)
-	auditor := audit.NewAuditor(st, ".workbuddy/sessions")
+	sessionsDir := ".workbuddy/sessions"
+	auditor := audit.NewAuditor(st, sessionsDir)
 
 	// Register embedded worker
 	workerID, err := reg.RegisterEmbedded(cfg.Global.Repo, opts.roles)
@@ -345,6 +346,7 @@ func runServeWithOpts(opts *serveOpts, ghReader poller.GHReader, launcherOverrid
 
 	// Session viewer web UI
 	sessionUI := webui.NewHandler(st)
+	sessionUI.SetSessionsDir(sessionsDir)
 	sessionUI.Register(mux)
 	srv := &http.Server{
 		Addr:    fmt.Sprintf(":%d", cfg.Global.Port),
@@ -424,6 +426,7 @@ func runServeWithOpts(opts *serveOpts, ghReader poller.GHReader, launcherOverrid
 		cfg:          cfg,
 		wsMgr:        wsMgr,
 		runningTasks: runningTasks,
+		sessionsDir:  sessionsDir,
 	}
 	workerDone := make(chan struct{})
 	wg.Add(1)
@@ -489,6 +492,7 @@ type workerDeps struct {
 	cfg          *config.FullConfig
 	wsMgr        *workspace.Manager
 	runningTasks *RunningTasks
+	sessionsDir  string
 }
 
 // runEmbeddedWorker runs the embedded worker loop.
@@ -550,7 +554,7 @@ func executeTask(ctx context.Context, task router.WorkerTask, deps *workerDeps) 
 	defer func() { _ = session.Close() }()
 
 	eventsCh := make(chan launcherevents.Event, 64)
-	eventsPath, waitEvents := streamSessionEvents(task.Context, eventsCh)
+	eventsPath, waitEvents := streamSessionEvents(deps.sessionsDir, task.Context, eventsCh)
 	result, err := session.Run(taskCtx, eventsCh)
 	close(eventsCh)
 	waitErr := waitEvents()
@@ -623,17 +627,11 @@ func executeTask(ctx context.Context, task router.WorkerTask, deps *workerDeps) 
 	deps.sm.MarkAgentCompleted(task.Repo, task.IssueNum, fetchCachedLabels(deps.store, task.Repo, task.IssueNum))
 }
 
-func streamSessionEvents(taskCtx *launcher.TaskContext, eventsCh <-chan launcherevents.Event) (string, func() error) {
-	baseDir := taskCtx.WorkDir
-	if baseDir == "" {
-		cwd, err := os.Getwd()
-		if err != nil {
-			baseDir = "."
-		} else {
-			baseDir = cwd
-		}
+func streamSessionEvents(sessionsDir string, taskCtx *launcher.TaskContext, eventsCh <-chan launcherevents.Event) (string, func() error) {
+	if sessionsDir == "" {
+		sessionsDir = ".workbuddy/sessions"
 	}
-	path := filepath.Join(baseDir, ".workbuddy", "sessions", taskCtx.Session.ID, "events-v1.jsonl")
+	path := filepath.Join(sessionsDir, taskCtx.Session.ID, "events-v1.jsonl")
 	errCh := make(chan error, 1)
 	go func() {
 		// Always drain eventsCh to completion so the runtime is never blocked

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -278,7 +278,14 @@ func runServeWithOpts(opts *serveOpts, ghReader poller.GHReader, launcherOverrid
 	// 4. Init components
 	evlog := eventlog.NewEventLogger(st)
 	reg := registry.NewRegistry(st, cfg.Global.PollInterval)
-	sessionsDir := ".workbuddy/sessions"
+	// Resolve sessionsDir to an absolute path up front so auditor, event writer,
+	// and web UI all read/write the same location even if something later
+	// changes the process working directory.
+	repoDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("serve: get working directory: %w", err)
+	}
+	sessionsDir := filepath.Join(repoDir, ".workbuddy", "sessions")
 	auditor := audit.NewAuditor(st, sessionsDir)
 
 	// Register embedded worker
@@ -295,7 +302,6 @@ func runServeWithOpts(opts *serveOpts, ghReader poller.GHReader, launcherOverrid
 	sm := statemachine.NewStateMachine(cfg.Workflows, st, dispatchCh, evlog)
 
 	// Workspace isolation via git worktrees
-	repoDir, _ := os.Getwd()
 	wsMgr := workspace.NewManager(repoDir)
 	wsMgr.Prune() // clean up orphaned worktrees from prior crashes
 

--- a/docs/planned/artifact-layout.md
+++ b/docs/planned/artifact-layout.md
@@ -1,0 +1,120 @@
+# Artifact Layout（计划中）
+
+状态：planned
+
+## 背景
+
+当前 session artifact（`codex-events.jsonl`、`events-v1.jsonl`、`codex-last-message.txt`）
+由 `internal/launcher/codex.go` 和 `cmd/serve.go:streamSessionEvents` 以 `task.WorkDir`
+为 baseDir 写入，因此最终落在 **每个任务的 git worktree 内部**：
+
+```
+.workbuddy/worktrees/issue-8-<taskShort>/.workbuddy/sessions/session-<sid>/
+├── codex-events.jsonl
+├── events-v1.jsonl
+└── codex-last-message.txt
+```
+
+问题：
+
+1. worktree 是 per-task 临时目录，任务结束后 `wsMgr.Remove(...)` 会被 defer 清理，原始事件流随之消失。
+2. 在 `cmd/serve.go:executeTask` 的 runtime 错误返回路径上，worker 在 `audit.Capture()`
+   被调用之前就 return，而 worktree 清理 defer 已注册 → 失败路径的 artifact 永远进不了 auditor。
+3. auditor 自己另写一份到仓库根 `.workbuddy/sessions/session-<sid>/`，和 launcher 侧的
+   artifact 目录名相同但物理路径不同，排障时极易混淆。
+
+## 目标
+
+给 workbuddy 的存储分三层，路径各司其职，互不踩踏：
+
+| 层级 | 路径 | 内容 | 生命周期 |
+| --- | --- | --- | --- |
+| 工作区 | `<repoRoot>/.workbuddy/worktrees/<issue>-<taskShort>/` | git worktree、agent 的临时分支 | task 结束即清理 |
+| Session artifact | `<repoRoot>/.workbuddy/sessions/session-<sid>/` | 事件流、last-message、auditor summary | 跟随仓库；`.gitignore` 内 |
+| Coordinator 运行时 | `~/.workbuddy/`（v0.2+） | 全局 DB、log、registry、credentials | 跨仓库长期保留 |
+
+本文档只规划前两层的收敛；第三层作为 v0.2.x 分布式拓扑的一部分，见
+`docs/planned/distributed-topology-and-cli.md`。
+
+## 设计
+
+### 1. Session artifact 统一写到仓库根
+
+原则：**launcher 写的 artifact 路径不依赖 `task.WorkDir`**。
+worktree 只装 agent 改的代码，不再装事件流。
+
+落地步骤：
+
+1. `internal/launcher/types.go`：`TaskContext` 增加 `RepoRoot string` 字段，语义为
+   "main worktree / coordinator 启动时的仓库根"。
+2. `cmd/serve.go`：在构造 `WorkerTask` 时填入 `RepoRoot = repoDir`（即当前
+   `workspace.NewManager(repoDir)` 的 `repoDir`）。
+3. `internal/launcher/codex.go:newCodexSession`：把 `baseDir` 从 `task.WorkDir` 改成
+   `task.RepoRoot`，artifact 目录变成 `<RepoRoot>/.workbuddy/sessions/session-<sid>/`。
+4. `cmd/serve.go:streamSessionEvents`：同样把 baseDir 改成 `task.RepoRoot`。
+5. auditor 已经用 `.workbuddy/sessions`，目录命名一致后可以直接复用（不再复制一份）。
+
+### 2. 错误路径下 artifact 不丢
+
+由于 artifact 已经不在 worktree 里，worktree 清理不会再把它删掉。
+在此基础上，`cmd/serve.go:executeTask` 进一步：
+
+- 无论 runtime 是否返错，只要 `session.Run(...)` 返回了非 nil `Result`（含
+  `SessionPath`、`LastMessage`、`TokenUsage`），都在 return 前先调 `audit.Capture(...)`。
+- audit 的 summary 写在同一个 session-id 目录下，不再另开新目录。
+
+### 3. 目录布局约定
+
+```
+<repoRoot>/
+├── .workbuddy/
+│   ├── workbuddy.db              # SQLite
+│   ├── logs/                     # coordinator 日志
+│   ├── sessions/
+│   │   └── session-<sid>/
+│   │       ├── events-v1.jsonl   # workbuddy 统一 Event Schema v1
+│   │       ├── codex-events.jsonl  # runtime 原始 JSONL（仅 codex-exec）
+│   │       ├── codex-last-message.txt
+│   │       └── audit-summary.md  # auditor 归档
+│   └── worktrees/
+│       └── issue-<N>-<taskShort>/  # 仅代码和临时分支
+└── .gitignore  # 追加 .workbuddy/
+```
+
+### 4. 兼容性
+
+- `TaskContext.RepoRoot` 为空时回退到 `WorkDir`（本地单元测试场景），保持现有
+  测试可跑。
+- artifact 迁移不涉及磁盘 schema 变更，旧 session 目录可以直接保留，不需要迁移脚本。
+- 不影响 `runtime: codex` → `codex-exec` 的既有 normalize 逻辑。
+
+## 与当前代码的距离
+
+| 项 | 现状 | 目标 |
+| --- | --- | --- |
+| codex session artifact baseDir | `task.WorkDir`（worktree 内）| `task.RepoRoot`（仓库根）|
+| stream events baseDir | `task.WorkDir` 或 CWD | `task.RepoRoot` |
+| auditor vs launcher 路径 | 命名一致但物理路径两份 | 物理路径归并到同一 `sessions/session-<sid>/` |
+| 失败路径 artifact | worktree 随 defer 清理丢失 | 保留在仓库根 sessions 下 |
+| TaskContext 字段 | 仅 `WorkDir` | `WorkDir` + `RepoRoot` |
+
+## 验收标准
+
+- Codex/Claude 两种 runtime 的 session artifact 均写在 `<repoRoot>/.workbuddy/sessions/session-<sid>/`，
+  worktree 内不再出现 `.workbuddy/sessions/`。
+- worker 无论 runtime success/timeout/cancel，只要有 `Result`，`audit.Capture(...)` 都会被调用。
+- 单元测试：给 `TaskContext.RepoRoot` 传任意临时目录，artifact 路径符合上表。
+- 集成验证：跑完一次 dev→test→review 闭环，review/test/dev 三个 session 的 jsonl
+  都在同一仓库根 `sessions/` 下，worktree 已清空但 artifact 仍在。
+
+## 不做（留给后续 issue）
+
+- 迁移到 `~/.workbuddy/` 的全局 coordinator 存储（由 v0.2.x 分布式拓扑覆盖）。
+- Session artifact 的异地归档 / 对象存储上传。
+- auditor 的 schema 升级（本文只改路径，不改产出格式）。
+
+## 依赖关系
+
+- 前置：Runtime / Session 抽象、Event Schema v1（都已 implemented）。
+- 阻挡：无；可独立落地。
+- 相关：`docs/planned/distributed-topology-and-cli.md`（全局 `~/.workbuddy/` 在那里讨论）。

--- a/docs/planned/index.md
+++ b/docs/planned/index.md
@@ -12,6 +12,7 @@
 | Agent catalog | 登记规划中的 agent 类型，作为批量开 issue 的索引 | `.github/workbuddy/agents/` | Agent schema vNext |
 | 迁移路径 | 控制 v0.1.x 到 v0.2.x 的重构顺序 | `internal/launcher/`, `internal/config/`, `internal/audit/` | 上述全部 |
 | 分布式拓扑与 CLI | 从单进程 `serve` 演进到 coordinator/worker 分离 | `cmd/`, `internal/router/`, `internal/registry/` | 独立，不依赖上述 |
+| Artifact 布局收敛 | Session artifact 从 worktree 内迁到仓库根 `.workbuddy/sessions/` | `internal/launcher/`, `cmd/serve.go`, `internal/audit/` | Runtime / Session 抽象、Event Schema v1 |
 
 ## 文档列表
 
@@ -21,6 +22,7 @@
 - `docs/planned/agent-catalog.md`
 - `docs/planned/distributed-topology-and-cli.md`
 - `docs/planned/runtime-migration-plan.md`
+- `docs/planned/artifact-layout.md`
 
 ## 维护规则
 

--- a/internal/launcher/template.go
+++ b/internal/launcher/template.go
@@ -21,14 +21,16 @@ func shellEscape(s string) string {
 func safeTaskContext(task *TaskContext) *TaskContext {
 	escaped := *task
 	escaped.Issue = IssueContext{
-		Number: task.Issue.Number,
-		Title:  shellEscape(task.Issue.Title),
-		Body:   shellEscape(task.Issue.Body),
-		Labels: make([]string, len(task.Issue.Labels)),
+		Number:       task.Issue.Number,
+		Title:        shellEscape(task.Issue.Title),
+		Body:         shellEscape(task.Issue.Body),
+		Labels:       make([]string, len(task.Issue.Labels)),
+		CommentsText: shellEscape(task.Issue.CommentsText),
 	}
 	for i, l := range task.Issue.Labels {
 		escaped.Issue.Labels[i] = shellEscape(l)
 	}
+	escaped.RelatedPRsText = shellEscape(task.RelatedPRsText)
 	return &escaped
 }
 

--- a/internal/launcher/types.go
+++ b/internal/launcher/types.go
@@ -66,18 +66,38 @@ func (AlwaysAllow) Approve(context.Context, ApprovalRequest) ApprovalDecision {
 
 // TaskContext provides the context for template rendering and agent execution.
 type TaskContext struct {
-	Issue   IssueContext
-	PR      PRContext
-	Repo    string
-	WorkDir string
-	Session SessionContext
+	Issue          IssueContext
+	PR             PRContext
+	Repo           string
+	WorkDir        string
+	Session        SessionContext
+	RelatedPRs     []PRSummary
+	RelatedPRsText string
 }
 
 type IssueContext struct {
-	Number int
-	Title  string
-	Body   string
-	Labels []string
+	Number       int
+	Title        string
+	Body         string
+	Labels       []string
+	Comments     []IssueComment
+	CommentsText string
+}
+
+type IssueComment struct {
+	Author    string
+	Body      string
+	CreatedAt string
+}
+
+type PRSummary struct {
+	Number      int
+	State       string
+	Title       string
+	HeadRefName string
+	BaseRefName string
+	URL         string
+	IsDraft     bool
 }
 
 type PRContext struct {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/Lincyaw/workbuddy/internal/config"
 	"github.com/Lincyaw/workbuddy/internal/launcher"
@@ -108,6 +109,16 @@ func (r *Router) handleDispatch(ctx context.Context, req statemachine.DispatchRe
 		issueCtx.Body = body
 		issueCtx.Labels = labels
 	}
+	if comments, err := fetchIssueComments(req.Repo, req.IssueNum); err != nil {
+		log.Printf("[router] warning: could not fetch issue comments: %v", err)
+	} else {
+		issueCtx.Comments = comments
+		issueCtx.CommentsText = formatComments(comments)
+	}
+	relatedPRs, err := fetchRelatedPRs(req.Repo, req.IssueNum)
+	if err != nil {
+		log.Printf("[router] warning: could not fetch related PRs: %v", err)
+	}
 
 	// Determine WorkDir: use an isolated worktree if workspace manager is set,
 	// otherwise fall back to CWD.
@@ -127,9 +138,11 @@ func (r *Router) handleDispatch(ctx context.Context, req statemachine.DispatchRe
 	}
 
 	taskCtx := &launcher.TaskContext{
-		Issue:   issueCtx,
-		Repo:    req.Repo,
-		WorkDir: workDir,
+		Issue:          issueCtx,
+		Repo:           req.Repo,
+		WorkDir:        workDir,
+		RelatedPRs:     relatedPRs,
+		RelatedPRsText: formatRelatedPRs(relatedPRs),
 		Session: launcher.SessionContext{
 			ID: fmt.Sprintf("session-%s", taskID),
 		},
@@ -194,4 +207,111 @@ func fetchIssueDetails(repo string, issueNum int) (title, body string, labels []
 		labels[i] = l.Name
 	}
 	return detail.Title, detail.Body, labels, nil
+}
+
+// ghIssueComments is the shape returned by `gh issue view --json comments`.
+type ghIssueComments struct {
+	Comments []struct {
+		Author    struct{ Login string } `json:"author"`
+		Body      string                 `json:"body"`
+		CreatedAt string                 `json:"createdAt"`
+	} `json:"comments"`
+}
+
+func fetchIssueComments(repo string, issueNum int) ([]launcher.IssueComment, error) {
+	cmd := exec.Command("gh", "issue", "view",
+		fmt.Sprintf("%d", issueNum),
+		"--repo", repo,
+		"--json", "comments",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("gh issue view comments: %w", err)
+	}
+	var parsed ghIssueComments
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		return nil, fmt.Errorf("gh issue view comments: parse: %w", err)
+	}
+	result := make([]launcher.IssueComment, 0, len(parsed.Comments))
+	for _, c := range parsed.Comments {
+		result = append(result, launcher.IssueComment{
+			Author:    c.Author.Login,
+			Body:      c.Body,
+			CreatedAt: c.CreatedAt,
+		})
+	}
+	return result, nil
+}
+
+func formatComments(comments []launcher.IssueComment) string {
+	if len(comments) == 0 {
+		return "(no comments)"
+	}
+	var b strings.Builder
+	for i, c := range comments {
+		if i > 0 {
+			b.WriteString("\n---\n")
+		}
+		fmt.Fprintf(&b, "[%s by %s]\n%s", c.CreatedAt, c.Author, c.Body)
+	}
+	return b.String()
+}
+
+type ghPRSummary struct {
+	Number      int    `json:"number"`
+	State       string `json:"state"`
+	Title       string `json:"title"`
+	HeadRefName string `json:"headRefName"`
+	BaseRefName string `json:"baseRefName"`
+	URL         string `json:"url"`
+	IsDraft     bool   `json:"isDraft"`
+}
+
+func fetchRelatedPRs(repo string, issueNum int) ([]launcher.PRSummary, error) {
+	cmd := exec.Command("gh", "pr", "list",
+		"--repo", repo,
+		"--state", "all",
+		"--search", fmt.Sprintf("%d in:title,body", issueNum),
+		"--json", "number,state,title,headRefName,baseRefName,url,isDraft",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("gh pr list: %w", err)
+	}
+	var parsed []ghPRSummary
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		return nil, fmt.Errorf("gh pr list: parse: %w", err)
+	}
+	result := make([]launcher.PRSummary, 0, len(parsed))
+	for _, p := range parsed {
+		result = append(result, launcher.PRSummary{
+			Number:      p.Number,
+			State:       p.State,
+			Title:       p.Title,
+			HeadRefName: p.HeadRefName,
+			BaseRefName: p.BaseRefName,
+			URL:         p.URL,
+			IsDraft:     p.IsDraft,
+		})
+	}
+	return result, nil
+}
+
+func formatRelatedPRs(prs []launcher.PRSummary) string {
+	if len(prs) == 0 {
+		return "(no related PRs)"
+	}
+	var b strings.Builder
+	for i, p := range prs {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		draft := ""
+		if p.IsDraft {
+			draft = " [draft]"
+		}
+		fmt.Fprintf(&b, "#%d [%s]%s %s (head: %s, base: %s) - %s",
+			p.Number, p.State, draft, p.Title, p.HeadRefName, p.BaseRefName, p.URL)
+	}
+	return b.String()
 }

--- a/internal/webui/handler.go
+++ b/internal/webui/handler.go
@@ -199,35 +199,10 @@ func (h *Handler) handleEventsJSON(w http.ResponseWriter, r *http.Request, sessi
 	}
 	defer func() { _ = f.Close() }()
 
-	lines, err := readAllLines(f)
+	out, total, start, end, err := readEventSlice(f, offset, limit, tail)
 	if err != nil {
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
-	}
-	total := len(lines)
-
-	start, end := offset, offset+limit
-	if tail {
-		end = total
-		start = total - limit
-		if start < 0 {
-			start = 0
-		}
-	}
-	if start > total {
-		start = total
-	}
-	if end > total {
-		end = total
-	}
-
-	out := make([]trimmedEvent, 0, end-start)
-	for i := start; i < end; i++ {
-		ev, ok := parseAndTrim(lines[i], i)
-		if !ok {
-			continue
-		}
-		out = append(out, ev)
 	}
 
 	writeJSON(w, eventsResponse{
@@ -236,6 +211,74 @@ func (h *Handler) handleEventsJSON(w http.ResponseWriter, r *http.Request, sessi
 		Start:  start,
 		End:    end,
 	})
+}
+
+// readEventSlice streams the file line-by-line and collects only the requested
+// slice so memory stays O(limit) instead of O(total). For `tail` it keeps a
+// ring buffer of the last `limit` lines.
+func readEventSlice(r io.Reader, offset, limit int, tail bool) ([]trimmedEvent, int, int, int, error) {
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+
+	if tail {
+		ring := make([]string, 0, limit)
+		total := 0
+		for sc.Scan() {
+			line := sc.Text()
+			total++
+			if len(ring) < limit {
+				ring = append(ring, line)
+			} else {
+				copy(ring, ring[1:])
+				ring[limit-1] = line
+			}
+		}
+		if err := sc.Err(); err != nil {
+			return nil, 0, 0, 0, err
+		}
+		start := total - len(ring)
+		if start < 0 {
+			start = 0
+		}
+		end := total
+		out := make([]trimmedEvent, 0, len(ring))
+		for i, line := range ring {
+			ev, ok := parseAndTrim(line, start+i)
+			if !ok {
+				continue
+			}
+			out = append(out, ev)
+		}
+		return out, total, start, end, nil
+	}
+
+	total := 0
+	desiredEnd := offset + limit
+	out := make([]trimmedEvent, 0, limit)
+	for sc.Scan() {
+		idx := total
+		total++
+		if idx < offset || idx >= desiredEnd {
+			continue
+		}
+		ev, ok := parseAndTrim(sc.Text(), idx)
+		if !ok {
+			continue
+		}
+		out = append(out, ev)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, 0, 0, 0, err
+	}
+	start := offset
+	if start > total {
+		start = total
+	}
+	end := desiredEnd
+	if end > total {
+		end = total
+	}
+	return out, total, start, end, nil
 }
 
 // handleStream tails events-v1.jsonl and pushes new events via SSE.
@@ -347,21 +390,31 @@ func (h *Handler) handleStream(w http.ResponseWriter, r *http.Request, sessionID
 // ---------------------------------------------------------------------------
 
 func (h *Handler) eventsPath(sessionID string) string {
-	if h.sessionsDir == "" || sessionID == "" {
+	if h.sessionsDir == "" || !isValidSessionID(sessionID) {
 		return ""
 	}
-	return filepath.Join(h.sessionsDir, sessionID, "events-v1.jsonl")
+	baseDir := filepath.Clean(h.sessionsDir)
+	fullPath := filepath.Join(baseDir, sessionID, "events-v1.jsonl")
+	rel, err := filepath.Rel(baseDir, fullPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return ""
+	}
+	return fullPath
 }
 
-func readAllLines(r io.Reader) ([]string, error) {
-	var out []string
-	sc := bufio.NewScanner(r)
-	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
-	for sc.Scan() {
-		out = append(out, sc.Text())
+// isValidSessionID rejects empty IDs, dot-paths, and any value containing a
+// path separator so a request cannot traverse out of the configured sessions
+// directory.
+func isValidSessionID(sessionID string) bool {
+	if sessionID == "" || sessionID == "." || sessionID == ".." {
+		return false
 	}
-	return out, sc.Err()
+	if strings.ContainsAny(sessionID, `/\`) {
+		return false
+	}
+	return true
 }
+
 
 func writeJSON(w http.ResponseWriter, v any) {
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/webui/handler.go
+++ b/internal/webui/handler.go
@@ -2,20 +2,28 @@
 package webui
 
 import (
+	"bufio"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"html/template"
+	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Lincyaw/workbuddy/internal/store"
 )
 
 // Handler serves the session viewer web UI.
 type Handler struct {
-	store     *store.Store
-	listTmpl  *template.Template
-	detailTmpl *template.Template
+	store        *store.Store
+	sessionsDir  string
+	listTmpl     *template.Template
+	detailTmpl   *template.Template
 	notFoundTmpl *template.Template
 }
 
@@ -37,10 +45,17 @@ func NewHandler(st *store.Store) *Handler {
 	return h
 }
 
+// SetSessionsDir configures the directory where per-session event logs live,
+// e.g. "<dir>/<session_id>/events-v1.jsonl". Required for the events.json and
+// stream endpoints; when unset they return 404.
+func (h *Handler) SetSessionsDir(dir string) {
+	h.sessionsDir = dir
+}
+
 // Register adds the session viewer routes to the given mux.
 func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("/sessions", h.handleList)
-	mux.HandleFunc("/sessions/", h.handleDetail)
+	mux.HandleFunc("/sessions/", h.handleSessionSubpath)
 }
 
 // handleList renders the session list page with optional filtering.
@@ -62,26 +77,40 @@ func (h *Handler) handleList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data := listData{
-		Sessions: sessions,
-		Filter:   filter,
-	}
-
+	data := listData{Sessions: sessions, Filter: filter}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := h.listTmpl.Execute(w, data); err != nil {
 		http.Error(w, "Template error", http.StatusInternalServerError)
 	}
 }
 
-// handleDetail renders a single session detail page.
-func (h *Handler) handleDetail(w http.ResponseWriter, r *http.Request) {
-	// Extract session ID from path: /sessions/{sessionID}
-	sessionID := strings.TrimPrefix(r.URL.Path, "/sessions/")
-	if sessionID == "" {
+// handleSessionSubpath dispatches requests under /sessions/ based on suffix:
+//
+//	/sessions/{id}                → detail HTML
+//	/sessions/{id}/events.json    → paginated JSON events
+//	/sessions/{id}/stream         → SSE tail
+func (h *Handler) handleSessionSubpath(w http.ResponseWriter, r *http.Request) {
+	rest := strings.TrimPrefix(r.URL.Path, "/sessions/")
+	if rest == "" {
 		http.Redirect(w, r, "/sessions", http.StatusFound)
 		return
 	}
 
+	sessionID, suffix, _ := strings.Cut(rest, "/")
+	switch suffix {
+	case "":
+		h.handleDetail(w, r, sessionID)
+	case "events.json":
+		h.handleEventsJSON(w, r, sessionID)
+	case "stream":
+		h.handleStream(w, r, sessionID)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+// handleDetail renders a single session detail page.
+func (h *Handler) handleDetail(w http.ResponseWriter, r *http.Request, sessionID string) {
 	sess, err := h.store.GetAgentSession(sessionID)
 	if err != nil {
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
@@ -94,7 +123,6 @@ func (h *Handler) handleDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Look up the task record for extra metadata (status, duration).
 	var taskStatus string
 	if sess.TaskID != "" {
 		tasks, err := h.store.QueryTasks("")
@@ -108,15 +136,346 @@ func (h *Handler) handleDetail(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	hasEvents := false
+	if p := h.eventsPath(sessionID); p != "" {
+		if _, err := os.Stat(p); err == nil {
+			hasEvents = true
+		}
+	}
+
 	data := detailData{
 		Session:    *sess,
 		TaskStatus: taskStatus,
+		HasEvents:  hasEvents,
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := h.detailTmpl.Execute(w, data); err != nil {
 		http.Error(w, "Template error", http.StatusInternalServerError)
 	}
+}
+
+// handleEventsJSON returns a paginated slice of events from events-v1.jsonl.
+//
+// Query params:
+//
+//	offset (int, default 0)       — skip this many events from the start
+//	limit  (int, default 200)     — max events returned (capped at 1000)
+//	tail   ("1" to take last N)   — when set, returns the last `limit` events;
+//	                                `offset` is ignored.
+//
+// Bulky string fields inside payload/raw are truncated server-side to keep
+// the response small. Clients can request the full event via the stream or
+// by re-querying without truncation (not yet implemented — intentional).
+func (h *Handler) handleEventsJSON(w http.ResponseWriter, r *http.Request, sessionID string) {
+	path := h.eventsPath(sessionID)
+	if path == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	q := r.URL.Query()
+	offset, _ := strconv.Atoi(q.Get("offset"))
+	if offset < 0 {
+		offset = 0
+	}
+	limit, _ := strconv.Atoi(q.Get("limit"))
+	if limit <= 0 {
+		limit = 200
+	}
+	if limit > 1000 {
+		limit = 1000
+	}
+	tail := q.Get("tail") == "1"
+
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			writeJSON(w, eventsResponse{Events: []trimmedEvent{}, Total: 0})
+			return
+		}
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+	defer func() { _ = f.Close() }()
+
+	lines, err := readAllLines(f)
+	if err != nil {
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+	total := len(lines)
+
+	start, end := offset, offset+limit
+	if tail {
+		end = total
+		start = total - limit
+		if start < 0 {
+			start = 0
+		}
+	}
+	if start > total {
+		start = total
+	}
+	if end > total {
+		end = total
+	}
+
+	out := make([]trimmedEvent, 0, end-start)
+	for i := start; i < end; i++ {
+		ev, ok := parseAndTrim(lines[i], i)
+		if !ok {
+			continue
+		}
+		out = append(out, ev)
+	}
+
+	writeJSON(w, eventsResponse{
+		Events: out,
+		Total:  total,
+		Start:  start,
+		End:    end,
+	})
+}
+
+// handleStream tails events-v1.jsonl and pushes new events via SSE.
+// Polls the file once per second for simplicity (no fsnotify dep).
+// Closes cleanly when the client disconnects via r.Context().
+func (h *Handler) handleStream(w http.ResponseWriter, r *http.Request, sessionID string) {
+	path := h.eventsPath(sessionID)
+	if path == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	afterStr := r.URL.Query().Get("after")
+	after, _ := strconv.Atoi(afterStr)
+	if after < 0 {
+		after = 0
+	}
+
+	var f *os.File
+	var reader *bufio.Reader
+	openFile := func() bool {
+		var err error
+		f, err = os.Open(path)
+		if err != nil {
+			return false
+		}
+		reader = bufio.NewReader(f)
+		return true
+	}
+	defer func() {
+		if f != nil {
+			_ = f.Close()
+		}
+	}()
+
+	if !openFile() {
+		fmt.Fprint(w, ": events file not ready\n\n")
+		flusher.Flush()
+	}
+
+	idx := 0
+	var pending strings.Builder
+	emit := func(line string) {
+		if idx >= after {
+			ev, ok := parseAndTrim(line, idx)
+			if ok {
+				data, _ := json.Marshal(ev)
+				fmt.Fprintf(w, "event: evt\nid: %d\ndata: %s\n\n", idx, data)
+			}
+		}
+		idx++
+	}
+
+	// Initial drain + then poll loop.
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+	heartbeat := time.NewTicker(15 * time.Second)
+	defer heartbeat.Stop()
+
+	ctx := r.Context()
+	for {
+		if reader != nil {
+			for {
+				line, err := reader.ReadString('\n')
+				if line != "" {
+					pending.WriteString(line)
+					if strings.HasSuffix(line, "\n") {
+						emit(strings.TrimRight(pending.String(), "\r\n"))
+						pending.Reset()
+					}
+				}
+				if err != nil {
+					if !errors.Is(err, io.EOF) {
+						fmt.Fprintf(w, "event: error\ndata: %q\n\n", err.Error())
+					}
+					break
+				}
+			}
+			flusher.Flush()
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-heartbeat.C:
+			fmt.Fprint(w, ": ping\n\n")
+			flusher.Flush()
+		case <-ticker.C:
+			if reader == nil {
+				openFile()
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func (h *Handler) eventsPath(sessionID string) string {
+	if h.sessionsDir == "" || sessionID == "" {
+		return ""
+	}
+	return filepath.Join(h.sessionsDir, sessionID, "events-v1.jsonl")
+}
+
+func readAllLines(r io.Reader) ([]string, error) {
+	var out []string
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for sc.Scan() {
+		out = append(out, sc.Text())
+	}
+	return out, sc.Err()
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+type eventsResponse struct {
+	Events []trimmedEvent `json:"events"`
+	Total  int            `json:"total"`
+	Start  int            `json:"start,omitempty"`
+	End    int            `json:"end,omitempty"`
+}
+
+// trimmedEvent is the on-the-wire shape: a thin projection of
+// launcherevents.Event that strips Raw and truncates bulky strings in Payload.
+type trimmedEvent struct {
+	Index     int    `json:"index"`
+	Kind      string `json:"kind"`
+	Timestamp string `json:"ts,omitempty"`
+	SessionID string `json:"session_id,omitempty"`
+	TurnID    string `json:"turn_id,omitempty"`
+	Seq       uint64 `json:"seq"`
+	Payload   any    `json:"payload,omitempty"`
+	Truncated bool   `json:"truncated,omitempty"`
+}
+
+const maxStringLen = 4000
+
+func parseAndTrim(line string, idx int) (trimmedEvent, bool) {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return trimmedEvent{}, false
+	}
+	var raw struct {
+		Kind      string          `json:"kind"`
+		Timestamp string          `json:"ts"`
+		SessionID string          `json:"session_id"`
+		TurnID    string          `json:"turn_id"`
+		Seq       uint64          `json:"seq"`
+		Payload   json.RawMessage `json:"payload"`
+	}
+	if err := json.Unmarshal([]byte(line), &raw); err != nil {
+		return trimmedEvent{
+			Index: idx,
+			Kind:  "unparseable",
+			Payload: map[string]string{
+				"error": err.Error(),
+				"line":  truncString(line, maxStringLen),
+			},
+			Truncated: len(line) > maxStringLen,
+		}, true
+	}
+	var payload any
+	truncated := false
+	if len(raw.Payload) > 0 {
+		if err := json.Unmarshal(raw.Payload, &payload); err == nil {
+			payload, truncated = trimValue(payload)
+		} else {
+			payload = string(raw.Payload)
+		}
+	}
+	return trimmedEvent{
+		Index:     idx,
+		Kind:      raw.Kind,
+		Timestamp: raw.Timestamp,
+		SessionID: raw.SessionID,
+		TurnID:    raw.TurnID,
+		Seq:       raw.Seq,
+		Payload:   payload,
+		Truncated: truncated,
+	}, true
+}
+
+// trimValue recursively walks decoded JSON and truncates long strings in place.
+// Returns (possibly-new) value and whether any truncation occurred.
+func trimValue(v any) (any, bool) {
+	switch x := v.(type) {
+	case string:
+		if len(x) > maxStringLen {
+			return x[:maxStringLen] + "… [truncated]", true
+		}
+		return x, false
+	case map[string]any:
+		trunc := false
+		for k, val := range x {
+			nv, t := trimValue(val)
+			x[k] = nv
+			trunc = trunc || t
+		}
+		return x, trunc
+	case []any:
+		trunc := false
+		// Cap array length so a 10k-line tool output doesn't blow the wire.
+		const maxArr = 200
+		if len(x) > maxArr {
+			x = append(x[:maxArr], "… [truncated "+strconv.Itoa(len(x)-maxArr)+" more]")
+			trunc = true
+		}
+		for i, val := range x {
+			nv, t := trimValue(val)
+			x[i] = nv
+			trunc = trunc || t
+		}
+		return x, trunc
+	default:
+		return v, false
+	}
+}
+
+func truncString(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "… [truncated]"
 }
 
 // listData is the template data for the session list page.
@@ -129,6 +488,7 @@ type listData struct {
 type detailData struct {
 	Session    store.AgentSession
 	TaskStatus string
+	HasEvents  bool
 }
 
 // SessionURL returns the URL path for a session detail page.

--- a/internal/webui/handler_test.go
+++ b/internal/webui/handler_test.go
@@ -1,11 +1,15 @@
 package webui
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Lincyaw/workbuddy/internal/store"
 )
@@ -222,5 +226,198 @@ func TestSessionURL(t *testing.T) {
 	url := SessionURL("session-abc")
 	if url != "/sessions/session-abc" {
 		t.Fatalf("expected /sessions/session-abc, got %s", url)
+	}
+}
+
+// writeEventsFile lays out <dir>/<sessionID>/events-v1.jsonl with the given lines.
+func writeEventsFile(t *testing.T, dir, sessionID string, lines []string) {
+	t.Helper()
+	sessionDir := filepath.Join(dir, sessionID)
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body := strings.Join(lines, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(sessionDir, "events-v1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write events: %v", err)
+	}
+}
+
+func sampleEventLine(seq uint64, kind, text string) string {
+	payload, _ := json.Marshal(map[string]any{"text": text})
+	evt := map[string]any{
+		"kind":       kind,
+		"ts":         "2026-04-15T04:00:00Z",
+		"session_id": "session-t",
+		"turn_id":    "turn-t",
+		"seq":        seq,
+		"payload":    json.RawMessage(payload),
+	}
+	b, _ := json.Marshal(evt)
+	return string(b)
+}
+
+func TestEventsJSON_OffsetLimit(t *testing.T) {
+	st := newTestStore(t)
+	h := NewHandler(st)
+	dir := t.TempDir()
+	h.SetSessionsDir(dir)
+
+	var lines []string
+	for i := 0; i < 10; i++ {
+		lines = append(lines, sampleEventLine(uint64(i+1), "log", "line"))
+	}
+	writeEventsFile(t, dir, "session-t", lines)
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	req := httptest.NewRequest("GET", "/sessions/session-t/events.json?offset=3&limit=4", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var resp eventsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, w.Body.String())
+	}
+	if resp.Total != 10 {
+		t.Fatalf("total = %d, want 10", resp.Total)
+	}
+	if resp.Start != 3 || resp.End != 7 {
+		t.Fatalf("start/end = %d/%d, want 3/7", resp.Start, resp.End)
+	}
+	if len(resp.Events) != 4 {
+		t.Fatalf("events = %d, want 4", len(resp.Events))
+	}
+	if resp.Events[0].Index != 3 {
+		t.Fatalf("first index = %d, want 3", resp.Events[0].Index)
+	}
+}
+
+func TestEventsJSON_Tail(t *testing.T) {
+	st := newTestStore(t)
+	h := NewHandler(st)
+	dir := t.TempDir()
+	h.SetSessionsDir(dir)
+
+	var lines []string
+	for i := 0; i < 10; i++ {
+		lines = append(lines, sampleEventLine(uint64(i+1), "log", "line"))
+	}
+	writeEventsFile(t, dir, "session-t", lines)
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	req := httptest.NewRequest("GET", "/sessions/session-t/events.json?tail=1&limit=3", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp eventsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Total != 10 || resp.Start != 7 || resp.End != 10 {
+		t.Fatalf("total/start/end = %d/%d/%d, want 10/7/10", resp.Total, resp.Start, resp.End)
+	}
+	if len(resp.Events) != 3 || resp.Events[0].Index != 7 {
+		t.Fatalf("events = %+v", resp.Events)
+	}
+}
+
+func TestEventsJSON_PayloadTruncation(t *testing.T) {
+	st := newTestStore(t)
+	h := NewHandler(st)
+	dir := t.TempDir()
+	h.SetSessionsDir(dir)
+
+	// One event with a text field larger than maxStringLen.
+	big := strings.Repeat("x", maxStringLen+500)
+	line := sampleEventLine(1, "log", big)
+	writeEventsFile(t, dir, "session-t", []string{line})
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	req := httptest.NewRequest("GET", "/sessions/session-t/events.json", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	var resp eventsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Events) != 1 {
+		t.Fatalf("events = %d", len(resp.Events))
+	}
+	if !resp.Events[0].Truncated {
+		t.Fatalf("expected truncated flag on oversized payload")
+	}
+	payload, ok := resp.Events[0].Payload.(map[string]any)
+	if !ok {
+		t.Fatalf("payload type = %T", resp.Events[0].Payload)
+	}
+	text, _ := payload["text"].(string)
+	if len(text) == 0 || len(text) > maxStringLen+100 {
+		t.Fatalf("text length = %d, expected <= ~maxStringLen", len(text))
+	}
+}
+
+func TestEventsJSON_RejectsPathTraversal(t *testing.T) {
+	st := newTestStore(t)
+	h := NewHandler(st)
+	dir := t.TempDir()
+	h.SetSessionsDir(dir)
+
+	// Pre-create a file outside the sessions dir that a naive join could reach.
+	secret := filepath.Join(filepath.Dir(dir), "secret-events-v1.jsonl")
+	if err := os.WriteFile(secret, []byte(`{"kind":"secret"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+
+	for _, sid := range []string{"..", ".", "../secret", "foo/bar", "foo\\bar"} {
+		req := httptest.NewRequest("GET", "/sessions/"+sid+"/events.json", nil)
+		w := httptest.NewRecorder()
+		// Route directly to the subpath dispatcher.
+		h.handleSessionSubpath(w, req)
+		if w.Code == http.StatusOK && strings.Contains(w.Body.String(), "secret") {
+			t.Fatalf("sessionID %q leaked secret content: %s", sid, w.Body.String())
+		}
+	}
+}
+
+func TestStream_SmokeEmitsEvent(t *testing.T) {
+	st := newTestStore(t)
+	h := NewHandler(st)
+	dir := t.TempDir()
+	h.SetSessionsDir(dir)
+	writeEventsFile(t, dir, "session-t", []string{sampleEventLine(1, "log", "hello")})
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req := httptest.NewRequest("GET", "/sessions/session-t/stream", nil).WithContext(ctx)
+	w := httptest.NewRecorder()
+	go func() {
+		// Give the handler just enough time to drain the initial file and
+		// write the first event before the request context expires.
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+	}()
+	mux.ServeHTTP(w, req)
+
+	body := w.Body.String()
+	if !strings.Contains(body, "event: evt") {
+		t.Fatalf("expected SSE event line, got: %s", body)
+	}
+	if !strings.Contains(body, `"kind":"log"`) {
+		t.Fatalf("expected event payload in body, got: %s", body)
 	}
 }

--- a/internal/webui/templates.go
+++ b/internal/webui/templates.go
@@ -203,7 +203,7 @@ const detailHTML = `<!DOCTYPE html>
 {{if .HasEvents}}
 <script>
 (function() {
-  const SID = {{.Session.SessionID}};
+  const SID = {{printf "%q" .Session.SessionID}};
   const timeline = document.getElementById("timeline");
   const statusEl = document.getElementById("status");
   const emptyEl = document.getElementById("empty");

--- a/internal/webui/templates.go
+++ b/internal/webui/templates.go
@@ -69,6 +69,8 @@ const listHTML = `<!DOCTYPE html>
 </html>`
 
 // detailHTML is the template for the session detail page.
+// Renders a live-updating timeline of Event Schema v1 events with color-coded
+// kinds, collapsible payloads, tail-follow toggle, and SSE-backed streaming.
 const detailHTML = `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -78,48 +80,275 @@ const detailHTML = `<!DOCTYPE html>
 <style>
   * { box-sizing: border-box; margin: 0; padding: 0; }
   body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #f6f8fa; color: #24292f; line-height: 1.5; }
-  .container { max-width: 960px; margin: 0 auto; padding: 24px 16px; }
-  h1 { margin-bottom: 8px; font-size: 24px; }
-  .breadcrumb { margin-bottom: 16px; font-size: 14px; color: #656d76; }
+  .container { max-width: 1080px; margin: 0 auto; padding: 24px 16px 96px; }
+  h1 { margin-bottom: 8px; font-size: 22px; }
+  h2 { font-size: 16px; margin-bottom: 10px; }
+  .breadcrumb { margin-bottom: 16px; font-size: 13px; color: #656d76; }
   .breadcrumb a { color: #0969da; text-decoration: none; }
   .breadcrumb a:hover { text-decoration: underline; }
-  .meta { background: #fff; border: 1px solid #d0d7de; border-radius: 6px; padding: 16px; margin-bottom: 16px; }
-  .meta table { width: 100%; }
-  .meta td { padding: 4px 12px; font-size: 14px; vertical-align: top; }
-  .meta td:first-child { font-weight: 600; width: 140px; color: #656d76; }
   a { color: #0969da; text-decoration: none; }
   a:hover { text-decoration: underline; }
-  code { background: #f0f3f6; padding: 2px 6px; border-radius: 4px; font-size: 13px; }
-  .summary { background: #fff; border: 1px solid #d0d7de; border-radius: 6px; padding: 16px; margin-bottom: 16px; }
-  .summary h2 { font-size: 18px; margin-bottom: 8px; }
-  .summary pre { background: #f6f8fa; border: 1px solid #d0d7de; border-radius: 6px; padding: 12px; overflow-x: auto; font-size: 13px; white-space: pre-wrap; word-wrap: break-word; }
+  code, .mono { font-family: "SF Mono", ui-monospace, Menlo, Consolas, monospace; font-size: 12.5px; }
+  code { background: #eef1f4; padding: 1px 6px; border-radius: 4px; }
+  .card { background: #fff; border: 1px solid #d0d7de; border-radius: 8px; padding: 14px 16px; margin-bottom: 14px; }
+  .meta-grid { display: grid; grid-template-columns: max-content 1fr; gap: 4px 16px; font-size: 13px; }
+  .meta-grid dt { color: #656d76; font-weight: 600; }
+  .meta-grid dd { overflow-wrap: anywhere; }
+  .toolbar { position: sticky; top: 0; z-index: 5; display: flex; align-items: center; gap: 8px; padding: 10px 12px; margin-bottom: 14px; background: rgba(246,248,250,0.92); backdrop-filter: blur(6px); border: 1px solid #d0d7de; border-radius: 8px; flex-wrap: wrap; }
+  .toolbar .grow { flex: 1 1 auto; }
+  .toolbar select, .toolbar input, .toolbar button { font-size: 13px; padding: 4px 10px; border: 1px solid #d0d7de; border-radius: 6px; background: #fff; color: #24292f; }
+  .toolbar button { cursor: pointer; }
+  .toolbar button:hover { background: #f3f5f7; }
+  .toolbar button.active { background: #dbeeff; border-color: #7abaf5; color: #0550a0; }
+  .status { font-size: 12px; color: #656d76; }
+  .status.live::before { content: ""; display: inline-block; width: 8px; height: 8px; border-radius: 50%; background: #2da44e; margin-right: 6px; vertical-align: middle; animation: pulse 1.6s infinite; }
+  @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.35; } }
+  .timeline { display: flex; flex-direction: column; gap: 8px; }
+  .event { background: #fff; border: 1px solid #d0d7de; border-left-width: 3px; border-radius: 6px; padding: 8px 12px; font-size: 13px; }
+  .event.hidden { display: none; }
+  .event-header { display: flex; align-items: baseline; gap: 10px; cursor: pointer; user-select: none; }
+  .kind-badge { display: inline-block; padding: 1px 8px; border-radius: 999px; font-size: 11px; font-weight: 600; letter-spacing: 0.2px; }
+  .event-title { font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1 1 auto; }
+  .event-time { color: #8c959f; font-size: 11px; flex: 0 0 auto; }
+  .event-body { margin-top: 8px; border-top: 1px dashed #e2e5e8; padding-top: 8px; }
+  .event-body pre { background: #f6f8fa; border-radius: 4px; padding: 8px 10px; overflow: auto; max-height: 360px; font-size: 12px; white-space: pre-wrap; word-break: break-word; }
+  .event.collapsed .event-body { display: none; }
+  /* kind palette */
+  .k-agent_message  { border-left-color: #6f42c1; }
+  .k-agent_message  .kind-badge { background: #efe2fa; color: #5a32a3; }
+  .k-reasoning      { border-left-color: #8b949e; }
+  .k-reasoning      .kind-badge { background: #eef1f4; color: #57606a; }
+  .k-tool_call      { border-left-color: #0969da; }
+  .k-tool_call      .kind-badge { background: #ddf4ff; color: #0550a0; }
+  .k-tool_result    { border-left-color: #1f883d; }
+  .k-tool_result    .kind-badge { background: #dcffe4; color: #116329; }
+  .k-command_exec   { border-left-color: #bf8700; }
+  .k-command_exec   .kind-badge { background: #fff1cc; color: #7d4e00; }
+  .k-command_output { border-left-color: #d4a72c; }
+  .k-command_output .kind-badge { background: #fff8c5; color: #7d4e00; }
+  .k-file_change    { border-left-color: #0969da; }
+  .k-file_change    .kind-badge { background: #ddf4ff; color: #0550a0; }
+  .k-turn_started   { border-left-color: #2da44e; }
+  .k-turn_started   .kind-badge { background: #dcffe4; color: #116329; }
+  .k-turn_completed { border-left-color: #2da44e; }
+  .k-turn_completed .kind-badge { background: #dcffe4; color: #116329; }
+  .k-token_usage    { border-left-color: #8250df; }
+  .k-token_usage    .kind-badge { background: #efe2fa; color: #5a32a3; }
+  .k-log            { border-left-color: #8c959f; }
+  .k-log            .kind-badge { background: #eef1f4; color: #57606a; }
+  .k-error          { border-left-color: #cf222e; background: #fff5f5; }
+  .k-error          .kind-badge { background: #ffe2e5; color: #a40e26; }
+  .empty { text-align: center; padding: 32px; color: #656d76; font-size: 14px; }
+  details.summary-fallback > summary { cursor: pointer; font-weight: 600; margin-bottom: 8px; font-size: 14px; }
+  details.summary-fallback pre { background: #f6f8fa; border: 1px solid #d0d7de; border-radius: 6px; padding: 12px; overflow-x: auto; font-size: 12.5px; white-space: pre-wrap; word-wrap: break-word; }
 </style>
 </head>
 <body>
 <div class="container">
   <div class="breadcrumb"><a href="/sessions">Sessions</a> / <code>{{.Session.SessionID}}</code></div>
-  <h1>Session Detail</h1>
+  <h1>Session · {{.Session.AgentName}} · {{.Session.Repo}}#{{.Session.IssueNum}}</h1>
 
-  <div class="meta">
-    <table>
-      <tr><td>Session ID</td><td><code>{{.Session.SessionID}}</code></td></tr>
-      <tr><td>Task ID</td><td><code>{{.Session.TaskID}}</code></td></tr>
-      <tr><td>Agent</td><td>{{.Session.AgentName}}</td></tr>
-      <tr><td>Repo</td><td>{{.Session.Repo}}</td></tr>
-      <tr><td>Issue</td><td>#{{.Session.IssueNum}}</td></tr>
-      {{if .TaskStatus}}<tr><td>Task Status</td><td>{{.TaskStatus}}</td></tr>{{end}}
-      <tr><td>Created</td><td>{{.Session.CreatedAt.Format "2006-01-02 15:04:05 UTC"}}</td></tr>
-      {{if .Session.RawPath}}<tr><td>Raw File</td><td><code>{{.Session.RawPath}}</code></td></tr>{{end}}
-    </table>
+  <div class="card">
+    <dl class="meta-grid">
+      <dt>Session ID</dt><dd><code>{{.Session.SessionID}}</code></dd>
+      <dt>Task ID</dt><dd><code>{{.Session.TaskID}}</code></dd>
+      <dt>Agent</dt><dd>{{.Session.AgentName}}</dd>
+      <dt>Repo</dt><dd>{{.Session.Repo}}</dd>
+      <dt>Issue</dt><dd>#{{.Session.IssueNum}}</dd>
+      {{if .TaskStatus}}<dt>Task Status</dt><dd>{{.TaskStatus}}</dd>{{end}}
+      <dt>Created</dt><dd>{{.Session.CreatedAt.Format "2006-01-02 15:04:05 UTC"}}</dd>
+      {{if .Session.RawPath}}<dt>Raw File</dt><dd><code>{{.Session.RawPath}}</code></dd>{{end}}
+    </dl>
   </div>
 
+  {{if .HasEvents}}
+  <div class="toolbar" id="toolbar">
+    <strong style="font-size:14px;">Event Timeline</strong>
+    <select id="filter-kind">
+      <option value="">All kinds</option>
+      <option value="agent.message">agent.message</option>
+      <option value="reasoning">reasoning</option>
+      <option value="tool.call">tool.call</option>
+      <option value="tool.result">tool.result</option>
+      <option value="command.exec">command.exec</option>
+      <option value="command.output">command.output</option>
+      <option value="file.change">file.change</option>
+      <option value="turn.started">turn.started</option>
+      <option value="turn.completed">turn.completed</option>
+      <option value="token.usage">token.usage</option>
+      <option value="error">error</option>
+      <option value="log">log</option>
+    </select>
+    <input id="filter-text" type="search" placeholder="Search payload…" style="min-width:180px;">
+    <button id="toggle-follow" class="active" type="button">Follow tail</button>
+    <button id="expand-all" type="button">Expand all</button>
+    <button id="collapse-all" type="button">Collapse all</button>
+    <span class="grow"></span>
+    <span class="status" id="status">connecting…</span>
+  </div>
+  <div class="timeline" id="timeline"></div>
+  <div class="empty" id="empty" style="display:none;">No events yet.</div>
+  {{end}}
+
   {{if .Session.Summary}}
-  <div class="summary">
-    <h2>Conversation Log</h2>
-    <pre>{{.Session.Summary}}</pre>
+  <div class="card">
+    <details class="summary-fallback"{{if not .HasEvents}} open{{end}}>
+      <summary>Textual summary (legacy)</summary>
+      <pre>{{.Session.Summary}}</pre>
+    </details>
   </div>
   {{end}}
 </div>
+
+{{if .HasEvents}}
+<script>
+(function() {
+  const SID = {{.Session.SessionID}};
+  const timeline = document.getElementById("timeline");
+  const statusEl = document.getElementById("status");
+  const emptyEl = document.getElementById("empty");
+  const kindSel = document.getElementById("filter-kind");
+  const textIn = document.getElementById("filter-text");
+  const followBtn = document.getElementById("toggle-follow");
+  let follow = true;
+  let seen = new Set();
+
+  function setStatus(msg, live) {
+    statusEl.textContent = msg;
+    statusEl.className = "status" + (live ? " live" : "");
+  }
+
+  function kindClass(k) { return "k-" + String(k || "unknown").replace(/\./g, "_"); }
+
+  function eventTitle(ev) {
+    const p = ev.payload || {};
+    switch (ev.kind) {
+      case "agent.message":   return shorten(p.text || p.content || "");
+      case "reasoning":       return shorten(p.text || p.summary || "");
+      case "tool.call":       return (p.name || p.tool || "tool") + "(" + Object.keys(p.input || p.arguments || {}).join(", ") + ")";
+      case "tool.result":     return (p.name || p.tool || "result") + (p.is_error ? " · ERROR" : "");
+      case "command.exec":    return shorten(Array.isArray(p.command) ? p.command.join(" ") : (p.command || ""));
+      case "command.output":  return shorten(p.chunk || p.output || p.text || "");
+      case "file.change":     return (p.action || "change") + " " + (p.path || "");
+      case "turn.started":    return "turn " + (p.turn_id || ev.turn_id || "");
+      case "turn.completed":  return "turn " + (p.turn_id || ev.turn_id || "") + (p.status ? " · " + p.status : "");
+      case "token.usage":     return (p.input_tokens || 0) + " in / " + (p.output_tokens || 0) + " out";
+      case "error":           return shorten(p.message || p.error || "error");
+      case "log":             return shorten(p.message || p.text || "");
+    }
+    return "";
+  }
+
+  function shorten(s) {
+    s = String(s || "").replace(/\s+/g, " ").trim();
+    return s.length > 140 ? s.slice(0, 140) + "…" : s;
+  }
+
+  function renderEvent(ev) {
+    if (seen.has(ev.index)) return;
+    seen.add(ev.index);
+    const el = document.createElement("div");
+    el.className = "event collapsed " + kindClass(ev.kind);
+    el.dataset.kind = ev.kind || "";
+    const payloadText = ev.payload == null ? "" : JSON.stringify(ev.payload, null, 2);
+    el.dataset.search = (ev.kind + " " + payloadText).toLowerCase();
+
+    const hdr = document.createElement("div");
+    hdr.className = "event-header";
+    const badge = document.createElement("span");
+    badge.className = "kind-badge";
+    badge.textContent = ev.kind || "?";
+    const title = document.createElement("span");
+    title.className = "event-title";
+    title.textContent = eventTitle(ev);
+    const time = document.createElement("span");
+    time.className = "event-time";
+    time.textContent = ev.ts ? new Date(ev.ts).toLocaleTimeString() : ("#" + ev.index);
+    hdr.append(badge, title, time);
+
+    const body = document.createElement("div");
+    body.className = "event-body";
+    const pre = document.createElement("pre");
+    pre.textContent = payloadText || "(no payload)";
+    body.append(pre);
+    if (ev.truncated) {
+      const note = document.createElement("div");
+      note.style.fontSize = "11px"; note.style.color = "#8c959f"; note.style.marginTop = "6px";
+      note.textContent = "payload truncated for transport";
+      body.append(note);
+    }
+
+    hdr.addEventListener("click", () => el.classList.toggle("collapsed"));
+    el.append(hdr, body);
+    applyFilter(el);
+    timeline.append(el);
+    if (follow) el.scrollIntoView({ block: "end", behavior: "instant" });
+  }
+
+  function applyFilter(el) {
+    const k = kindSel.value;
+    const q = textIn.value.trim().toLowerCase();
+    const kindOK = !k || el.dataset.kind === k;
+    const textOK = !q || el.dataset.search.includes(q);
+    el.classList.toggle("hidden", !(kindOK && textOK));
+  }
+  function refilter() { [...timeline.children].forEach(applyFilter); }
+
+  kindSel.addEventListener("change", refilter);
+  textIn.addEventListener("input", refilter);
+  followBtn.addEventListener("click", () => {
+    follow = !follow;
+    followBtn.classList.toggle("active", follow);
+    followBtn.textContent = follow ? "Follow tail" : "Paused";
+  });
+  document.getElementById("expand-all").addEventListener("click", () => {
+    timeline.querySelectorAll(".event").forEach(e => e.classList.remove("collapsed"));
+  });
+  document.getElementById("collapse-all").addEventListener("click", () => {
+    timeline.querySelectorAll(".event").forEach(e => e.classList.add("collapsed"));
+  });
+
+  let lastIndex = -1;
+
+  async function loadInitial() {
+    setStatus("loading events…", false);
+    try {
+      const resp = await fetch("/sessions/" + encodeURIComponent(SID) + "/events.json?tail=1&limit=200");
+      if (!resp.ok) throw new Error("HTTP " + resp.status);
+      const data = await resp.json();
+      (data.events || []).forEach(ev => { renderEvent(ev); lastIndex = Math.max(lastIndex, ev.index); });
+      if ((data.events || []).length === 0 && data.total === 0) {
+        emptyEl.style.display = "block";
+      }
+    } catch (e) {
+      setStatus("load failed: " + e.message, false);
+      return;
+    }
+    subscribe();
+  }
+
+  function subscribe() {
+    const url = "/sessions/" + encodeURIComponent(SID) + "/stream?after=" + (lastIndex + 1);
+    const es = new EventSource(url);
+    setStatus("streaming", true);
+    es.addEventListener("evt", e => {
+      try {
+        const ev = JSON.parse(e.data);
+        renderEvent(ev);
+        lastIndex = Math.max(lastIndex, ev.index);
+        emptyEl.style.display = "none";
+      } catch (_) {}
+    });
+    es.addEventListener("error", () => {
+      setStatus("reconnecting…", false);
+    });
+    window.addEventListener("beforeunload", () => es.close());
+  }
+
+  loadInitial();
+})();
+</script>
+{{end}}
 </body>
 </html>`
 

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -155,6 +155,17 @@ documentation:
         - .github/workbuddy/agents/
       notes: Catalog of planned agent types remains the future index, while codex-dev-agent now explicitly notes the codex-exec Event v1 and draft-PR development path.
 
+    - path: docs/planned/artifact-layout.md
+      bucket: planned
+      status: proposed
+      related_code:
+        - internal/launcher/codex.go
+        - internal/launcher/types.go
+        - cmd/serve.go
+        - internal/audit/audit.go
+        - internal/workspace/workspace.go
+      notes: Move session artifacts out of per-task worktrees into repo-root .workbuddy/sessions/ so they survive worktree cleanup and the runtime error path reaches auditor.
+
     - path: docs/mismatch/index.md
       bucket: mismatch
       status: maintained


### PR DESCRIPTION
## Summary
- Enrich `TaskContext` with issue comments and related PRs so stateless agents can catch up on prior history before acting.
- Teach dev-agent and review-agent to enforce the "one issue → one open PR" invariant: when multiple PRs exist, they pick one to continue on / review and close the rest with a superseded-by comment.
- Centralize session artifacts under repo-root `.workbuddy/sessions/` so they survive worktree cleanup; expand the session viewer to read from the stable path.

## Motivation
Issue #8 produced two concurrent PRs (#9 and #10) because the dev-agent prompt only said "reuse existing PR" and gave no guidance for the multi-PR case. The agent silently opened a new branch. This PR closes the guidance gap at the prompt layer (dev/review agents now have explicit authority + procedure) and gives both agents the context they need (full comment thread + PR metadata) to make the decision.

## Commit breakdown
1. Enrich TaskContext with issue comments and related PRs
2. Teach agents to handle multiple open PRs per issue
3. Centralize sessions directory and expand session viewer
4. Add artifact-layout planning doc and index it
5. Add codex dev-loop and long-horizon skills

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1`
- [ ] Manual: create a test issue with two concurrent PRs, confirm dev-agent picks one and closes the other with the expected comment
- [ ] Manual: confirm session artifacts now persist after worktree cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)