### PR TITLE
Address Copilot review findings from PR #10

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -553,10 +553,18 @@ func executeTask(ctx context.Context, task router.WorkerTask, deps *workerDeps) 
 	eventsPath, waitEvents := streamSessionEvents(task.Context, eventsCh)
 	result, err := session.Run(taskCtx, eventsCh)
 	close(eventsCh)
-	if waitErr := waitEvents(); waitErr != nil {
+	waitErr := waitEvents()
+	if waitErr != nil {
 		log.Printf("[worker] event capture failed: %v", waitErr)
 	}
-	if result != nil && result.SessionPath == "" && eventsPath != "" {
+	if result != nil && eventsPath != "" && waitErr == nil {
+		// Prefer the normalized Event Schema v1 artifact as the session's
+		// canonical path so audit/reporter work off the unified stream.
+		// The runtime-native artifact (e.g. codex-exec.jsonl) stays on disk
+		// but is no longer the handle handed downstream.
+		if result.RawSessionPath == "" {
+			result.RawSessionPath = result.SessionPath
+		}
 		result.SessionPath = eventsPath
 	}
 	if err != nil {
@@ -628,24 +636,38 @@ func streamSessionEvents(taskCtx *launcher.TaskContext, eventsCh <-chan launcher
 	path := filepath.Join(baseDir, ".workbuddy", "sessions", taskCtx.Session.ID, "events-v1.jsonl")
 	errCh := make(chan error, 1)
 	go func() {
+		// Always drain eventsCh to completion so the runtime is never blocked
+		// on a full send buffer, even if we can't persist the artifact.
+		var initErr, encodeErr error
+		var f *os.File
+		var enc *json.Encoder
 		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			errCh <- err
-			return
+			initErr = err
+		} else if created, err := os.Create(path); err != nil {
+			initErr = err
+		} else {
+			f = created
+			enc = json.NewEncoder(f)
 		}
-		f, err := os.Create(path)
-		if err != nil {
-			errCh <- err
-			return
-		}
-		defer func() { _ = f.Close() }()
-		enc := json.NewEncoder(f)
 		for evt := range eventsCh {
+			if enc == nil || encodeErr != nil {
+				continue
+			}
 			if err := enc.Encode(evt); err != nil {
-				errCh <- err
-				return
+				encodeErr = err
 			}
 		}
-		errCh <- nil
+		if f != nil {
+			_ = f.Close()
+		}
+		switch {
+		case initErr != nil:
+			errCh <- initErr
+		case encodeErr != nil:
+			errCh <- encodeErr
+		default:
+			errCh <- nil
+		}
 	}()
 	return path, func() error { return <-errCh }
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -202,6 +202,7 @@ func normalizeAgentConfig(agent *AgentConfig) ([]Warning, error) {
 		case "read-only", "danger-full-access":
 		case "workspace-write":
 			warnings = append(warnings, Warning{Message: fmt.Sprintf("agent %q: runtime %q does not support workspace-write sandbox; degrading to read-only semantics", agent.Name, agent.Runtime)})
+			agent.Policy.Sandbox = "read-only"
 		default:
 			return warnings, fmt.Errorf("unsupported policy.sandbox %q for runtime %q", agent.Policy.Sandbox, agent.Runtime)
 		}

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -208,6 +208,9 @@ func TestNormalizeAgentConfig_ClaudeWorkspaceWriteWarns(t *testing.T) {
 	if !strings.Contains(warnings[0].Message, "workspace-write") {
 		t.Fatalf("warning = %q", warnings[0].Message)
 	}
+	if agent.Policy.Sandbox != "read-only" {
+		t.Fatalf("expected sandbox to be normalized to read-only, got %q", agent.Policy.Sandbox)
+	}
 }
 
 func TestNormalizeAgentConfig_CodexAppServerAllowsViaApprover(t *testing.T) {

--- a/internal/launcher/codex.go
+++ b/internal/launcher/codex.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -142,7 +143,9 @@ func (s *codexSession) Run(ctx context.Context, events chan<- launcherevents.Eve
 	wg.Wait()
 	duration := time.Since(start)
 
-	if scanErr != nil && !strings.Contains(scanErr.Error(), "file already closed") {
+	// The stdout pipe may be closed when the child process exits; that is the
+	// expected termination for the scanner, not a real read error.
+	if scanErr != nil && !errors.Is(scanErr, os.ErrClosed) {
 		return nil, fmt.Errorf("launcher: codex-exec: read stdout: %w", scanErr)
 	}
 
@@ -150,6 +153,7 @@ func (s *codexSession) Run(ctx context.Context, events chan<- launcherevents.Eve
 		if events != nil {
 			emitEvent(events, &seq, s.task.Session.ID, mapper.effectiveTurnID(), launcherevents.KindError, launcherevents.ErrorPayload{Code: "timeout", Message: execCtx.Err().Error(), Recoverable: false}, nil)
 			emitEvent(events, &seq, s.task.Session.ID, mapper.effectiveTurnID(), launcherevents.KindTurnCompleted, launcherevents.TurnCompletedPayload{TurnID: mapper.effectiveTurnID(), Status: "error"}, nil)
+			mapper.turnCompleteSaw = true
 		}
 		return &Result{
 			ExitCode:    -1,
@@ -167,6 +171,7 @@ func (s *codexSession) Run(ctx context.Context, events chan<- launcherevents.Eve
 		if events != nil {
 			emitEvent(events, &seq, s.task.Session.ID, mapper.effectiveTurnID(), launcherevents.KindError, launcherevents.ErrorPayload{Code: "cancelled", Message: ctx.Err().Error(), Recoverable: false}, nil)
 			emitEvent(events, &seq, s.task.Session.ID, mapper.effectiveTurnID(), launcherevents.KindTurnCompleted, launcherevents.TurnCompletedPayload{TurnID: mapper.effectiveTurnID(), Status: "interrupted"}, nil)
+			mapper.turnCompleteSaw = true
 		}
 		return &Result{
 			ExitCode:    -1,
@@ -186,6 +191,20 @@ func (s *codexSession) Run(ctx context.Context, events chan<- launcherevents.Eve
 			return nil, fmt.Errorf("launcher: codex-exec: wait: %w", runErr)
 		}
 		exitCode = exitErr.ExitCode()
+	}
+
+	// Codex is supposed to print a `task_complete` JSONL line before exiting.
+	// If it crashed or exited early without one, consumers of the event stream
+	// would otherwise never see a terminal event. Synthesize one so audit/UI
+	// always has a turn-completion signal.
+	if events != nil && !mapper.turnCompleteSaw {
+		status := "ok"
+		if exitCode != 0 {
+			status = "error"
+			emitEvent(events, &seq, s.task.Session.ID, mapper.effectiveTurnID(), launcherevents.KindError, launcherevents.ErrorPayload{Code: "codex_exit", Message: fmt.Sprintf("codex exec exited %d without task_complete", exitCode), Recoverable: false}, nil)
+		}
+		emitEvent(events, &seq, s.task.Session.ID, mapper.effectiveTurnID(), launcherevents.KindTurnCompleted, launcherevents.TurnCompletedPayload{TurnID: mapper.effectiveTurnID(), Status: status}, nil)
+		mapper.turnCompleteSaw = true
 	}
 
 	lastMessage := readOptionalFile(s.lastMsgPath)
@@ -268,10 +287,11 @@ func readOptionalFile(path string) string {
 }
 
 type codexEventMapper struct {
-	sessionID  string
-	sessionRef SessionRef
-	turnID     string
-	tokenUsage *launcherevents.TokenUsagePayload
+	sessionID       string
+	sessionRef      SessionRef
+	turnID          string
+	tokenUsage      *launcherevents.TokenUsagePayload
+	turnCompleteSaw bool
 }
 
 func newCodexEventMapper(sessionID string) *codexEventMapper {
@@ -394,6 +414,7 @@ func (m *codexEventMapper) Map(line []byte, seq *uint64) []launcherevents.Event 
 		} else if rawBool(raw, "error") {
 			status = "error"
 		}
+		m.turnCompleteSaw = true
 		return []launcherevents.Event{m.makeEvent(seq, launcherevents.KindTurnCompleted, launcherevents.TurnCompletedPayload{TurnID: m.effectiveTurnID(), Status: status}, line)}
 
 	case "error":

--- a/internal/launcher/codex_test.go
+++ b/internal/launcher/codex_test.go
@@ -244,6 +244,62 @@ func TestCodexExecE2E(t *testing.T) {
 	}
 }
 
+func TestCodexSessionRunSynthesizesTurnCompletedOnCrash(t *testing.T) {
+	restore := installFakeCodexScript(t, "#!/bin/sh\nprintf 'boom\\n' >&2\nexit 3\n")
+	defer restore()
+
+	launcher := NewLauncher()
+	task := newTestTask(t)
+	agent := &config.AgentConfig{
+		Name:    "codex-agent",
+		Runtime: config.RuntimeCodexExec,
+		Prompt:  "irrelevant",
+		Policy:  config.PolicyConfig{Sandbox: "danger-full-access", Approval: "on-request"},
+		Timeout: 5 * time.Second,
+	}
+	session, err := launcher.Start(context.Background(), agent, task)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer func() { _ = session.Close() }()
+
+	ch := make(chan launcherevents.Event, 16)
+	var collected []launcherevents.Event
+	done := make(chan struct{})
+	go func() {
+		for evt := range ch {
+			collected = append(collected, evt)
+		}
+		close(done)
+	}()
+
+	result, err := session.Run(context.Background(), ch)
+	close(ch)
+	<-done
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if result.ExitCode != 3 {
+		t.Fatalf("exit code = %d, want 3", result.ExitCode)
+	}
+
+	var sawError, sawTurnCompleted bool
+	for _, evt := range collected {
+		switch evt.Kind {
+		case launcherevents.KindError:
+			sawError = true
+		case launcherevents.KindTurnCompleted:
+			sawTurnCompleted = true
+		}
+	}
+	if !sawError {
+		t.Fatalf("expected synthetic error event on non-zero exit without task_complete, got %v", collected)
+	}
+	if !sawTurnCompleted {
+		t.Fatalf("expected synthetic turn.completed event when codex crashed without task_complete, got %v", collected)
+	}
+}
+
 func installFakeCodex(t *testing.T) func() {
 	t.Helper()
 
@@ -277,6 +333,24 @@ func installFakeCodex(t *testing.T) func() {
 		"fi\n" +
 		"cat \"" + fixturePath + "\"\n" +
 		"printf 'codex stderr for testing\\n' >&2\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake codex: %v", err)
+	}
+
+	oldPath := os.Getenv("PATH")
+	if err := os.Setenv("PATH", binDir+string(os.PathListSeparator)+oldPath); err != nil {
+		t.Fatalf("set PATH: %v", err)
+	}
+	return func() {
+		_ = os.Setenv("PATH", oldPath)
+	}
+}
+
+func installFakeCodexScript(t *testing.T, script string) func() {
+	t.Helper()
+
+	binDir := t.TempDir()
+	scriptPath := filepath.Join(binDir, "codex")
 	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake codex: %v", err)
 	}

--- a/internal/launcher/process.go
+++ b/internal/launcher/process.go
@@ -129,7 +129,13 @@ func newClaudePromptCommand(execCtx context.Context, prompt string, extraArgs []
 }
 
 func claudePolicyArgs(policy config.PolicyConfig) []string {
-	args := []string{"--dangerously-skip-permissions"}
+	var args []string
+	// Only bypass Claude's permission prompts when the policy explicitly opts
+	// into unsandboxed execution. read-only / workspace-write keep the default
+	// permission gating so the runtime cannot write or execute without prompts.
+	if policy.Sandbox == "danger-full-access" {
+		args = append(args, "--dangerously-skip-permissions")
+	}
 	if policy.Model != "" {
 		args = append(args, "--model", policy.Model)
 	}

--- a/internal/launcher/process_test.go
+++ b/internal/launcher/process_test.go
@@ -58,16 +58,17 @@ func TestProcessSessionSessionLookupPathPrefersRepo(t *testing.T) {
 
 func TestClaudePolicyArgs_SandboxGatesPermissionBypass(t *testing.T) {
 	cases := []struct {
+		name       string
 		sandbox    string
 		wantBypass bool
 	}{
-		{"read-only", false},
-		{"workspace-write", false},
-		{"danger-full-access", true},
-		{"", false},
+		{"read-only", "read-only", false},
+		{"workspace-write", "workspace-write", false},
+		{"danger-full-access", "danger-full-access", true},
+		{"empty", "", false},
 	}
 	for _, tc := range cases {
-		t.Run(tc.sandbox, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			args := claudePolicyArgs(config.PolicyConfig{Sandbox: tc.sandbox})
 			joined := strings.Join(args, " ")
 			has := strings.Contains(joined, "--dangerously-skip-permissions")

--- a/internal/launcher/process_test.go
+++ b/internal/launcher/process_test.go
@@ -55,3 +55,25 @@ func TestProcessSessionSessionLookupPathPrefersRepo(t *testing.T) {
 		t.Fatalf("lookup path = %q, want %q", got, task.Repo)
 	}
 }
+
+func TestClaudePolicyArgs_SandboxGatesPermissionBypass(t *testing.T) {
+	cases := []struct {
+		sandbox    string
+		wantBypass bool
+	}{
+		{"read-only", false},
+		{"workspace-write", false},
+		{"danger-full-access", true},
+		{"", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.sandbox, func(t *testing.T) {
+			args := claudePolicyArgs(config.PolicyConfig{Sandbox: tc.sandbox})
+			joined := strings.Join(args, " ")
+			has := strings.Contains(joined, "--dangerously-skip-permissions")
+			if has != tc.wantBypass {
+				t.Fatalf("sandbox=%q args=%q bypass=%v want %v", tc.sandbox, joined, has, tc.wantBypass)
+			}
+		})
+	}
+}

--- a/internal/launcher/types.go
+++ b/internal/launcher/types.go
@@ -100,8 +100,15 @@ type Result struct {
 	Stderr      string
 	Duration    time.Duration
 	Meta        map[string]string
-	SessionPath string
-	LastMessage string
-	TokenUsage  *launcherevents.TokenUsagePayload
-	SessionRef  SessionRef
+	// SessionPath is the canonical session artifact path handed to audit
+	// and reporter. When Event Schema v1 capture succeeds this points at
+	// the normalized events-v1.jsonl; otherwise it falls back to whatever
+	// the runtime produced natively (e.g. codex-exec.jsonl).
+	SessionPath    string
+	// RawSessionPath preserves the runtime-native artifact path (if any)
+	// when SessionPath has been overridden with the normalized v1 stream.
+	RawSessionPath string
+	LastMessage    string
+	TokenUsage     *launcherevents.TokenUsagePayload
+	SessionRef     SessionRef
 }


### PR DESCRIPTION
## Summary
Follow-up to PR #10 (merged as 18302df), addressing all 6 review findings from Copilot.

## Fixes

1. **`claudePolicyArgs` permission bypass** (`internal/launcher/process.go`) — `--dangerously-skip-permissions` is now only emitted for `policy.sandbox: danger-full-access`. `read-only` / `workspace-write` keep Claude's default permission gating. **Security regression fix.**
2. **`streamSessionEvents` channel drain** (`cmd/serve.go`) — when artifact file init fails, still drain `eventsCh` to completion so the runtime cannot block on a full buffered channel.
3. **`events-v1.jsonl` as canonical `SessionPath`** (`cmd/serve.go`, `internal/launcher/types.go`) — audit/reporter now work off the normalized Event Schema v1 artifact instead of the runtime-native JSONL. Introduced `Result.RawSessionPath` so the native artifact path is preserved.
4. **Codex stdout close-error match** (`internal/launcher/codex.go`) — replaced brittle `strings.Contains("file already closed")` with `errors.Is(err, os.ErrClosed)`.
5. **Synthetic `turn.completed` on codex crash** (`internal/launcher/codex.go`) — when codex exits without emitting `task_complete`, the mapper now synthesizes a terminal `error` (for non-zero exit) + `turn.completed` event so consumers always see a completion signal.
6. **Claude `workspace-write` sandbox normalization** (`internal/config/loader.go`) — warning path now also mutates `Policy.Sandbox` to `read-only` so the normalized config matches its documented semantics.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1`
- [x] New unit tests:
  - `TestClaudePolicyArgs_SandboxGatesPermissionBypass` (fix 1)
  - `TestNormalizeAgentConfig_ClaudeWorkspaceWriteWarns` extended (fix 6)
  - `TestCodexSessionRunSynthesizesTurnCompletedOnCrash` (fix 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)