### PR TITLE
Implement bounded embedded worker parallelism for #19

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -107,6 +107,25 @@ func (l *issueTaskLocks) For(repo string, issue int) *sync.Mutex {
 	return lock.(*sync.Mutex)
 }
 
+// closedIssues tracks issues that were closed while same-issue work was still
+// queued so deferred tasks can be dropped before they start.
+type closedIssues struct {
+	issues sync.Map // key: "repo#issueNum" -> struct{}
+}
+
+func (c *closedIssues) MarkClosed(repo string, issue int) {
+	c.issues.Store(runningTaskKey(repo, issue), struct{}{})
+}
+
+func (c *closedIssues) MarkOpen(repo string, issue int) {
+	c.issues.Delete(runningTaskKey(repo, issue))
+}
+
+func (c *closedIssues) IsClosed(repo string, issue int) bool {
+	_, ok := c.issues.Load(runningTaskKey(repo, issue))
+	return ok
+}
+
 // GHCLIReader implements poller.GHReader using the gh CLI.
 type GHCLIReader struct{}
 
@@ -403,6 +422,7 @@ func runServeWithOpts(opts *serveOpts, ghReader poller.GHReader, launcherOverrid
 
 	// Running tasks registry for cancellation on issue close.
 	runningTasks := NewRunningTasks()
+	closedIssues := &closedIssues{}
 
 	// 7. Start StateMachine event processor (reads from poller events)
 	wg.Add(1)
@@ -418,11 +438,13 @@ func runServeWithOpts(opts *serveOpts, ghReader poller.GHReader, launcherOverrid
 				}
 				// Handle issue closure: cancel running agent and skip state machine.
 				if ev.Type == poller.EventIssueClosed {
+					closedIssues.MarkClosed(ev.Repo, ev.IssueNum)
 					if cancelled := runningTasks.Cancel(ev.Repo, ev.IssueNum); cancelled {
 						log.Printf("[serve] cancelled agent for closed issue %s#%d", ev.Repo, ev.IssueNum)
 					}
 					continue // don't pass to state machine
 				}
+				closedIssues.MarkOpen(ev.Repo, ev.IssueNum)
 				smEvent := statemachine.ChangeEvent{
 					Type:     ev.Type,
 					Repo:     ev.Repo,
@@ -457,6 +479,7 @@ func runServeWithOpts(opts *serveOpts, ghReader poller.GHReader, launcherOverrid
 		cfg:          cfg,
 		wsMgr:        wsMgr,
 		runningTasks: runningTasks,
+		closedIssues: closedIssues,
 		sessionsDir:  sessionsDir,
 	}
 	workerDone := make(chan struct{})
@@ -523,6 +546,7 @@ type workerDeps struct {
 	cfg          *config.FullConfig
 	wsMgr        *workspace.Manager
 	runningTasks *RunningTasks
+	closedIssues *closedIssues
 	sessionsDir  string
 }
 
@@ -571,9 +595,28 @@ func runEmbeddedWorker(ctx context.Context, taskCh <-chan router.WorkerTask, dep
 				}
 				defer func() { <-parallelLimiter }()
 
+				if deps.closedIssues != nil && deps.closedIssues.IsClosed(task.Repo, task.IssueNum) {
+					skipTaskForClosedIssue(task, deps)
+					return
+				}
+
 				executeTask(ctx, task, deps)
 			}(task)
 		}
+	}
+}
+
+func skipTaskForClosedIssue(task router.WorkerTask, deps *workerDeps) {
+	log.Printf("[worker] skipping queued task %s for closed issue %s#%d",
+		task.TaskID, task.Repo, task.IssueNum)
+
+	if deps.store != nil {
+		if err := deps.store.UpdateTaskStatus(task.TaskID, store.TaskStatusFailed); err != nil {
+			log.Printf("[worker] failed to update skipped task status: %v", err)
+		}
+	}
+	if deps.sm != nil {
+		deps.sm.MarkAgentCompleted(task.Repo, task.IssueNum, fetchCachedLabels(deps.store, task.Repo, task.IssueNum))
 	}
 }
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -32,11 +33,12 @@ import (
 )
 
 const (
-	defaultPort         = 8080
-	defaultPollInterval = 30 * time.Second
-	taskChanSize        = 64
-	dispatchChanSize    = 64
-	agentShutdownWait   = 60 * time.Second
+	defaultPort             = 8080
+	defaultPollInterval     = 30 * time.Second
+	defaultMaxParallelTasks = 4
+	taskChanSize            = 64
+	dispatchChanSize        = 64
+	agentShutdownWait       = 60 * time.Second
 )
 
 // RunningTasks is a thread-safe registry of cancel functions for running agent tasks.
@@ -85,11 +87,24 @@ func (rt *RunningTasks) Remove(repo string, issue int) {
 
 // serveOpts holds parsed CLI flags for the serve command.
 type serveOpts struct {
-	port         int
-	pollInterval time.Duration
-	roles        []string
-	configDir    string
-	dbPath       string
+	port             int
+	pollInterval     time.Duration
+	maxParallelTasks int
+	roles            []string
+	configDir        string
+	dbPath           string
+}
+
+// issueTaskLocks provides reusable per-issue mutexes so only one task per
+// repo+issue can execute at a time.
+type issueTaskLocks struct {
+	locks sync.Map // key: "repo#issueNum" -> *sync.Mutex
+}
+
+func (l *issueTaskLocks) For(repo string, issue int) *sync.Mutex {
+	key := runningTaskKey(repo, issue)
+	lock, _ := l.locks.LoadOrStore(key, &sync.Mutex{})
+	return lock.(*sync.Mutex)
 }
 
 // GHCLIReader implements poller.GHReader using the gh CLI.
@@ -201,6 +216,7 @@ Worker in the same process. Communication is via Go channels.`,
 func init() {
 	serveCmd.Flags().IntP("port", "p", defaultPort, "HTTP server port")
 	serveCmd.Flags().Duration("poll-interval", defaultPollInterval, "GitHub poll interval")
+	serveCmd.Flags().Int("max-parallel-tasks", defaultMaxParallelTasks, "Maximum number of embedded worker tasks to run in parallel across issues")
 	serveCmd.Flags().StringSlice("roles", []string{"dev", "test", "review"}, "Worker roles")
 	serveCmd.Flags().String("config-dir", ".github/workbuddy", "Configuration directory")
 	serveCmd.Flags().String("db-path", ".workbuddy/workbuddy.db", "SQLite database path")
@@ -220,16 +236,21 @@ func runServe(cmd *cobra.Command, _ []string) error {
 func parseServeFlags(cmd *cobra.Command) (*serveOpts, error) {
 	port, _ := cmd.Flags().GetInt("port")
 	pollInterval, _ := cmd.Flags().GetDuration("poll-interval")
+	maxParallelTasks, _ := cmd.Flags().GetInt("max-parallel-tasks")
 	roles, _ := cmd.Flags().GetStringSlice("roles")
 	configDir, _ := cmd.Flags().GetString("config-dir")
 	dbPath, _ := cmd.Flags().GetString("db-path")
+	if maxParallelTasks <= 0 {
+		return nil, fmt.Errorf("serve: --max-parallel-tasks must be > 0")
+	}
 
 	return &serveOpts{
-		port:         port,
-		pollInterval: pollInterval,
-		roles:        roles,
-		configDir:    configDir,
-		dbPath:       dbPath,
+		port:             port,
+		pollInterval:     pollInterval,
+		maxParallelTasks: maxParallelTasks,
+		roles:            roles,
+		configDir:        configDir,
+		dbPath:           dbPath,
 	}, nil
 }
 
@@ -237,6 +258,10 @@ func parseServeFlags(cmd *cobra.Command) (*serveOpts, error) {
 // ghReader and launcherOverride allow tests to inject mocks.
 // If parentCtx is non-nil, it is used instead of signal handling (for tests).
 func runServeWithOpts(opts *serveOpts, ghReader poller.GHReader, launcherOverride *launcher.Launcher, parentCtx ...context.Context) error {
+	if opts.maxParallelTasks <= 0 {
+		opts.maxParallelTasks = defaultEmbeddedWorkerParallelism()
+	}
+
 	// 1. Load config
 	cfg, warnings, err := config.LoadConfig(opts.configDir)
 	if err != nil {
@@ -439,7 +464,7 @@ func runServeWithOpts(opts *serveOpts, ghReader poller.GHReader, launcherOverrid
 	go func() {
 		defer wg.Done()
 		defer close(workerDone)
-		runEmbeddedWorker(ctx, taskCh, deps)
+		runEmbeddedWorker(ctx, taskCh, deps, opts.maxParallelTasks)
 	}()
 
 	// Print startup message
@@ -501,17 +526,53 @@ type workerDeps struct {
 	sessionsDir  string
 }
 
-// runEmbeddedWorker runs the embedded worker loop.
-func runEmbeddedWorker(ctx context.Context, taskCh <-chan router.WorkerTask, deps *workerDeps) {
+func defaultEmbeddedWorkerParallelism() int {
+	if runtime.NumCPU() < defaultMaxParallelTasks {
+		return runtime.NumCPU()
+	}
+	return defaultMaxParallelTasks
+}
+
+// runEmbeddedWorker runs the embedded worker loop with bounded cross-issue
+// parallelism while serializing tasks for the same repo+issue.
+func runEmbeddedWorker(ctx context.Context, taskCh <-chan router.WorkerTask, deps *workerDeps, maxParallelTasks int) {
+	if maxParallelTasks <= 0 {
+		maxParallelTasks = defaultEmbeddedWorkerParallelism()
+	}
+
+	issueLocks := &issueTaskLocks{}
+	parallelLimiter := make(chan struct{}, maxParallelTasks)
+	var wg sync.WaitGroup
+
 	for {
 		select {
 		case <-ctx.Done():
+			wg.Wait()
 			return
 		case task, ok := <-taskCh:
 			if !ok {
+				wg.Wait()
 				return
 			}
-			executeTask(ctx, task, deps)
+			wg.Add(1)
+			go func(task router.WorkerTask) {
+				defer wg.Done()
+
+				issueLock := issueLocks.For(task.Repo, task.IssueNum)
+				issueLock.Lock()
+				defer issueLock.Unlock()
+
+				// Take the global slot after the per-issue lock so queued work for
+				// one issue does not consume the shared parallelism budget.
+				select {
+				case parallelLimiter <- struct{}{}:
+				case <-ctx.Done():
+					return
+				}
+				defer func() { <-parallelLimiter }()
+
+				executeTask(ctx, task, deps)
+			}(task)
 		}
 	}
 }

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -187,6 +187,102 @@ func (m *mockCommentWriter) Comments() []string {
 	return append([]string(nil), m.comments...)
 }
 
+func setupFakeGHCLI(t *testing.T) {
+	t.Helper()
+	fakeBin := t.TempDir()
+	ghPath := filepath.Join(fakeBin, "gh")
+	writeFile(t, ghPath, "#!/bin/sh\nexit 0\n")
+	if err := os.Chmod(ghPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func newWorkerTestDeps(t *testing.T, rt *mockRuntime) (*workerDeps, *store.Store) {
+	t.Helper()
+	setupFakeGHCLI(t)
+
+	st, err := store.NewStore(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	lnch := launcher.NewLauncher()
+	lnch.Register(rt, config.RuntimeClaudeCode, config.RuntimeClaudeShot)
+
+	return &workerDeps{
+		launcher:     lnch,
+		auditor:      audit.NewAuditor(st, filepath.Join(t.TempDir(), "archive")),
+		reporter:     reporter.NewReporter(&mockCommentWriter{}),
+		store:        st,
+		sm:           statemachine.NewStateMachine(nil, st, nil, eventlog.NewEventLogger(st)),
+		workerID:     "worker-1",
+		cfg:          &config.FullConfig{Workflows: map[string]*config.WorkflowConfig{"dev-workflow": {MaxRetries: 3}}},
+		runningTasks: NewRunningTasks(),
+		sessionsDir:  filepath.Join(t.TempDir(), ".workbuddy", "sessions"),
+	}, st
+}
+
+func newWorkerTestTask(t *testing.T, st *store.Store, repo string, issueNum int, taskID string) router.WorkerTask {
+	t.Helper()
+
+	if err := st.InsertTask(store.TaskRecord{
+		ID:        taskID,
+		Repo:      repo,
+		IssueNum:  issueNum,
+		AgentName: "dev-agent",
+		Status:    store.TaskStatusRunning,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertIssueCache(store.IssueCache{
+		Repo:     repo,
+		IssueNum: issueNum,
+		Labels:   `["workbuddy","status:developing"]`,
+		State:    "open",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	return router.WorkerTask{
+		TaskID:    taskID,
+		Repo:      repo,
+		IssueNum:  issueNum,
+		AgentName: "dev-agent",
+		Agent: &config.AgentConfig{
+			Name:    "dev-agent",
+			Runtime: config.RuntimeClaudeCode,
+			Prompt:  "test prompt",
+		},
+		Workflow: "dev-workflow",
+		State:    "developing",
+		Context: &launcher.TaskContext{
+			Repo:    repo,
+			WorkDir: t.TempDir(),
+			Issue: launcher.IssueContext{
+				Number: issueNum,
+				Title:  fmt.Sprintf("Issue %d", issueNum),
+			},
+			Session: launcher.SessionContext{ID: "session-" + taskID},
+		},
+	}
+}
+
+func taskStatusesByID(t *testing.T, st *store.Store) map[string]string {
+	t.Helper()
+
+	tasks, err := st.QueryTasks("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	statuses := make(map[string]string, len(tasks))
+	for _, task := range tasks {
+		statuses[task.ID] = task.Status
+	}
+	return statuses
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -429,6 +525,232 @@ func TestRunningTasks_Concurrent(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
+}
+
+func TestRunEmbeddedWorker_ParallelAcrossIssues(t *testing.T) {
+	started := make(chan int, 2)
+	release := make(chan struct{})
+
+	mockRT := &mockRuntime{name: config.RuntimeClaudeCode, resultFn: func(_ context.Context, _ *config.AgentConfig, task *launcher.TaskContext) (*launcher.Result, error) {
+		started <- task.Issue.Number
+		<-release
+		return &launcher.Result{
+			ExitCode: 0,
+			Duration: 50 * time.Millisecond,
+			Meta:     map[string]string{},
+		}, nil
+	}}
+	deps, st := newWorkerTestDeps(t, mockRT)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	taskCh := make(chan router.WorkerTask, 2)
+	done := make(chan struct{})
+	go func() {
+		runEmbeddedWorker(ctx, taskCh, deps, 2)
+		close(done)
+	}()
+
+	taskCh <- newWorkerTestTask(t, st, "owner/repo", 1, "task-1")
+	taskCh <- newWorkerTestTask(t, st, "owner/repo", 2, "task-2")
+	close(taskCh)
+
+	seen := map[int]bool{}
+	for len(seen) < 2 {
+		select {
+		case issueNum := <-started:
+			seen[issueNum] = true
+		case <-time.After(2 * time.Second):
+			t.Fatalf("expected both issues to start concurrently, saw %v", seen)
+		}
+	}
+
+	close(release)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("embedded worker did not exit after completing tasks")
+	}
+
+	statuses := taskStatusesByID(t, st)
+	if statuses["task-1"] != store.TaskStatusCompleted {
+		t.Fatalf("task-1 status = %q, want %q", statuses["task-1"], store.TaskStatusCompleted)
+	}
+	if statuses["task-2"] != store.TaskStatusCompleted {
+		t.Fatalf("task-2 status = %q, want %q", statuses["task-2"], store.TaskStatusCompleted)
+	}
+}
+
+func TestRunEmbeddedWorker_SerializesTasksWithinIssue(t *testing.T) {
+	firstStarted := make(chan struct{}, 1)
+	secondStarted := make(chan struct{}, 1)
+	releaseFirst := make(chan struct{})
+	releaseSecond := make(chan struct{})
+
+	var mu sync.Mutex
+	callCount := 0
+	mockRT := &mockRuntime{name: config.RuntimeClaudeCode, resultFn: func(_ context.Context, _ *config.AgentConfig, _ *launcher.TaskContext) (*launcher.Result, error) {
+		mu.Lock()
+		callCount++
+		callNum := callCount
+		mu.Unlock()
+
+		switch callNum {
+		case 1:
+			firstStarted <- struct{}{}
+			<-releaseFirst
+		case 2:
+			secondStarted <- struct{}{}
+			<-releaseSecond
+		default:
+			t.Fatalf("unexpected runtime call %d", callNum)
+		}
+
+		return &launcher.Result{
+			ExitCode: 0,
+			Duration: 50 * time.Millisecond,
+			Meta:     map[string]string{},
+		}, nil
+	}}
+	deps, st := newWorkerTestDeps(t, mockRT)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	taskCh := make(chan router.WorkerTask, 2)
+	done := make(chan struct{})
+	go func() {
+		runEmbeddedWorker(ctx, taskCh, deps, 2)
+		close(done)
+	}()
+
+	taskCh <- newWorkerTestTask(t, st, "owner/repo", 7, "task-1")
+	taskCh <- newWorkerTestTask(t, st, "owner/repo", 7, "task-2")
+	close(taskCh)
+
+	select {
+	case <-firstStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first task did not start")
+	}
+
+	select {
+	case <-secondStarted:
+		t.Fatal("second task started before the first one completed")
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	close(releaseFirst)
+
+	select {
+	case <-secondStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second task did not start after the first one completed")
+	}
+
+	close(releaseSecond)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("embedded worker did not exit after serial tasks completed")
+	}
+
+	statuses := taskStatusesByID(t, st)
+	if statuses["task-1"] != store.TaskStatusCompleted {
+		t.Fatalf("task-1 status = %q, want %q", statuses["task-1"], store.TaskStatusCompleted)
+	}
+	if statuses["task-2"] != store.TaskStatusCompleted {
+		t.Fatalf("task-2 status = %q, want %q", statuses["task-2"], store.TaskStatusCompleted)
+	}
+}
+
+func TestRunEmbeddedWorker_CancelOnlyStopsMatchingIssue(t *testing.T) {
+	started := make(chan int, 2)
+	cancelled := make(chan int, 1)
+	releaseIssue2 := make(chan struct{})
+
+	mockRT := &mockRuntime{name: config.RuntimeClaudeCode, resultFn: func(ctx context.Context, _ *config.AgentConfig, task *launcher.TaskContext) (*launcher.Result, error) {
+		started <- task.Issue.Number
+		switch task.Issue.Number {
+		case 1:
+			<-ctx.Done()
+			cancelled <- task.Issue.Number
+			return nil, ctx.Err()
+		case 2:
+			<-releaseIssue2
+			return &launcher.Result{
+				ExitCode: 0,
+				Duration: 50 * time.Millisecond,
+				Meta:     map[string]string{},
+			}, nil
+		default:
+			t.Fatalf("unexpected issue number %d", task.Issue.Number)
+			return nil, nil
+		}
+	}}
+	deps, st := newWorkerTestDeps(t, mockRT)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	taskCh := make(chan router.WorkerTask, 2)
+	done := make(chan struct{})
+	go func() {
+		runEmbeddedWorker(ctx, taskCh, deps, 2)
+		close(done)
+	}()
+
+	taskCh <- newWorkerTestTask(t, st, "owner/repo", 1, "task-1")
+	taskCh <- newWorkerTestTask(t, st, "owner/repo", 2, "task-2")
+	close(taskCh)
+
+	seen := map[int]bool{}
+	for len(seen) < 2 {
+		select {
+		case issueNum := <-started:
+			seen[issueNum] = true
+		case <-time.After(2 * time.Second):
+			t.Fatalf("expected both issues to start before cancel, saw %v", seen)
+		}
+	}
+
+	if !deps.runningTasks.Cancel("owner/repo", 1) {
+		t.Fatal("expected cancel for issue #1 to succeed")
+	}
+
+	select {
+	case issueNum := <-cancelled:
+		if issueNum != 1 {
+			t.Fatalf("cancelled issue = %d, want 1", issueNum)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("issue #1 task was not cancelled")
+	}
+
+	select {
+	case <-time.After(250 * time.Millisecond):
+	case issueNum := <-cancelled:
+		t.Fatalf("unexpected additional cancellation for issue #%d", issueNum)
+	}
+
+	close(releaseIssue2)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("embedded worker did not exit after cancel test")
+	}
+
+	statuses := taskStatusesByID(t, st)
+	if statuses["task-1"] != store.TaskStatusFailed {
+		t.Fatalf("task-1 status = %q, want %q", statuses["task-1"], store.TaskStatusFailed)
+	}
+	if statuses["task-2"] != store.TaskStatusCompleted {
+		t.Fatalf("task-2 status = %q, want %q", statuses["task-2"], store.TaskStatusCompleted)
+	}
 }
 
 func TestExecuteTask_PersistsPartialResultOnRunError(t *testing.T) {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -220,6 +220,7 @@ func newWorkerTestDeps(t *testing.T, rt *mockRuntime) (*workerDeps, *store.Store
 		workerID:     "worker-1",
 		cfg:          &config.FullConfig{Workflows: map[string]*config.WorkflowConfig{"dev-workflow": {MaxRetries: 3}}},
 		runningTasks: NewRunningTasks(),
+		closedIssues: &closedIssues{},
 		sessionsDir:  filepath.Join(t.TempDir(), ".workbuddy", "sessions"),
 	}, st
 }
@@ -750,6 +751,89 @@ func TestRunEmbeddedWorker_CancelOnlyStopsMatchingIssue(t *testing.T) {
 	}
 	if statuses["task-2"] != store.TaskStatusCompleted {
 		t.Fatalf("task-2 status = %q, want %q", statuses["task-2"], store.TaskStatusCompleted)
+	}
+}
+
+func TestRunEmbeddedWorker_SkipsQueuedTaskAfterIssueClose(t *testing.T) {
+	firstStarted := make(chan struct{}, 1)
+	secondStarted := make(chan struct{}, 1)
+	releaseFirst := make(chan struct{})
+
+	var mu sync.Mutex
+	callCount := 0
+	mockRT := &mockRuntime{name: config.RuntimeClaudeCode, resultFn: func(ctx context.Context, _ *config.AgentConfig, _ *launcher.TaskContext) (*launcher.Result, error) {
+		mu.Lock()
+		callCount++
+		callNum := callCount
+		mu.Unlock()
+
+		switch callNum {
+		case 1:
+			firstStarted <- struct{}{}
+			<-ctx.Done()
+			<-releaseFirst
+			return nil, ctx.Err()
+		case 2:
+			secondStarted <- struct{}{}
+			return &launcher.Result{
+				ExitCode: 0,
+				Duration: 50 * time.Millisecond,
+				Meta:     map[string]string{},
+			}, nil
+		default:
+			t.Fatalf("unexpected runtime call %d", callNum)
+			return nil, nil
+		}
+	}}
+	deps, st := newWorkerTestDeps(t, mockRT)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	taskCh := make(chan router.WorkerTask, 2)
+	done := make(chan struct{})
+	go func() {
+		runEmbeddedWorker(ctx, taskCh, deps, 2)
+		close(done)
+	}()
+
+	taskCh <- newWorkerTestTask(t, st, "owner/repo", 9, "task-1")
+	taskCh <- newWorkerTestTask(t, st, "owner/repo", 9, "task-2")
+	close(taskCh)
+
+	select {
+	case <-firstStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first task did not start")
+	}
+
+	deps.closedIssues.MarkClosed("owner/repo", 9)
+	if err := st.DeleteIssueCache("owner/repo", 9); err != nil {
+		t.Fatal(err)
+	}
+	if !deps.runningTasks.Cancel("owner/repo", 9) {
+		t.Fatal("expected cancel for issue #9 to succeed")
+	}
+	close(releaseFirst)
+
+	select {
+	case <-secondStarted:
+		t.Fatal("queued same-issue task started after the issue was closed")
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("embedded worker did not exit after closing queued issue")
+	}
+
+	statuses := taskStatusesByID(t, st)
+	if statuses["task-1"] != store.TaskStatusFailed {
+		t.Fatalf("task-1 status = %q, want %q", statuses["task-1"], store.TaskStatusFailed)
+	}
+	if statuses["task-2"] != store.TaskStatusFailed {
+		t.Fatalf("task-2 status = %q, want %q", statuses["task-2"], store.TaskStatusFailed)
 	}
 }
 

--- a/decisions.md
+++ b/decisions.md
@@ -3,3 +3,4 @@
 ## 2026-04-15
 
 - `[L4]` Embedded worker scheduling now acquires the per-issue lock before taking a global parallel slot so queued work for one issue does not consume the shared concurrency budget and starve unrelated issues.
+- `[L2]` Closed issues are tracked in-process so same-issue tasks that were already queued but not yet executing are skipped after the current task is cancelled, matching the issue-close semantics without broadening cross-issue cancellation.

--- a/decisions.md
+++ b/decisions.md
@@ -1,0 +1,5 @@
+# Decisions
+
+## 2026-04-15
+
+- `[L4]` Embedded worker scheduling now acquires the per-issue lock before taking a global parallel slot so queued work for one issue does not consume the shared concurrency budget and starve unrelated issues.

--- a/docs/implemented/current-architecture.md
+++ b/docs/implemented/current-architecture.md
@@ -27,7 +27,7 @@
 5. Poller 事件进入 state machine。
 6. 进入带 `agent` 的状态时，state machine 发出 dispatch request。
 7. Router 创建 task，并通过 Go channel 发送给进程内 worker。
-8. Worker 调用 launcher 运行 agent 子进程。
+8. Worker 调用 launcher 运行 agent 子进程；不同 issue 可以并行执行，但同一 `repo#issue` 仍严格串行，并受 `--max-parallel-tasks` 全局限流。
 9. 结果写回 reporter、audit、store，并通过 `/sessions` 可查看。
 
 关键代码：

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -674,7 +674,8 @@ requirements:
       `workbuddy serve` — v0.1.0 single-process mode running both
       Coordinator and Worker in the same binary. Coordinator polls
       GitHub and manages state machine; embedded Worker executes
-      Claude Code via channel communication.
+      Claude Code via channel communication with bounded cross-issue
+      parallelism and per-issue serialization.
     priority: P0
     version: v0.1.0
     status: tested
@@ -690,6 +691,8 @@ requirements:
       - "AC-017-9: 重启恢复——启动时从 SQLite 读取 task_queue 中 status=running 的任务，标记为 failed（子进程已丢失），status=pending 的任务重新路由"
       - "AC-017-10: 集成测试：启动 serve → 发送 SIGTERM → 验证优雅退出；重启后 pending 任务重新路由"
       - "AC-017-11: E2E 集成测试（mock-based）：使用 mock GHExecutor 模拟完整闭环——创建 Issue → Agent mock 执行 → mock Agent 改 label → 状态机检测 → 下一个 Agent 触发 → 完成或重试上限触发 failed"
+      - "AC-017-12: 内嵌 Worker 支持 `--max-parallel-tasks` 限制跨 issue 的并发执行；不同 issue 的任务可并行推进"
+      - "AC-017-13: 同一 repo#issue 的任务必须串行执行；Issue 关闭时仅取消该 issue 当前运行中的任务，不影响其他 issue"
     code:
       - cmd/serve.go
       - internal/router/router.go


### PR DESCRIPTION
## Summary
- add `--max-parallel-tasks` and run embedded worker tasks concurrently across issues while keeping each `repo#issue` serialized
- wait for spawned worker goroutines during shutdown and keep per-issue cancel behavior wired through `RunningTasks`
- add worker-loop tests for cross-issue parallelism, same-issue serialization, and cancel isolation; update docs and requirement index

## Validation
- /home/ddq/go-sdk/go/bin/go build ./...
- /home/ddq/go-sdk/go/bin/go vet ./...
- /home/ddq/go-sdk/go/bin/go test ./... -count=1

Refs #19