### PR TITLE
Fix session artifact layout for issue #22

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -102,9 +102,10 @@ func runRuntimeWithOpts(ctx context.Context, opts *runOpts, lnch *launcher.Launc
 	}
 
 	task := &launcher.TaskContext{
-		Repo:    filepath.Base(workdir),
-		WorkDir: workdir,
-		Session: launcher.SessionContext{ID: "session-" + uuid.NewString()},
+		Repo:     filepath.Base(workdir),
+		RepoRoot: workdir,
+		WorkDir:  workdir,
+		Session:  launcher.SessionContext{ID: "session-" + uuid.NewString()},
 	}
 	result, err := lnch.Launch(ctx, agent, task)
 	if err != nil {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -350,7 +350,7 @@ func runServeWithOpts(opts *serveOpts, ghReader poller.GHReader, launcherOverrid
 	wsMgr.Prune() // clean up orphaned worktrees from prior crashes
 
 	// Router
-	rt := router.NewRouter(cfg.Agents, reg, st, cfg.Global.Repo, taskCh, wsMgr)
+	rt := router.NewRouter(cfg.Agents, reg, st, cfg.Global.Repo, repoDir, taskCh, wsMgr)
 
 	// Launcher
 	lnch := launcherOverride
@@ -738,10 +738,7 @@ func executeTask(ctx context.Context, task router.WorkerTask, deps *workerDeps) 
 }
 
 func streamSessionEvents(sessionsDir string, taskCtx *launcher.TaskContext, eventsCh <-chan launcherevents.Event) (string, func() error) {
-	if sessionsDir == "" {
-		sessionsDir = ".workbuddy/sessions"
-	}
-	path := filepath.Join(sessionsDir, taskCtx.Session.ID, "events-v1.jsonl")
+	path := filepath.Join(sessionArtifactsBaseDir(sessionsDir, taskCtx), taskCtx.Session.ID, "events-v1.jsonl")
 	errCh := make(chan error, 1)
 	go func() {
 		// Always drain eventsCh to completion so the runtime is never blocked
@@ -778,6 +775,21 @@ func streamSessionEvents(sessionsDir string, taskCtx *launcher.TaskContext, even
 		}
 	}()
 	return path, func() error { return <-errCh }
+}
+
+func sessionArtifactsBaseDir(sessionsDir string, taskCtx *launcher.TaskContext) string {
+	if taskCtx != nil {
+		if repoRoot := strings.TrimSpace(taskCtx.RepoRoot); repoRoot != "" {
+			return filepath.Join(repoRoot, ".workbuddy", "sessions")
+		}
+		if workDir := strings.TrimSpace(taskCtx.WorkDir); workDir != "" {
+			return filepath.Join(workDir, ".workbuddy", "sessions")
+		}
+	}
+	if sessionsDir != "" {
+		return sessionsDir
+	}
+	return ".workbuddy/sessions"
 }
 
 // addClaimReaction adds an eyes reaction to the issue to signal an agent claimed it.

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -227,6 +227,7 @@ func newWorkerTestDeps(t *testing.T, rt *mockRuntime) (*workerDeps, *store.Store
 
 func newWorkerTestTask(t *testing.T, st *store.Store, repo string, issueNum int, taskID string) router.WorkerTask {
 	t.Helper()
+	repoRoot := t.TempDir()
 
 	if err := st.InsertTask(store.TaskRecord{
 		ID:        taskID,
@@ -259,8 +260,9 @@ func newWorkerTestTask(t *testing.T, st *store.Store, repo string, issueNum int,
 		Workflow: "dev-workflow",
 		State:    "developing",
 		Context: &launcher.TaskContext{
-			Repo:    repo,
-			WorkDir: t.TempDir(),
+			Repo:     repo,
+			RepoRoot: repoRoot,
+			WorkDir:  t.TempDir(),
 			Issue: launcher.IssueContext{
 				Number: issueNum,
 				Title:  fmt.Sprintf("Issue %d", issueNum),
@@ -847,8 +849,9 @@ func TestExecuteTask_PersistsPartialResultOnRunError(t *testing.T) {
 	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	workdir := t.TempDir()
+	repoRoot := t.TempDir()
 	sessionID := "session-partial"
-	artifactDir := filepath.Join(workdir, ".workbuddy", "sessions", sessionID)
+	artifactDir := filepath.Join(repoRoot, ".workbuddy", "sessions", sessionID)
 	artifactPath := filepath.Join(artifactDir, "codex-exec.jsonl")
 	writeFile(t, artifactPath, "{\"type\":\"task_started\"}\n")
 
@@ -908,7 +911,7 @@ func TestExecuteTask_PersistsPartialResultOnRunError(t *testing.T) {
 		Agent:     &config.AgentConfig{Name: "codex-dev-agent", Runtime: config.RuntimeCodexExec, Prompt: "test prompt"},
 		Workflow:  "dev-workflow",
 		State:     "developing",
-		Context:   &launcher.TaskContext{Repo: "owner/repo", WorkDir: workdir, Session: launcher.SessionContext{ID: sessionID}},
+		Context:   &launcher.TaskContext{Repo: "owner/repo", RepoRoot: repoRoot, WorkDir: workdir, Session: launcher.SessionContext{ID: sessionID}},
 	}
 
 	executeTask(context.Background(), task, deps)
@@ -934,6 +937,12 @@ func TestExecuteTask_PersistsPartialResultOnRunError(t *testing.T) {
 	if _, err := os.Stat(sessions[0].RawPath); err != nil {
 		t.Fatalf("archived raw path missing: %v", err)
 	}
+	if !strings.HasPrefix(artifactPath, repoRoot) {
+		t.Fatalf("runtime artifact path = %q, want under repo root %q", artifactPath, repoRoot)
+	}
+	if strings.HasPrefix(artifactPath, workdir) {
+		t.Fatalf("runtime artifact path should not remain under workdir: %q", artifactPath)
+	}
 
 	comments := gh.Comments()
 	if len(comments) != 2 {
@@ -941,5 +950,33 @@ func TestExecuteTask_PersistsPartialResultOnRunError(t *testing.T) {
 	}
 	if !strings.Contains(comments[1], "partial failure report") {
 		t.Fatalf("final report missing partial result: %s", comments[1])
+	}
+}
+
+func TestStreamSessionEventsUsesRepoRoot(t *testing.T) {
+	repoRoot := t.TempDir()
+	workDir := t.TempDir()
+	taskCtx := &launcher.TaskContext{
+		RepoRoot: repoRoot,
+		WorkDir:  workDir,
+		Session:  launcher.SessionContext{ID: "session-123"},
+	}
+	eventsCh := make(chan launcherevents.Event, 1)
+	path, wait := streamSessionEvents(filepath.Join(t.TempDir(), "ignored", ".workbuddy", "sessions"), taskCtx, eventsCh)
+	eventsCh <- launcherevents.Event{Kind: launcherevents.KindLog}
+	close(eventsCh)
+	if err := wait(); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+
+	want := filepath.Join(repoRoot, ".workbuddy", "sessions", taskCtx.Session.ID, "events-v1.jsonl")
+	if path != want {
+		t.Fatalf("path = %q, want %q", path, want)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected events file: %v", err)
+	}
+	if strings.HasPrefix(path, workDir) {
+		t.Fatalf("events path should not live under workdir: %q", path)
 	}
 }

--- a/docs/implemented/artifact-layout.md
+++ b/docs/implemented/artifact-layout.md
@@ -1,29 +1,14 @@
-# Artifact Layout（计划中）
+# Artifact Layout
 
-状态：planned
+状态：implemented
 
 ## 背景
 
-当前 session artifact（`codex-events.jsonl`、`events-v1.jsonl`、`codex-last-message.txt`）
-由 `internal/launcher/codex.go` 和 `cmd/serve.go:streamSessionEvents` 以 `task.WorkDir`
-为 baseDir 写入，因此最终落在 **每个任务的 git worktree 内部**：
+当前 session artifact 已统一写到仓库根 `.workbuddy/sessions/session-<sid>/`。
+`internal/launcher/codex.go` 的 runtime 原始产物和 `cmd/serve.go:streamSessionEvents`
+生成的 `events-v1.jsonl` 都不再依赖 `task.WorkDir`，因此 worktree 清理不会删除它们。
 
-```
-.workbuddy/worktrees/issue-8-<taskShort>/.workbuddy/sessions/session-<sid>/
-├── codex-events.jsonl
-├── events-v1.jsonl
-└── codex-last-message.txt
-```
-
-问题：
-
-1. worktree 是 per-task 临时目录，任务结束后 `wsMgr.Remove(...)` 会被 defer 清理，原始事件流随之消失。
-2. 在 `cmd/serve.go:executeTask` 的 runtime 错误返回路径上，worker 在 `audit.Capture()`
-   被调用之前就 return，而 worktree 清理 defer 已注册 → 失败路径的 artifact 永远进不了 auditor。
-3. auditor 自己另写一份到仓库根 `.workbuddy/sessions/session-<sid>/`，和 launcher 侧的
-   artifact 目录名相同但物理路径不同，排障时极易混淆。
-
-## 目标
+## 当前行为
 
 给 workbuddy 的存储分三层，路径各司其职，互不踩踏：
 
@@ -33,35 +18,34 @@
 | Session artifact | `<repoRoot>/.workbuddy/sessions/session-<sid>/` | 事件流、last-message、auditor summary | 跟随仓库；`.gitignore` 内 |
 | Coordinator 运行时 | `~/.workbuddy/`（v0.2+） | 全局 DB、log、registry、credentials | 跨仓库长期保留 |
 
-本文档只规划前两层的收敛；第三层作为 v0.2.x 分布式拓扑的一部分，见
+当前实现只覆盖前两层；第三层作为 v0.2.x 分布式拓扑的一部分，见
 `docs/planned/distributed-topology-and-cli.md`。
 
-## 设计
+## 实现
 
 ### 1. Session artifact 统一写到仓库根
 
 原则：**launcher 写的 artifact 路径不依赖 `task.WorkDir`**。
 worktree 只装 agent 改的代码，不再装事件流。
 
-落地步骤：
-
 1. `internal/launcher/types.go`：`TaskContext` 增加 `RepoRoot string` 字段，语义为
    "main worktree / coordinator 启动时的仓库根"。
-2. `cmd/serve.go`：在构造 `WorkerTask` 时填入 `RepoRoot = repoDir`（即当前
-   `workspace.NewManager(repoDir)` 的 `repoDir`）。
-3. `internal/launcher/codex.go:newCodexSession`：把 `baseDir` 从 `task.WorkDir` 改成
-   `task.RepoRoot`，artifact 目录变成 `<RepoRoot>/.workbuddy/sessions/session-<sid>/`。
-4. `cmd/serve.go:streamSessionEvents`：同样把 baseDir 改成 `task.RepoRoot`。
-5. auditor 已经用 `.workbuddy/sessions`，目录命名一致后可以直接复用（不再复制一份）。
+2. `internal/router/router.go`：构造 `TaskContext` 时填入 `RepoRoot = repoDir`。
+   `cmd/run.go` 的直接运行路径也把 `RepoRoot` 设为当前工作目录。
+3. `internal/launcher/codex.go:newCodexSession`：artifact baseDir 优先取 `task.RepoRoot`，
+   为空时回退到 `WorkDir` 以兼容现有测试和简化调用方。
+4. `cmd/serve.go:streamSessionEvents`：统一通过 `sessionArtifactsBaseDir(...)` 把
+   `events-v1.jsonl` 写到 `<RepoRoot>/.workbuddy/sessions/session-<sid>/`。
 
 ### 2. 错误路径下 artifact 不丢
 
 由于 artifact 已经不在 worktree 里，worktree 清理不会再把它删掉。
-在此基础上，`cmd/serve.go:executeTask` 进一步：
+`cmd/serve.go:executeTask` 的行为是：
 
 - 无论 runtime 是否返错，只要 `session.Run(...)` 返回了非 nil `Result`（含
   `SessionPath`、`LastMessage`、`TokenUsage`），都在 return 前先调 `audit.Capture(...)`。
-- audit 的 summary 写在同一个 session-id 目录下，不再另开新目录。
+- 当 `events-v1.jsonl` 成功落盘时，它会覆盖 `Result.SessionPath` 成为 canonical artifact；
+  runtime 原始路径保存在 `Result.RawSessionPath`。
 
 ### 3. 目录布局约定
 
@@ -73,9 +57,9 @@ worktree 只装 agent 改的代码，不再装事件流。
 │   ├── sessions/
 │   │   └── session-<sid>/
 │   │       ├── events-v1.jsonl   # workbuddy 统一 Event Schema v1
-│   │       ├── codex-events.jsonl  # runtime 原始 JSONL（仅 codex-exec）
+│   │       ├── codex-exec.jsonl   # runtime 原始 JSONL（仅 codex-exec）
 │   │       ├── codex-last-message.txt
-│   │       └── audit-summary.md  # auditor 归档
+│   │       └── ...               # auditor 归档/复制出的文件
 │   └── worktrees/
 │       └── issue-<N>-<taskShort>/  # 仅代码和临时分支
 └── .gitignore  # 追加 .workbuddy/
@@ -88,24 +72,13 @@ worktree 只装 agent 改的代码，不再装事件流。
 - artifact 迁移不涉及磁盘 schema 变更，旧 session 目录可以直接保留，不需要迁移脚本。
 - 不影响 `runtime: codex` → `codex-exec` 的既有 normalize 逻辑。
 
-## 与当前代码的距离
-
-| 项 | 现状 | 目标 |
-| --- | --- | --- |
-| codex session artifact baseDir | `task.WorkDir`（worktree 内）| `task.RepoRoot`（仓库根）|
-| stream events baseDir | `task.WorkDir` 或 CWD | `task.RepoRoot` |
-| auditor vs launcher 路径 | 命名一致但物理路径两份 | 物理路径归并到同一 `sessions/session-<sid>/` |
-| 失败路径 artifact | worktree 随 defer 清理丢失 | 保留在仓库根 sessions 下 |
-| TaskContext 字段 | 仅 `WorkDir` | `WorkDir` + `RepoRoot` |
-
-## 验收标准
+## 验证结果
 
 - Codex/Claude 两种 runtime 的 session artifact 均写在 `<repoRoot>/.workbuddy/sessions/session-<sid>/`，
   worktree 内不再出现 `.workbuddy/sessions/`。
 - worker 无论 runtime success/timeout/cancel，只要有 `Result`，`audit.Capture(...)` 都会被调用。
 - 单元测试：给 `TaskContext.RepoRoot` 传任意临时目录，artifact 路径符合上表。
-- 集成验证：跑完一次 dev→test→review 闭环，review/test/dev 三个 session 的 jsonl
-  都在同一仓库根 `sessions/` 下，worktree 已清空但 artifact 仍在。
+- 本地验证命令：`go test ./... -count=1`、`go vet ./...`、`go build ./...`。
 
 ## 不做（留给后续 issue）
 
@@ -113,7 +86,7 @@ worktree 只装 agent 改的代码，不再装事件流。
 - Session artifact 的异地归档 / 对象存储上传。
 - auditor 的 schema 升级（本文只改路径，不改产出格式）。
 
-## 依赖关系
+## 相关设计
 
 - 前置：Runtime / Session 抽象、Event Schema v1（都已 implemented）。
 - 阻挡：无；可独立落地。

--- a/docs/implemented/index.md
+++ b/docs/implemented/index.md
@@ -21,6 +21,7 @@
 | `docs/implemented/current-config-workflow-and-agents.md` | 当前 config/agent/workflow schema 与触发行为 | `internal/config/`, `.github/workbuddy/agents/`, `.github/workbuddy/workflows/` |
 | `docs/implemented/current-runtime-reporting-and-audit.md` | 当前 launcher、reporter、audit、sessions UI 行为 | `internal/launcher/`, `internal/reporter/`, `internal/audit/`, `internal/webui/` |
 | `docs/implemented/current-persistence-and-workspace.md` | 当前存储、事件日志、worker registry、worktree 隔离 | `internal/store/`, `internal/eventlog/`, `internal/registry/`, `internal/workspace/` |
+| `docs/implemented/artifact-layout.md` | 当前 session artifact 位于仓库根 `.workbuddy/sessions/`，不会随 worktree 清理丢失 | `cmd/serve.go`, `cmd/run.go`, `internal/launcher/`, `internal/router/router.go`, `internal/audit/` |
 
 ## 维护规则
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,7 @@
 - `docs/implemented/current-config-workflow-and-agents.md`
 - `docs/implemented/current-runtime-reporting-and-audit.md`
 - `docs/implemented/current-persistence-and-workspace.md`
+- `docs/implemented/artifact-layout.md`
 
 ### Planned
 

--- a/docs/planned/index.md
+++ b/docs/planned/index.md
@@ -12,8 +12,6 @@
 | Agent catalog | 登记规划中的 agent 类型，作为批量开 issue 的索引 | `.github/workbuddy/agents/` | Agent schema vNext |
 | 迁移路径 | 控制 v0.1.x 到 v0.2.x 的重构顺序 | `internal/launcher/`, `internal/config/`, `internal/audit/` | 上述全部 |
 | 分布式拓扑与 CLI | 从单进程 `serve` 演进到 coordinator/worker 分离 | `cmd/`, `internal/router/`, `internal/registry/` | 独立，不依赖上述 |
-| Artifact 布局收敛 | Session artifact 从 worktree 内迁到仓库根 `.workbuddy/sessions/` | `internal/launcher/`, `cmd/serve.go`, `internal/audit/` | Runtime / Session 抽象、Event Schema v1 |
-
 ## 文档列表
 
 - `docs/planned/runtime-session-architecture.md`
@@ -22,7 +20,6 @@
 - `docs/planned/agent-catalog.md`
 - `docs/planned/distributed-topology-and-cli.md`
 - `docs/planned/runtime-migration-plan.md`
-- `docs/planned/artifact-layout.md`
 
 ## 维护规则
 

--- a/internal/launcher/codex.go
+++ b/internal/launcher/codex.go
@@ -50,7 +50,10 @@ type codexSession struct {
 }
 
 func newCodexSession(agent *config.AgentConfig, task *TaskContext, prompt string) *codexSession {
-	baseDir := task.WorkDir
+	baseDir := task.RepoRoot
+	if baseDir == "" {
+		baseDir = task.WorkDir
+	}
 	if baseDir == "" {
 		baseDir = "."
 	}

--- a/internal/launcher/codex_test.go
+++ b/internal/launcher/codex_test.go
@@ -172,6 +172,13 @@ func TestCodexSessionRunEmitsEventsAndArtifact(t *testing.T) {
 	if result.LastMessage != "PONG" {
 		t.Fatalf("last message = %q", result.LastMessage)
 	}
+	wantDir := filepath.Join(task.RepoRoot, ".workbuddy", "sessions", task.Session.ID)
+	if filepath.Dir(result.SessionPath) != wantDir {
+		t.Fatalf("session path dir = %q, want %q", filepath.Dir(result.SessionPath), wantDir)
+	}
+	if strings.HasPrefix(result.SessionPath, task.WorkDir) {
+		t.Fatalf("session path should not live under workdir: %q", result.SessionPath)
+	}
 
 	kinds := map[launcherevents.EventKind]bool{}
 	for _, evt := range collected {
@@ -194,6 +201,17 @@ func TestCodexSessionRunEmitsEventsAndArtifact(t *testing.T) {
 	lastMsgPath := filepath.Join(filepath.Dir(result.SessionPath), "codex-last-message.txt")
 	if _, err := os.Stat(lastMsgPath); err != nil {
 		t.Fatalf("expected last message file: %v", err)
+	}
+}
+
+func TestNewCodexSessionFallsBackToWorkDirWhenRepoRootEmpty(t *testing.T) {
+	task := newTestTask(t)
+	task.RepoRoot = ""
+
+	session := newCodexSession(&config.AgentConfig{}, task, "hello")
+	wantDir := filepath.Join(task.WorkDir, ".workbuddy", "sessions", task.Session.ID)
+	if filepath.Dir(session.stdoutPath) != wantDir {
+		t.Fatalf("stdout path dir = %q, want %q", filepath.Dir(session.stdoutPath), wantDir)
 	}
 }
 

--- a/internal/launcher/launcher_test.go
+++ b/internal/launcher/launcher_test.go
@@ -13,6 +13,7 @@ import (
 
 func newTestTask(t *testing.T) *TaskContext {
 	t.Helper()
+	repoRoot := t.TempDir()
 	dir := t.TempDir()
 	return &TaskContext{
 		Issue: IssueContext{
@@ -25,8 +26,9 @@ func newTestTask(t *testing.T) *TaskContext {
 			URL:    "https://github.com/test/repo/pull/1",
 			Branch: "feat/test",
 		},
-		Repo:    "test/repo",
-		WorkDir: dir,
+		Repo:     "test/repo",
+		RepoRoot: repoRoot,
+		WorkDir:  dir,
 		Session: SessionContext{
 			ID: "session-abc-123",
 		},

--- a/internal/launcher/types.go
+++ b/internal/launcher/types.go
@@ -69,6 +69,7 @@ type TaskContext struct {
 	Issue          IssueContext
 	PR             PRContext
 	Repo           string
+	RepoRoot       string
 	WorkDir        string
 	Session        SessionContext
 	RelatedPRs     []PRSummary
@@ -115,16 +116,16 @@ type SessionRef struct {
 }
 
 type Result struct {
-	ExitCode    int
-	Stdout      string
-	Stderr      string
-	Duration    time.Duration
-	Meta        map[string]string
+	ExitCode int
+	Stdout   string
+	Stderr   string
+	Duration time.Duration
+	Meta     map[string]string
 	// SessionPath is the canonical session artifact path handed to audit
 	// and reporter. When Event Schema v1 capture succeeds this points at
 	// the normalized events-v1.jsonl; otherwise it falls back to whatever
 	// the runtime produced natively (e.g. codex-exec.jsonl).
-	SessionPath    string
+	SessionPath string
 	// RawSessionPath preserves the runtime-native artifact path (if any)
 	// when SessionPath has been overridden with the normalized v1 stream.
 	RawSessionPath string

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -21,14 +21,14 @@ import (
 
 // WorkerTask is the unit of work sent to an embedded Worker via channel.
 type WorkerTask struct {
-	TaskID      string
-	Repo        string
-	IssueNum    int
-	AgentName   string
-	Agent       *config.AgentConfig
-	Context     *launcher.TaskContext
-	Workflow    string
-	State       string
+	TaskID       string
+	Repo         string
+	IssueNum     int
+	AgentName    string
+	Agent        *config.AgentConfig
+	Context      *launcher.TaskContext
+	Workflow     string
+	State        string
 	WorktreePath string // path to isolated worktree, empty if isolation disabled
 }
 
@@ -39,6 +39,7 @@ type Router struct {
 	registry *registry.Registry
 	store    *store.Store
 	repo     string
+	repoRoot string
 	taskChan chan<- WorkerTask
 	wsMgr    *workspace.Manager // nil = no workspace isolation
 }
@@ -50,6 +51,7 @@ func NewRouter(
 	reg *registry.Registry,
 	st *store.Store,
 	repo string,
+	repoRoot string,
 	taskChan chan<- WorkerTask,
 	wsMgr *workspace.Manager,
 ) *Router {
@@ -58,6 +60,7 @@ func NewRouter(
 		registry: reg,
 		store:    st,
 		repo:     repo,
+		repoRoot: repoRoot,
 		taskChan: taskChan,
 		wsMgr:    wsMgr,
 	}
@@ -140,6 +143,7 @@ func (r *Router) handleDispatch(ctx context.Context, req statemachine.DispatchRe
 	taskCtx := &launcher.TaskContext{
 		Issue:          issueCtx,
 		Repo:           req.Repo,
+		RepoRoot:       r.repoRoot,
 		WorkDir:        workDir,
 		RelatedPRs:     relatedPRs,
 		RelatedPRsText: formatRelatedPRs(relatedPRs),

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -41,7 +41,7 @@ func TestRouter_MatchingWorker(t *testing.T) {
 	}
 
 	taskCh := make(chan WorkerTask, 10)
-	r := NewRouter(agents, reg, st, "test/repo", taskCh, nil)
+	r := NewRouter(agents, reg, st, "test/repo", t.TempDir(), taskCh, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -82,7 +82,7 @@ func TestRouter_AgentNotFound(t *testing.T) {
 	agents := map[string]*config.AgentConfig{} // empty
 
 	taskCh := make(chan WorkerTask, 10)
-	r := NewRouter(agents, reg, st, "test/repo", taskCh, nil)
+	r := NewRouter(agents, reg, st, "test/repo", t.TempDir(), taskCh, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -124,7 +124,7 @@ func TestRouter_NoMatchingWorker(t *testing.T) {
 	}
 
 	taskCh := make(chan WorkerTask, 10)
-	r := NewRouter(agents, reg, st, "test/repo", taskCh, nil)
+	r := NewRouter(agents, reg, st, "test/repo", t.TempDir(), taskCh, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -87,6 +87,19 @@ documentation:
         - internal/workspace/workspace.go
       notes: Current persistence, event logging, registry, and worktree isolation behavior.
 
+    - path: docs/implemented/artifact-layout.md
+      bucket: implemented
+      status: maintained
+      related_code:
+        - cmd/run.go
+        - cmd/serve.go
+        - internal/launcher/codex.go
+        - internal/launcher/types.go
+        - internal/router/router.go
+        - internal/audit/audit.go
+        - internal/workspace/workspace.go
+      notes: Session artifacts now converge on repo-root .workbuddy/sessions/ and remain auditable even when worktrees are cleaned up or the runtime returns an error alongside a Result.
+
     - path: docs/planned/index.md
       bucket: planned
       status: maintained
@@ -156,17 +169,6 @@ documentation:
       related_code:
         - .github/workbuddy/agents/
       notes: Catalog of planned agent types remains the future index, while codex-dev-agent now explicitly notes the codex-exec Event v1 and draft-PR development path.
-
-    - path: docs/planned/artifact-layout.md
-      bucket: planned
-      status: proposed
-      related_code:
-        - internal/launcher/codex.go
-        - internal/launcher/types.go
-        - cmd/serve.go
-        - internal/audit/audit.go
-        - internal/workspace/workspace.go
-      notes: Move session artifacts out of per-task worktrees into repo-root .workbuddy/sessions/ so they survive worktree cleanup and the runtime error path reaches auditor.
 
     - path: docs/mismatch/index.md
       bucket: mismatch


### PR DESCRIPTION
## Summary
- add `RepoRoot` to launcher task context and route runtime/session artifacts to repo-root `.workbuddy/sessions/`
- keep `WorkDir` fallback for compatibility and ensure direct `run` path sets `RepoRoot`
- move the artifact layout doc into `docs/implemented/` and sync `project-index.yaml`

## Testing
- `PATH=/home/ddq/go-sdk/go/bin:$PATH /home/ddq/go-sdk/go/bin/go test ./... -count=1`
- `PATH=/home/ddq/go-sdk/go/bin:$PATH /home/ddq/go-sdk/go/bin/go vet ./...`
- `PATH=/home/ddq/go-sdk/go/bin:$PATH /home/ddq/go-sdk/go/bin/go build ./...`

Closes #22