### PR TITLE
Implement issue dependency mechanism

### DIFF
--- a/.github/workbuddy/agents/dependency-resolver-agent.md
+++ b/.github/workbuddy/agents/dependency-resolver-agent.md
@@ -1,0 +1,41 @@
+---
+name: dependency-resolver-agent
+description: Dependency resolver agent - reconciles blocked/unblocked dependency UX on GitHub from the local queue
+triggers:
+  - label: "status:blocked"
+    event: labeled
+role: maintenance
+runtime: codex
+policy:
+  sandbox: danger-full-access
+  approval: never
+  timeout: 15m
+prompt: |
+  You are the dependency resolver agent for repo {{.Repo}}.
+
+  ## Task
+  Reconcile the latest queued dependency state for issue #{{.Issue.Number}} onto GitHub.
+
+  ## Requirements
+  1. Read `.workbuddy/workbuddy.db` and select the latest `queued` row from `dependency_reconcile_queue` for `repo='{{.Repo}}'` and `issue_num={{.Issue.Number}}`.
+  2. Re-read the issue from GitHub with `gh issue view {{.Issue.Number}} --repo {{.Repo}} --json labels,comments`.
+  3. If label `override:force-unblock` is present, do not add `status:blocked`.
+  4. Converge labels with `gh issue edit`:
+     - When `desired_blocked=true`: remove `desired_resume_label` if present and add `status:blocked`.
+     - When `desired_blocked=false`: remove `status:blocked`; if `desired_resume_label` is non-empty, restore it.
+     - When `desired_needs_human=true`: add `needs-human`.
+  5. Upsert exactly one managed comment containing marker `<!-- workbuddy:dependency-status -->`.
+  6. Print only JSON matching the output contract.
+
+  ## Notes
+  - This agent owns dependency labels/comments only.
+  - Do not emit prose outside the final JSON object.
+output_contract:
+  schema_file: schemas/dependency-resolver-agent-result.json
+command: >
+  codex exec --skip-git-repo-check --sandbox danger-full-access --json "legacy compatibility shim"
+---
+
+## Dependency Resolver Agent
+
+Schedule-driven agent that applies dependency queue generations without expanding Go's GitHub write boundary.

--- a/.github/workbuddy/agents/schemas/dependency-resolver-agent-result.json
+++ b/.github/workbuddy/agents/schemas/dependency-resolver-agent-result.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "generation",
+    "status",
+    "comment_hash",
+    "comment_id"
+  ],
+  "properties": {
+    "generation": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "applied",
+        "failed"
+      ]
+    },
+    "comment_hash": {
+      "type": "string"
+    },
+    "comment_id": {
+      "type": "string"
+    },
+    "error": {
+      "type": "string"
+    }
+  }
+}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/Lincyaw/workbuddy/internal/audit"
 	"github.com/Lincyaw/workbuddy/internal/config"
+	"github.com/Lincyaw/workbuddy/internal/dependency"
 	"github.com/Lincyaw/workbuddy/internal/eventlog"
 	"github.com/Lincyaw/workbuddy/internal/labelcheck"
 	"github.com/Lincyaw/workbuddy/internal/launcher"
@@ -187,6 +188,25 @@ type ghIssueLabelsJSON struct {
 	} `json:"labels"`
 }
 
+type ghIssueDetailJSON struct {
+	Number      int    `json:"number"`
+	State       string `json:"state"`
+	StateReason string `json:"stateReason"`
+	Body        string `json:"body"`
+	Labels      struct {
+		Nodes []struct {
+			Name string `json:"name"`
+		} `json:"nodes"`
+	} `json:"labels"`
+	ClosedByPullRequestsReferences struct {
+		Nodes []struct {
+			Number int    `json:"number"`
+			State  string `json:"state"`
+			URL    string `json:"url"`
+		} `json:"nodes"`
+	} `json:"closedByPullRequestsReferences"`
+}
+
 // ghPRJSON matches the JSON output of gh pr list --json.
 type ghPRJSON struct {
 	Number      int    `json:"number"`
@@ -290,6 +310,47 @@ func (g *GHCLIReader) ReadIssueLabels(repo string, issueNum int) ([]string, erro
 		labels[i] = label.Name
 	}
 	return labels, nil
+}
+
+func (g *GHCLIReader) ReadIssue(repo string, issueNum int) (poller.IssueDetails, error) {
+	parts := strings.SplitN(repo, "/", 2)
+	if len(parts) != 2 {
+		return poller.IssueDetails{}, fmt.Errorf("invalid repo %q", repo)
+	}
+	query := `query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){issue(number:$number){number state stateReason body labels(first:100){nodes{name}} closedByPullRequestsReferences(first:10){nodes{number state url}}}}}`
+	cmd := exec.Command("gh", "api", "graphql",
+		"-f", "query="+query,
+		"-F", "owner="+parts[0],
+		"-F", "name="+parts[1],
+		"-F", fmt.Sprintf("number=%d", issueNum),
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		return poller.IssueDetails{}, fmt.Errorf("gh api graphql issue detail: %w", err)
+	}
+	var response struct {
+		Data struct {
+			Repository struct {
+				Issue ghIssueDetailJSON `json:"issue"`
+			} `json:"repository"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(out, &response); err != nil {
+		return poller.IssueDetails{}, fmt.Errorf("gh api graphql issue detail parse: %w", err)
+	}
+	issue := response.Data.Repository.Issue
+	labels := make([]string, len(issue.Labels.Nodes))
+	for i, label := range issue.Labels.Nodes {
+		labels[i] = label.Name
+	}
+	return poller.IssueDetails{
+		Number:           issue.Number,
+		State:            strings.ToLower(issue.State),
+		StateReason:      strings.ToLower(issue.StateReason),
+		Body:             issue.Body,
+		Labels:           labels,
+		ClosedByLinkedPR: len(issue.ClosedByPullRequestsReferences.Nodes) > 0,
+	}, nil
 }
 
 var serveCmd = &cobra.Command{
@@ -414,6 +475,7 @@ func runServeWithOpts(opts *serveOpts, ghReader poller.GHReader, launcherOverrid
 
 	// State machine
 	sm := statemachine.NewStateMachine(cfg.Workflows, st, dispatchCh, evlog)
+	depResolver := dependency.NewResolver(st, ghReader, evlog)
 
 	// Workspace isolation via git worktrees
 	wsMgr := workspace.NewManager(repoDir)
@@ -502,6 +564,41 @@ func runServeWithOpts(opts *serveOpts, ghReader poller.GHReader, launcherOverrid
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		var depsResolvedThisCycle bool
+		var depGraphVersion int64
+		runDependencyMaintenance := func(ctx context.Context) {
+			depGraphVersion++
+			if err := depResolver.EvaluateOpenIssues(ctx, cfg.Global.Repo, depGraphVersion); err != nil {
+				log.Printf("[serve] dependency resolver error: %v", err)
+				return
+			}
+			items, err := st.ListQueuedDependencyReconciles(cfg.Global.Repo, 100)
+			if err != nil {
+				log.Printf("[serve] dependency queue list error: %v", err)
+				return
+			}
+			for _, item := range items {
+				active, err := st.HasActiveTask(item.Repo, item.IssueNum, dependency.ResolverAgentName)
+				if err != nil {
+					log.Printf("[serve] dependency queue active-task check failed: %v", err)
+					continue
+				}
+				if active {
+					continue
+				}
+				select {
+				case dispatchCh <- statemachine.DispatchRequest{
+					Repo:      item.Repo,
+					IssueNum:  item.IssueNum,
+					AgentName: dependency.ResolverAgentName,
+					Workflow:  dependency.DependencySchedulerReason,
+					State:     dependency.DependencySchedulerReason,
+				}:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
 		for {
 			select {
 			case <-ctx.Done():
@@ -515,8 +612,16 @@ func runServeWithOpts(opts *serveOpts, ghReader poller.GHReader, launcherOverrid
 				// state. Without this, a label like status:developing that is
 				// re-added after a review bounce-back would be silently dropped.
 				if ev.Type == poller.EventPollCycleDone {
+					if !depsResolvedThisCycle {
+						runDependencyMaintenance(ctx)
+					}
+					depsResolvedThisCycle = false
 					sm.ResetDedup()
 					continue
+				}
+				if !depsResolvedThisCycle {
+					runDependencyMaintenance(ctx)
+					depsResolvedThisCycle = true
 				}
 				// Handle issue closure: cancel running agent and skip state machine.
 				if ev.Type == poller.EventIssueClosed {
@@ -727,14 +832,19 @@ func executeTask(ctx context.Context, task router.WorkerTask, deps *workerDeps) 
 	}
 	log.Printf("[worker] executing task %s: agent=%s issue=%s#%d",
 		task.TaskID, task.AgentName, task.Repo, task.IssueNum)
+	isDependencyResolver := task.AgentName == dependency.ResolverAgentName
 
 	// Add claim reaction (eyes) to signal this issue is being worked on.
-	addClaimReaction(taskCtx, task.Repo, task.IssueNum, task.AgentName)
+	if !isDependencyResolver {
+		addClaimReaction(taskCtx, task.Repo, task.IssueNum, task.AgentName)
+	}
 
 	// Post "Agent Started" comment with session link.
 	sessionID := task.Context.Session.ID
-	if err := deps.reporter.ReportStarted(task.Repo, task.IssueNum, task.AgentName, sessionID, deps.workerID); err != nil {
-		log.Printf("[worker] report started failed: %v", err)
+	if !isDependencyResolver {
+		if err := deps.reporter.ReportStarted(task.Repo, task.IssueNum, task.AgentName, sessionID, deps.workerID); err != nil {
+			log.Printf("[worker] report started failed: %v", err)
+		}
 	}
 
 	session, err := deps.launcher.Start(taskCtx, task.Agent, task.Context)
@@ -841,6 +951,11 @@ func executeTask(ctx context.Context, task router.WorkerTask, deps *workerDeps) 
 	if err := deps.auditor.Capture(sessionID, task.TaskID, task.Repo, task.IssueNum, task.AgentName, result); err != nil {
 		log.Printf("[worker] audit capture failed: %v", err)
 	}
+	if isDependencyResolver {
+		if err := handleDependencyResolverResult(task, deps, result, status); err != nil {
+			log.Printf("[worker] dependency resolver result handling failed: %v", err)
+		}
+	}
 
 	// Get retry count for reporting
 	retryCount := 0
@@ -859,9 +974,11 @@ func executeTask(ctx context.Context, task router.WorkerTask, deps *workerDeps) 
 	}
 
 	// Report to issue
-	if err := deps.reporter.Report(task.Repo, task.IssueNum, task.AgentName, result,
-		sessionID, deps.workerID, retryCount, maxRetries, labelSummary); err != nil {
-		log.Printf("[worker] report failed: %v", err)
+	if !isDependencyResolver {
+		if err := deps.reporter.Report(task.Repo, task.IssueNum, task.AgentName, result,
+			sessionID, deps.workerID, retryCount, maxRetries, labelSummary); err != nil {
+			log.Printf("[worker] report failed: %v", err)
+		}
 	}
 
 	// Mark agent completed in state machine
@@ -1053,6 +1170,46 @@ func exitCodeForValidation(result *launcher.Result) int {
 		return -1
 	}
 	return result.ExitCode
+}
+
+type dependencyResolverResult struct {
+	Generation  int64  `json:"generation"`
+	Status      string `json:"status"`
+	CommentHash string `json:"comment_hash"`
+	CommentID   string `json:"comment_id"`
+	Error       string `json:"error"`
+}
+
+func handleDependencyResolverResult(task router.WorkerTask, deps *workerDeps, result *launcher.Result, taskStatus string) error {
+	latest, err := deps.store.LatestDependencyReconcile(task.Repo, task.IssueNum)
+	if err != nil {
+		return err
+	}
+	if latest == nil {
+		return nil
+	}
+	if result == nil {
+		return deps.store.MarkDependencyReconcileFailed(task.Repo, task.IssueNum, latest.Generation, "missing_result")
+	}
+
+	var payload dependencyResolverResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(result.Stdout)), &payload); err != nil {
+		return deps.store.MarkDependencyReconcileFailed(task.Repo, task.IssueNum, latest.Generation, "invalid_json_output")
+	}
+	if payload.Generation == 0 {
+		payload.Generation = latest.Generation
+	}
+	if taskStatus == store.TaskStatusCompleted && payload.Status == store.DependencyQueueStatusApplied {
+		return deps.store.MarkDependencyReconcileApplied(task.Repo, task.IssueNum, payload.Generation, payload.CommentHash, payload.CommentID)
+	}
+	reason := strings.TrimSpace(payload.Error)
+	if reason == "" {
+		reason = strings.TrimSpace(payload.Status)
+	}
+	if reason == "" {
+		reason = "unknown"
+	}
+	return deps.store.MarkDependencyReconcileFailed(task.Repo, task.IssueNum, payload.Generation, reason)
 }
 
 func cloneLabels(labels []string) []string {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -50,10 +50,24 @@ timeout: 30s
 ---
 # Dev Agent
 `
+	dependencyResolverAgentMD := `---
+name: dependency-resolver-agent
+description: Dependency resolver
+triggers:
+  - label: "status:blocked"
+    event: labeled
+role: maintenance
+runtime: claude-code
+command: echo '{"generation":1,"status":"applied","comment_hash":"x","comment_id":"1"}'
+timeout: 30s
+---
+# Dependency Resolver Agent
+`
 	if err := os.MkdirAll(filepath.Join(dir, "agents"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	writeFile(t, filepath.Join(dir, "agents", "dev-agent.md"), agentMD)
+	writeFile(t, filepath.Join(dir, "agents", "dependency-resolver-agent.md"), dependencyResolverAgentMD)
 
 	// Workflow
 	workflowMD := `---
@@ -130,6 +144,22 @@ func (m *mockGHReader) ReadIssueLabels(_ string, _ int) ([]string, error) {
 	return append([]string(nil), m.labelSnapshots[idx]...), nil
 }
 
+func (m *mockGHReader) ReadIssue(_ string, issueNum int) (poller.IssueDetails, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, issue := range m.issues {
+		if issue.Number == issueNum {
+			return poller.IssueDetails{
+				Number: issueNum,
+				State:  issue.State,
+				Body:   issue.Body,
+				Labels: append([]string(nil), issue.Labels...),
+			}, nil
+		}
+	}
+	return poller.IssueDetails{Number: issueNum, State: "closed"}, nil
+}
+
 func (m *mockGHReader) SetIssues(issues []poller.Issue) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -141,6 +171,7 @@ type mockRuntime struct {
 	name     string
 	mu       sync.Mutex
 	calls    int
+	countFor string
 	resultFn func(ctx context.Context, agent *config.AgentConfig, task *launcher.TaskContext) (*launcher.Result, error)
 }
 
@@ -165,7 +196,9 @@ func (m *mockRuntime) Start(ctx context.Context, agent *config.AgentConfig, task
 
 func (m *mockRuntime) Launch(ctx context.Context, agent *config.AgentConfig, task *launcher.TaskContext) (*launcher.Result, error) {
 	m.mu.Lock()
-	m.calls++
+	if m.countFor == "" || (agent != nil && agent.Name == m.countFor) {
+		m.calls++
+	}
 	fn := m.resultFn
 	m.mu.Unlock()
 	if fn != nil {
@@ -279,6 +312,54 @@ func newWorkerTestDepsWithComments(t *testing.T, rt *mockRuntime, readers ...iss
 		sessionsDir:  filepath.Join(t.TempDir(), ".workbuddy", "sessions"),
 		issueReader:  issueReader,
 	}, st, comments
+}
+
+func TestServeDependencyGateBlocksUntilDependencyDone(t *testing.T) {
+	setupFakeGHCLI(t)
+	repo := "owner/repo"
+	configDir := setupTestConfigDir(t, repo)
+	rt := &mockRuntime{name: "mock", countFor: "dev-agent"}
+
+	gh := &mockGHReader{}
+	gh.onPoll = func(call int) {
+		switch call {
+		case 1:
+			gh.issues = []poller.Issue{
+				{Number: 1, Title: "A", State: "open", Labels: []string{"workbuddy", "status:triage"}},
+				{Number: 2, Title: "B", State: "open", Labels: []string{"workbuddy", "status:developing"}, Body: "```yaml\nworkbuddy:\n  depends_on:\n    - \"#1\"\n```"},
+			}
+		case 2:
+			gh.issues = []poller.Issue{
+				{Number: 1, Title: "A", State: "open", Labels: []string{"workbuddy", "status:done"}},
+				{Number: 2, Title: "B", State: "open", Labels: []string{"workbuddy", "status:blocked"}, Body: "```yaml\nworkbuddy:\n  depends_on:\n    - \"#1\"\n```"},
+			}
+		default:
+			gh.issues = []poller.Issue{
+				{Number: 1, Title: "A", State: "open", Labels: []string{"workbuddy", "status:done"}},
+				{Number: 2, Title: "B", State: "open", Labels: []string{"workbuddy", "status:developing"}, Body: "```yaml\nworkbuddy:\n  depends_on:\n    - \"#1\"\n```"},
+			}
+		}
+	}
+
+	lnch := launcher.NewLauncher()
+	lnch.Register(rt, config.RuntimeClaudeCode, config.RuntimeClaudeShot)
+	opts := &serveOpts{
+		port:             18939,
+		pollInterval:     40 * time.Millisecond,
+		maxParallelTasks: 1,
+		roles:            []string{"dev"},
+		configDir:        configDir,
+		dbPath:           filepath.Join(t.TempDir(), "workbuddy.db"),
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 1200*time.Millisecond)
+	defer cancel()
+
+	if err := runServeWithOpts(opts, gh, lnch, ctx); err != nil {
+		t.Fatalf("runServeWithOpts: %v", err)
+	}
+	if calls := rt.CallCount(); calls != 1 {
+		t.Fatalf("runtime call count=%d want 1", calls)
+	}
 }
 
 func newWorkerTestTask(t *testing.T, st *store.Store, repo string, issueNum int, taskID string) router.WorkerTask {

--- a/decisions.md
+++ b/decisions.md
@@ -6,3 +6,5 @@
 - `[L4]` Embedded worker scheduling now acquires the per-issue lock before taking a global parallel slot so queued work for one issue does not consume the shared concurrency budget and starve unrelated issues.
 - `[L2]` Closed issues are tracked in-process so same-issue tasks that were already queued but not yet executing are skipped after the current task is cancelled, matching the issue-close semantics without broadening cross-issue cancellation.
 - `[L2]` Claude prompt executions now use a dedicated `stream-json` mapping path for Event Schema v1, while generic shell-backed `claude-code` commands remain on the minimal compatibility path so existing launcher tests and workflows do not regress.
+- `[L2]` Issue dependency resolution now reads the settled per-cycle issue cache snapshot before dispatch, so dependency verdicts are computed from one coherent poll image instead of racing event emission order.
+- `[L4]` Closed dependency satisfaction uses GitHub GraphQL `closedByPullRequestsReferences` through `gh api graphql`; this keeps the reader on the gh CLI boundary while giving deterministic “closed via linked PR” semantics without adding raw HTTP clients.

--- a/docs/implemented/index.md
+++ b/docs/implemented/index.md
@@ -10,6 +10,7 @@
 | 执行模型 | Router 通过 channel 派发给内嵌 worker，runtime 已升级为 `Start(...) -> Session.Run(...)`，并保留 `Launch(...)` 兼容包装 | `internal/router/router.go`, `internal/launcher/types.go`, `internal/launcher/process.go` |
 | 配置模型 | 使用 `.github/workbuddy/` 下的 Markdown + YAML frontmatter | `internal/config/loader.go`, `internal/config/types.go` |
 | 工作流模型 | 以 issue label 为主驱动；Go 侧记录 retry/failure intent，agent 通过 `gh issue edit` 推进状态 | `internal/statemachine/statemachine.go`, `internal/store/store.go`, `.github/workbuddy/workflows/*.md` |
+| Issue 依赖 | 已支持 `workbuddy.depends_on` 解析、本地 verdict/queue、dispatch hard gate、以及 schedule-driven dependency resolver agent | `cmd/serve.go`, `internal/dependency/`, `internal/store/`, `internal/statemachine/`, `internal/router/`, `.github/workbuddy/agents/dependency-resolver-agent.md` |
 | 可观测性 | 已有 SQLite、event log、Event Schema v1 session artifact、session audit、`/sessions` Web UI | `internal/store/`, `internal/eventlog/`, `internal/launcher/`, `internal/audit/`, `internal/webui/` |
 | 工作区隔离 | 已支持每任务 git worktree 隔离 | `internal/workspace/workspace.go` |
 
@@ -26,6 +27,7 @@
 | `docs/implemented/event-schema-v1.md` | 当前 Event Schema v1 合同、runtime 映射、artifact 消费路径 | `internal/launcher/events/`, `internal/launcher/codex.go`, `internal/launcher/claude_stream.go`, `cmd/serve.go`, `internal/audit/`, `internal/webui/` |
 | `docs/implemented/current-persistence-and-workspace.md` | 当前存储、事件日志、worker registry、worktree 隔离 | `internal/store/`, `internal/eventlog/`, `internal/registry/`, `internal/workspace/` |
 | `docs/implemented/artifact-layout.md` | 当前 session artifact 位于仓库根 `.workbuddy/sessions/`，不会随 worktree 清理丢失 | `cmd/serve.go`, `cmd/run.go`, `internal/launcher/`, `internal/router/router.go`, `internal/audit/` |
+| `docs/implemented/issue-dependencies.md` | 当前 issue dependency 声明、resolver/store/queue、dispatch gate 与 dependency-resolver agent 行为 | `cmd/serve.go`, `internal/dependency/`, `internal/store/`, `internal/statemachine/`, `internal/router/`, `.github/workbuddy/agents/dependency-resolver-agent.md` |
 
 ## 维护规则
 

--- a/docs/implemented/issue-dependencies.md
+++ b/docs/implemented/issue-dependencies.md
@@ -1,6 +1,6 @@
 # Issue Dependency Mechanism
 
-状态：planned
+状态：implemented
 
 ## Goal
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,11 +35,11 @@
 - `docs/implemented/event-schema-v1.md`
 - `docs/implemented/current-persistence-and-workspace.md`
 - `docs/implemented/artifact-layout.md`
+- `docs/implemented/issue-dependencies.md`
 
 ### Planned
 
 - `docs/planned/index.md`
-- `docs/planned/issue-dependencies.md`
 - `docs/planned/distributed-topology-and-cli.md`
 - `docs/planned/runtime-migration-plan.md`
 

--- a/docs/planned/index.md
+++ b/docs/planned/index.md
@@ -7,12 +7,10 @@
 | 主题 | 目标 | 基线代码 | 依赖前置 |
 | --- | --- | --- | --- |
 | Long-lived runtime / pooling | 为长驻 runtime 增加 per-repo 生命周期、连接复用与 idle 回收 | `internal/launcher/`, `cmd/serve.go` | 现有 one-shot Session 抽象已完成 |
-| Issue dependency mechanism | 为 issue 增加声明式前置依赖、blocked/unblock 规则与可观测图查询 | `internal/poller/`, `internal/statemachine/`, `internal/router/`, `internal/store/` | 独立；与现有 workflow label 兼容 |
 | 迁移路径 | 控制 v0.1.x 到 v0.2.x 的重构顺序 | `internal/launcher/`, `internal/config/`, `internal/audit/` | 上述全部 |
 | 分布式拓扑与 CLI | 从单进程 `serve` 演进到 coordinator/worker 分离 | `cmd/`, `internal/router/`, `internal/registry/` | 独立，不依赖上述 |
 ## 文档列表
 
-- `docs/planned/issue-dependencies.md`
 - `docs/planned/distributed-topology-and-cli.md`
 - `docs/planned/runtime-migration-plan.md`
 

--- a/docs_consistency_test.go
+++ b/docs_consistency_test.go
@@ -173,8 +173,8 @@ func TestRetryFailureDocIndexesStaySynced(t *testing.T) {
 	}
 }
 
-func TestIssueDependenciesPlannedDocIndexed(t *testing.T) {
-	docPath := "docs/planned/issue-dependencies.md"
+func TestIssueDependenciesImplementedDocIndexed(t *testing.T) {
+	docPath := "docs/implemented/issue-dependencies.md"
 	docContent := readRepoFile(t, docPath)
 	assertContainsAll(t, docPath, docContent, []string{
 		"# Issue Dependency Mechanism",
@@ -196,7 +196,7 @@ func TestIssueDependenciesPlannedDocIndexed(t *testing.T) {
 
 	for _, path := range []string{
 		"docs/index.md",
-		"docs/planned/index.md",
+		"docs/implemented/index.md",
 	} {
 		if !strings.Contains(readRepoFile(t, path), docPath) {
 			t.Fatalf("%s missing %s", path, docPath)

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -168,6 +168,7 @@ func TestRepositorySampleConfig_LoadsExpandedAgentCatalog(t *testing.T) {
 		"docs-agent",
 		"security-audit-agent",
 		"dependency-bump-agent",
+		"dependency-resolver-agent",
 		"release-agent",
 	}
 	for _, name := range expectedAgents {

--- a/internal/dependency/dependency.go
+++ b/internal/dependency/dependency.go
@@ -1,0 +1,484 @@
+package dependency
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Lincyaw/workbuddy/internal/eventlog"
+	"github.com/Lincyaw/workbuddy/internal/poller"
+	"github.com/Lincyaw/workbuddy/internal/store"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	Marker                    = "<!-- workbuddy:dependency-status -->"
+	OverrideLabel             = "override:force-unblock"
+	StatusBlocked             = "status:blocked"
+	StatusDone                = "status:done"
+	StatusFailed              = "status:failed"
+	ResolverAgentName         = "dependency-resolver-agent"
+	DependencySchedulerReason = "dependency_reconcile"
+)
+
+var yamlFenceRe = regexp.MustCompile("(?s)```yaml\\s*\n(.*?)```")
+var fqIssueRefRe = regexp.MustCompile(`^([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)#([1-9][0-9]*)$`)
+
+type IssueReader interface {
+	ListIssues(repo string) ([]poller.Issue, error)
+	ReadIssue(repo string, issueNum int) (poller.IssueDetails, error)
+}
+
+type EventRecorder interface {
+	Log(eventType, repo string, issueNum int, payload interface{})
+}
+
+type ParsedDependency struct {
+	Raw              string
+	Repo             string
+	IssueNum         int
+	Status           string
+	Normalized       string
+	ParseErrorReason string
+}
+
+type ParsedDeclaration struct {
+	Dependencies []ParsedDependency
+	SourceHash   string
+	HasBlock     bool
+}
+
+type ResolveResult struct {
+	State store.IssueDependencyState
+	Queue store.DependencyReconcileQueueItem
+	Deps  []store.IssueDependency
+}
+
+type Resolver struct {
+	store    *store.Store
+	reader   IssueReader
+	eventlog EventRecorder
+}
+
+func NewResolver(st *store.Store, reader IssueReader, eventlog EventRecorder) *Resolver {
+	return &Resolver{store: st, reader: reader, eventlog: eventlog}
+}
+
+func ParseDeclaration(repo, body string) ParsedDeclaration {
+	matches := yamlFenceRe.FindAllStringSubmatch(body, -1)
+	for _, match := range matches {
+		var raw struct {
+			Workbuddy struct {
+				DependsOn []string `yaml:"depends_on"`
+			} `yaml:"workbuddy"`
+		}
+		if err := yaml.Unmarshal([]byte(match[1]), &raw); err != nil {
+			continue
+		}
+		if raw.Workbuddy.DependsOn == nil {
+			continue
+		}
+		decl := ParsedDeclaration{HasBlock: true}
+		seen := make(map[string]struct{})
+		for _, dep := range raw.Workbuddy.DependsOn {
+			parsed := normalizeDependency(repo, dep)
+			if parsed.Normalized != "" {
+				if _, ok := seen[parsed.Normalized]; ok {
+					continue
+				}
+				seen[parsed.Normalized] = struct{}{}
+			}
+			decl.Dependencies = append(decl.Dependencies, parsed)
+		}
+		sort.Slice(decl.Dependencies, func(i, j int) bool {
+			return decl.Dependencies[i].Normalized < decl.Dependencies[j].Normalized
+		})
+		decl.SourceHash = hashStrings(match[1], dependenciesSignature(decl.Dependencies))
+		return decl
+	}
+	return ParsedDeclaration{}
+}
+
+func (r *Resolver) EvaluateOpenIssues(ctx context.Context, repo string, graphVersion int64) error {
+	issues, err := r.store.ListIssueCaches(repo)
+	if err != nil {
+		return err
+	}
+	openIssues := make(map[int]poller.Issue, len(issues))
+	for _, cached := range issues {
+		if cached.State != "open" {
+			continue
+		}
+		openIssues[cached.IssueNum] = poller.Issue{
+			Number: cached.IssueNum,
+			Body:   cached.Body,
+			State:  cached.State,
+			Labels: labelsFromJSON(cached.Labels),
+		}
+	}
+
+	parsedDecls := make(map[int]ParsedDeclaration, len(openIssues))
+	graph := make(map[int][]int)
+	for num, issue := range openIssues {
+		decl := ParseDeclaration(repo, issue.Body)
+		parsedDecls[num] = decl
+		deps := make([]store.IssueDependency, 0, len(decl.Dependencies))
+		for _, dep := range decl.Dependencies {
+			deps = append(deps, store.IssueDependency{
+				Repo:              repo,
+				IssueNum:          num,
+				DependsOnRepo:     dep.Repo,
+				DependsOnIssueNum: dep.IssueNum,
+				SourceHash:        decl.SourceHash,
+				Status:            dep.Status,
+			})
+			if dep.Status == store.DependencyStatusActive && dep.Repo == repo {
+				graph[num] = append(graph[num], dep.IssueNum)
+			}
+		}
+		if err := r.store.ReplaceIssueDependencies(repo, num, deps); err != nil {
+			return err
+		}
+	}
+
+	cycles := detectCycles(graph)
+	closedCache := make(map[int]poller.IssueDetails)
+
+	for num, issue := range openIssues {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		result := buildResolveResult(repo, issue, parsedDecls[num], graphVersion, cycles[num], openIssues, closedCache, r.reader)
+		prev, err := r.store.QueryIssueDependencyState(repo, num)
+		if err != nil {
+			return err
+		}
+		if !parsedDecls[num].HasBlock && prev == nil {
+			continue
+		}
+		if prev != nil && prev.ResumeLabel != "" && result.State.ResumeLabel == "" {
+			result.State.ResumeLabel = prev.ResumeLabel
+			result.Queue.DesiredResumeLabel = prev.ResumeLabel
+		}
+		if err := r.store.UpsertIssueDependencyState(result.State); err != nil {
+			return err
+		}
+		enqueued, err := r.store.UpsertDependencyReconcile(result.Queue)
+		if err != nil {
+			return err
+		}
+		if prev == nil || prev.Verdict != result.State.Verdict || prev.BlockedReasonHash != result.State.BlockedReasonHash || prev.OverrideActive != result.State.OverrideActive {
+			r.eventlog.Log(eventlog.TypeDependencyVerdictChanged, repo, num, map[string]any{
+				"verdict":         result.State.Verdict,
+				"override_active": result.State.OverrideActive,
+				"graph_version":   graphVersion,
+			})
+		}
+		if cycles[num] != nil {
+			r.eventlog.Log(eventlog.TypeDependencyCycleDetected, repo, num, map[string]any{
+				"cycle_path": cycles[num],
+			})
+		}
+		if result.State.OverrideActive {
+			r.eventlog.Log(eventlog.TypeDependencyOverrideActivated, repo, num, map[string]any{
+				"resume_label": result.State.ResumeLabel,
+			})
+		}
+		if enqueued {
+			r.eventlog.Log(eventlog.TypeDependencyQueueQueued, repo, num, map[string]any{
+				"generation_hint": graphVersion,
+				"verdict":         result.State.Verdict,
+			})
+		}
+	}
+
+	return nil
+}
+
+func buildResolveResult(
+	repo string,
+	issue poller.Issue,
+	decl ParsedDeclaration,
+	graphVersion int64,
+	cyclePath []string,
+	openIssues map[int]poller.Issue,
+	closedCache map[int]poller.IssueDetails,
+	reader IssueReader,
+) ResolveResult {
+	reasons := make([]string, 0)
+	commentLines := []string{Marker, "", fmt.Sprintf("Issue `%s#%d` dependency verdict: `%s`.", repo, issue.Number, store.DependencyVerdictReady)}
+	verdict := store.DependencyVerdictReady
+	needsHuman := false
+	overrideActive := hasLabel(issue.Labels, OverrideLabel)
+	resumeLabel := findResumeLabel(issue.Labels, "")
+
+	if len(decl.Dependencies) > 0 {
+		commentLines = []string{Marker, "", "Dependencies:"}
+	}
+	if len(cyclePath) > 0 {
+		verdict = store.DependencyVerdictNeedsHuman
+		needsHuman = true
+		reasons = append(reasons, "cycle:"+strings.Join(cyclePath, " -> "))
+		commentLines = append(commentLines, fmt.Sprintf("- cycle detected: `%s`", strings.Join(cyclePath, " -> ")))
+	}
+
+	for _, dep := range decl.Dependencies {
+		status := "open"
+		switch dep.Status {
+		case store.DependencyStatusUnsupportedCrossRepo:
+			status = "unsupported-cross-repo"
+			verdict = store.DependencyVerdictNeedsHuman
+			needsHuman = true
+			reasons = append(reasons, dep.Normalized+":"+status)
+		case store.DependencyStatusInvalid:
+			status = "invalid"
+			verdict = store.DependencyVerdictNeedsHuman
+			needsHuman = true
+			reasons = append(reasons, dep.Raw+":"+dep.ParseErrorReason)
+		default:
+			if depIssue, ok := openIssues[dep.IssueNum]; ok && dep.Repo == repo {
+				status = classifyOpenDependency(depIssue.Labels)
+				if status != "done" {
+					if status == "failed" {
+						reasons = append(reasons, dep.Normalized+":failed")
+					} else {
+						reasons = append(reasons, dep.Normalized+":open")
+					}
+					if verdict == store.DependencyVerdictReady {
+						verdict = store.DependencyVerdictBlocked
+					}
+				}
+			} else {
+				detail, ok := closedCache[dep.IssueNum]
+				if !ok && dep.Repo == repo {
+					read, err := reader.ReadIssue(repo, dep.IssueNum)
+					if err == nil {
+						detail = read
+						closedCache[dep.IssueNum] = detail
+						ok = true
+					}
+				}
+				if ok && detail.State == "closed" && detail.ClosedByLinkedPR {
+					status = "done"
+				} else if ok && detail.State == "closed" {
+					status = "closed-without-linked-pr"
+					reasons = append(reasons, dep.Normalized+":"+status)
+					if verdict == store.DependencyVerdictReady {
+						verdict = store.DependencyVerdictBlocked
+					}
+				} else {
+					status = "invalid"
+					verdict = store.DependencyVerdictNeedsHuman
+					needsHuman = true
+					reasons = append(reasons, dep.Normalized+":unreadable")
+				}
+			}
+		}
+		label := dep.Normalized
+		if label == "" {
+			label = dep.Raw
+		}
+		commentLines = append(commentLines, fmt.Sprintf("- `%s`: `%s`", label, status))
+	}
+
+	if overrideActive {
+		verdict = store.DependencyVerdictOverride
+		needsHuman = false
+		commentLines = append(commentLines, "", "Override active via `override:force-unblock`.")
+	}
+
+	commentLines[2] = fmt.Sprintf("Issue `%s#%d` dependency verdict: `%s`.", repo, issue.Number, verdict)
+	if len(commentLines) == 3 {
+		commentLines = append(commentLines, "", "No active dependencies.")
+	}
+
+	commentBody := strings.Join(commentLines, "\n")
+	reasonHash := hashStrings(reasons...)
+	commentHash := hashStrings(commentBody)
+
+	state := store.IssueDependencyState{
+		Repo:              repo,
+		IssueNum:          issue.Number,
+		Verdict:           verdict,
+		ResumeLabel:       resumeLabel,
+		BlockedReasonHash: reasonHash,
+		OverrideActive:    overrideActive,
+		GraphVersion:      graphVersion,
+		LastCommentHash:   commentHash,
+		LastEvaluatedAt:   time.Now(),
+	}
+	queue := store.DependencyReconcileQueueItem{
+		Repo:               repo,
+		IssueNum:           issue.Number,
+		DesiredBlocked:     verdict == store.DependencyVerdictBlocked || verdict == store.DependencyVerdictNeedsHuman,
+		DesiredResumeLabel: resumeLabel,
+		DesiredNeedsHuman:  needsHuman,
+		DesiredCommentBody: commentBody,
+		DesiredCommentHash: commentHash,
+	}
+	return ResolveResult{State: state, Queue: queue}
+}
+
+func normalizeDependency(repo, raw string) ParsedDependency {
+	raw = strings.TrimSpace(raw)
+	parsed := ParsedDependency{Raw: raw}
+	switch {
+	case strings.HasPrefix(raw, "#"):
+		var num int
+		if _, err := fmt.Sscanf(raw, "#%d", &num); err != nil || num <= 0 {
+			parsed.Status = store.DependencyStatusInvalid
+			parsed.ParseErrorReason = "invalid_issue_number"
+			return parsed
+		}
+		parsed.Repo = repo
+		parsed.IssueNum = num
+		parsed.Status = store.DependencyStatusActive
+	case fqIssueRefRe.MatchString(raw):
+		match := fqIssueRefRe.FindStringSubmatch(raw)
+		var num int
+		if _, err := fmt.Sscanf(match[3], "%d", &num); err != nil || num <= 0 {
+			parsed.Status = store.DependencyStatusInvalid
+			parsed.ParseErrorReason = "invalid_repo_issue"
+			return parsed
+		}
+		parsed.Repo = match[1] + "/" + match[2]
+		parsed.IssueNum = num
+		if parsed.Repo == repo {
+			parsed.Status = store.DependencyStatusActive
+		} else {
+			parsed.Status = store.DependencyStatusUnsupportedCrossRepo
+		}
+	default:
+		parsed.Status = store.DependencyStatusInvalid
+		parsed.ParseErrorReason = "invalid_format"
+	}
+	if parsed.Repo != "" && parsed.IssueNum > 0 {
+		parsed.Normalized = fmt.Sprintf("%s#%d", parsed.Repo, parsed.IssueNum)
+	}
+	return parsed
+}
+
+func detectCycles(graph map[int][]int) map[int][]string {
+	type color int
+	const (
+		white color = iota
+		gray
+		black
+	)
+	colors := make(map[int]color, len(graph))
+	stack := make([]int, 0)
+	out := make(map[int][]string)
+	var visit func(int)
+	visit = func(node int) {
+		colors[node] = gray
+		stack = append(stack, node)
+		for _, next := range graph[node] {
+			switch colors[next] {
+			case white:
+				visit(next)
+			case gray:
+				path := extractCyclePath(stack, next)
+				for _, n := range path {
+					out[n] = formatCycle(path)
+				}
+			}
+		}
+		stack = stack[:len(stack)-1]
+		colors[node] = black
+	}
+	keys := make([]int, 0, len(graph))
+	for node := range graph {
+		keys = append(keys, node)
+	}
+	sort.Ints(keys)
+	for _, node := range keys {
+		if colors[node] == white {
+			visit(node)
+		}
+	}
+	return out
+}
+
+func extractCyclePath(stack []int, target int) []int {
+	start := 0
+	for i, n := range stack {
+		if n == target {
+			start = i
+			break
+		}
+	}
+	path := append([]int(nil), stack[start:]...)
+	path = append(path, target)
+	return path
+}
+
+func formatCycle(path []int) []string {
+	out := make([]string, len(path))
+	for i, n := range path {
+		out[i] = fmt.Sprintf("#%d", n)
+	}
+	return out
+}
+
+func classifyOpenDependency(labels []string) string {
+	switch {
+	case hasLabel(labels, StatusDone):
+		return "done"
+	case hasLabel(labels, StatusFailed):
+		return "failed"
+	default:
+		return "open"
+	}
+}
+
+func hasLabel(labels []string, want string) bool {
+	for _, label := range labels {
+		if label == want {
+			return true
+		}
+	}
+	return false
+}
+
+func findResumeLabel(labels []string, fallback string) string {
+	for _, label := range labels {
+		if strings.HasPrefix(label, "status:") && label != StatusBlocked {
+			return label
+		}
+	}
+	return fallback
+}
+
+func hashStrings(parts ...string) string {
+	h := sha256.New()
+	for _, part := range parts {
+		_, _ = h.Write([]byte(part))
+		_, _ = h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func dependenciesSignature(deps []ParsedDependency) string {
+	data, _ := json.Marshal(deps)
+	return string(data)
+}
+
+func labelsFromJSON(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	var labels []string
+	if err := json.Unmarshal([]byte(raw), &labels); err != nil {
+		return nil
+	}
+	return labels
+}

--- a/internal/dependency/dependency_test.go
+++ b/internal/dependency/dependency_test.go
@@ -1,0 +1,239 @@
+package dependency
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Lincyaw/workbuddy/internal/eventlog"
+	"github.com/Lincyaw/workbuddy/internal/poller"
+	"github.com/Lincyaw/workbuddy/internal/store"
+)
+
+type fakeReader struct {
+	details map[int]poller.IssueDetails
+}
+
+func (f *fakeReader) ListIssues(string) ([]poller.Issue, error) { return nil, nil }
+
+func (f *fakeReader) ReadIssue(_ string, issueNum int) (poller.IssueDetails, error) {
+	if detail, ok := f.details[issueNum]; ok {
+		return detail, nil
+	}
+	return poller.IssueDetails{}, nil
+}
+
+func newTestStore(t *testing.T) *store.Store {
+	t.Helper()
+	st, err := store.NewStore(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return st
+}
+
+func TestParseDeclaration(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		deps     []string
+		statuses []string
+		hasBlock bool
+	}{
+		{
+			name:     "local and fqdn normalized",
+			body:     "```yaml\nworkbuddy:\n  depends_on:\n    - \"#12\"\n    - \"Lincyaw/workbuddy#9\"\n```",
+			deps:     []string{"Lincyaw/workbuddy#12", "Lincyaw/workbuddy#9"},
+			statuses: []string{store.DependencyStatusActive, store.DependencyStatusActive},
+			hasBlock: true,
+		},
+		{
+			name:     "cross repo unsupported",
+			body:     "```yaml\nworkbuddy:\n  depends_on:\n    - \"other/repo#7\"\n```",
+			deps:     []string{"other/repo#7"},
+			statuses: []string{store.DependencyStatusUnsupportedCrossRepo},
+			hasBlock: true,
+		},
+		{
+			name:     "malformed ignored",
+			body:     "```yaml\nworkbuddy:\n  depends_on: nope\n```",
+			hasBlock: false,
+		},
+		{
+			name:     "natural language ignored",
+			body:     "depends on #12",
+			hasBlock: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseDeclaration("Lincyaw/workbuddy", tt.body)
+			if got.HasBlock != tt.hasBlock {
+				t.Fatalf("HasBlock=%v want %v", got.HasBlock, tt.hasBlock)
+			}
+			if len(got.Dependencies) != len(tt.deps) {
+				t.Fatalf("len deps=%d want %d", len(got.Dependencies), len(tt.deps))
+			}
+			for i, dep := range got.Dependencies {
+				if dep.Normalized != tt.deps[i] {
+					t.Fatalf("dep[%d]=%q want %q", i, dep.Normalized, tt.deps[i])
+				}
+				if dep.Status != tt.statuses[i] {
+					t.Fatalf("dep[%d] status=%q want %q", i, dep.Status, tt.statuses[i])
+				}
+			}
+		})
+	}
+}
+
+func TestDetectCycles(t *testing.T) {
+	graph := map[int][]int{
+		1: {2},
+		2: {3},
+		3: {1},
+		4: {5},
+	}
+	cycles := detectCycles(graph)
+	for _, node := range []int{1, 2, 3} {
+		if len(cycles[node]) == 0 {
+			t.Fatalf("node %d should be in cycle", node)
+		}
+	}
+	if len(cycles[4]) != 0 {
+		t.Fatalf("node 4 unexpectedly in cycle: %v", cycles[4])
+	}
+}
+
+func TestBuildResolveResultVerdicts(t *testing.T) {
+	openIssues := map[int]poller.Issue{
+		1: {Number: 1, Labels: []string{"status:developing"}},
+		2: {Number: 2, Labels: []string{"status:done"}},
+		3: {Number: 3, Labels: []string{"status:failed"}},
+		4: {Number: 4, Labels: []string{"status:developing", OverrideLabel}},
+	}
+	reader := &fakeReader{details: map[int]poller.IssueDetails{
+		5: {Number: 5, State: "closed", ClosedByLinkedPR: true},
+	}}
+	closedCache := map[int]poller.IssueDetails{}
+
+	tests := []struct {
+		name    string
+		issue   poller.Issue
+		decl    ParsedDeclaration
+		cycle   []string
+		want    string
+		needNH  bool
+		blocked bool
+	}{
+		{
+			name:  "ready when dep done",
+			issue: openIssues[1],
+			decl:  ParsedDeclaration{Dependencies: []ParsedDependency{{Raw: "#2", Repo: "owner/repo", IssueNum: 2, Status: store.DependencyStatusActive, Normalized: "owner/repo#2"}}},
+			want:  store.DependencyVerdictReady,
+		},
+		{
+			name:    "blocked when dep open",
+			issue:   openIssues[1],
+			decl:    ParsedDeclaration{Dependencies: []ParsedDependency{{Raw: "#3", Repo: "owner/repo", IssueNum: 3, Status: store.DependencyStatusActive, Normalized: "owner/repo#3"}}},
+			want:    store.DependencyVerdictBlocked,
+			blocked: true,
+		},
+		{
+			name:   "override wins",
+			issue:  openIssues[4],
+			decl:   ParsedDeclaration{Dependencies: []ParsedDependency{{Raw: "#3", Repo: "owner/repo", IssueNum: 3, Status: store.DependencyStatusActive, Normalized: "owner/repo#3"}}},
+			want:   store.DependencyVerdictOverride,
+			needNH: false,
+		},
+		{
+			name:    "needs human on cycle",
+			issue:   openIssues[1],
+			decl:    ParsedDeclaration{Dependencies: []ParsedDependency{{Raw: "#2", Repo: "owner/repo", IssueNum: 2, Status: store.DependencyStatusActive, Normalized: "owner/repo#2"}}},
+			cycle:   []string{"#1", "#2", "#1"},
+			want:    store.DependencyVerdictNeedsHuman,
+			needNH:  true,
+			blocked: true,
+		},
+		{
+			name:  "ready when closed via pr",
+			issue: openIssues[1],
+			decl:  ParsedDeclaration{Dependencies: []ParsedDependency{{Raw: "#5", Repo: "owner/repo", IssueNum: 5, Status: store.DependencyStatusActive, Normalized: "owner/repo#5"}}},
+			want:  store.DependencyVerdictReady,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildResolveResult("owner/repo", tt.issue, tt.decl, 1, tt.cycle, openIssues, closedCache, reader)
+			if result.State.Verdict != tt.want {
+				t.Fatalf("verdict=%q want %q", result.State.Verdict, tt.want)
+			}
+			if result.Queue.DesiredNeedsHuman != tt.needNH {
+				t.Fatalf("needsHuman=%v want %v", result.Queue.DesiredNeedsHuman, tt.needNH)
+			}
+			if result.Queue.DesiredBlocked != tt.blocked {
+				t.Fatalf("blocked=%v want %v", result.Queue.DesiredBlocked, tt.blocked)
+			}
+		})
+	}
+}
+
+func TestResolverEvaluateOpenIssuesEnqueuesIdempotently(t *testing.T) {
+	st := newTestStore(t)
+	if err := st.UpsertIssueCache(store.IssueCache{
+		Repo:     "owner/repo",
+		IssueNum: 2,
+		Labels:   `["status:done"]`,
+		Body:     "",
+		State:    "open",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertIssueCache(store.IssueCache{
+		Repo:     "owner/repo",
+		IssueNum: 3,
+		Labels:   `["status:developing"]`,
+		Body:     "```yaml\nworkbuddy:\n  depends_on:\n    - \"#2\"\n```",
+		State:    "open",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	resolver := NewResolver(st, &fakeReader{}, eventlog.NewEventLogger(st))
+	if err := resolver.EvaluateOpenIssues(context.Background(), "owner/repo", 1); err != nil {
+		t.Fatalf("EvaluateOpenIssues: %v", err)
+	}
+	queue, err := st.ListQueuedDependencyReconciles("owner/repo", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(queue) != 1 {
+		t.Fatalf("queued items=%d want 1", len(queue))
+	}
+	firstGen := queue[0].Generation
+
+	if err := resolver.EvaluateOpenIssues(context.Background(), "owner/repo", 2); err != nil {
+		t.Fatalf("EvaluateOpenIssues second run: %v", err)
+	}
+	queue, err = st.ListQueuedDependencyReconciles("owner/repo", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(queue) != 1 || queue[0].Generation != firstGen {
+		t.Fatalf("queue should remain idempotent, got %+v", queue)
+	}
+
+	state, err := st.QueryIssueDependencyState("owner/repo", 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state == nil || state.Verdict != store.DependencyVerdictReady {
+		t.Fatalf("state verdict=%v", state)
+	}
+	if !strings.Contains(queue[0].DesiredCommentBody, Marker) {
+		t.Fatalf("managed comment missing marker: %s", queue[0].DesiredCommentBody)
+	}
+}

--- a/internal/eventlog/eventlog.go
+++ b/internal/eventlog/eventlog.go
@@ -27,6 +27,10 @@ const (
 	TypeTransitionToFailed     = "transition_to_failed"
 	TypeStuckDetected          = "stuck_detected"
 	TypeDispatchSkippedInflight = "dispatch_skipped_inflight"
+	TypeDependencyVerdictChanged = "dependency_verdict_changed"
+	TypeDependencyQueueQueued    = "dependency_queue_queued"
+	TypeDependencyCycleDetected  = "dependency_cycle_detected"
+	TypeDependencyOverrideActivated = "dependency_override_activated"
 )
 
 // AllEventTypes lists every recognised event type.
@@ -46,6 +50,10 @@ var AllEventTypes = []string{
 	TypeTransitionToFailed,
 	TypeStuckDetected,
 	TypeDispatchSkippedInflight,
+	TypeDependencyVerdictChanged,
+	TypeDependencyQueueQueued,
+	TypeDependencyCycleDetected,
+	TypeDependencyOverrideActivated,
 }
 
 // EventFilter specifies optional criteria for querying events.

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -210,39 +210,39 @@ func (p *Poller) poll(ctx context.Context) {
 	// since issues beyond the first page would be falsely classified as closed.
 	if len(issues) >= ghListLimit {
 		log.Printf("[poller] issue list may be truncated (%d results), skipping close detection", len(issues))
-		return
-	}
-	openIssueNums := make(map[int]bool, len(issues))
-	for _, iss := range issues {
-		openIssueNums[iss.Number] = true
-	}
-	// Also include PR numbers so we don't treat them as closed issues.
-	openPRNums := make(map[int]bool, len(prs))
-	for _, pr := range prs {
-		openPRNums[pr.Number] = true
-	}
+	} else {
+		openIssueNums := make(map[int]bool, len(issues))
+		for _, iss := range issues {
+			openIssueNums[iss.Number] = true
+		}
+		// Also include PR numbers so we don't treat them as closed issues.
+		openPRNums := make(map[int]bool, len(prs))
+		for _, pr := range prs {
+			openPRNums[pr.Number] = true
+		}
 
-	cachedNums, err := p.store.ListCachedIssueNums(p.repo)
-	if err != nil {
-		log.Printf("[poller] error listing cached issue nums for %s: %v", p.repo, err)
-		return
-	}
-
-	for _, num := range cachedNums {
-		if ctx.Err() != nil {
+		cachedNums, err := p.store.ListCachedIssueNums(p.repo)
+		if err != nil {
+			log.Printf("[poller] error listing cached issue nums for %s: %v", p.repo, err)
 			return
 		}
-		if openIssueNums[num] || openPRNums[num] {
-			continue
-		}
-		pending = append(pending, ChangeEvent{
-			Type:     EventIssueClosed,
-			Repo:     p.repo,
-			IssueNum: num,
-			Detail:   "issue no longer in open issues list",
-		})
-		if err := p.store.DeleteIssueCache(p.repo, num); err != nil {
-			log.Printf("[poller] error deleting cache for closed issue %s#%d: %v", p.repo, num, err)
+
+		for _, num := range cachedNums {
+			if ctx.Err() != nil {
+				return
+			}
+			if openIssueNums[num] || openPRNums[num] {
+				continue
+			}
+			pending = append(pending, ChangeEvent{
+				Type:     EventIssueClosed,
+				Repo:     p.repo,
+				IssueNum: num,
+				Detail:   "issue no longer in open issues list",
+			})
+			if err := p.store.DeleteIssueCache(p.repo, num); err != nil {
+				log.Printf("[poller] error deleting cache for closed issue %s#%d: %v", p.repo, num, err)
+			}
 		}
 	}
 	for _, ev := range pending {

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -57,6 +57,15 @@ type PR struct {
 	State  string `json:"state"`
 }
 
+type IssueDetails struct {
+	Number           int
+	State            string
+	StateReason      string
+	Body             string
+	Labels           []string
+	ClosedByLinkedPR bool
+}
+
 // ChangeEvent describes a detected change between two polls.
 type ChangeEvent struct {
 	Type     string // EventIssueCreated, EventLabelAdded, EventLabelRemoved, EventPRCreated, EventPRStateChanged
@@ -75,6 +84,7 @@ type GHReader interface {
 	ListIssues(repo string) ([]Issue, error)
 	ListPRs(repo string) ([]PR, error)
 	CheckRepoAccess(repo string) error
+	ReadIssue(repo string, issueNum int) (IssueDetails, error)
 }
 
 // ---------------------------------------------------------------------------
@@ -156,6 +166,7 @@ func (p *Poller) Run(ctx context.Context) error {
 // per-cycle boundary signal (e.g. to reset dedup state).
 func (p *Poller) poll(ctx context.Context) {
 	defer p.emit(ctx, ChangeEvent{Type: EventPollCycleDone, Repo: p.repo})
+	var pending []ChangeEvent
 	// --- Issues ---
 	issues, err := p.gh.ListIssues(p.repo)
 	if err != nil {
@@ -171,7 +182,7 @@ func (p *Poller) poll(ctx context.Context) {
 		if ctx.Err() != nil {
 			return
 		}
-		p.diffIssue(ctx, iss)
+		pending = append(pending, p.diffIssue(iss)...)
 	}
 
 	// --- PRs ---
@@ -189,7 +200,7 @@ func (p *Poller) poll(ctx context.Context) {
 		if ctx.Err() != nil {
 			return
 		}
-		p.diffPR(ctx, pr)
+		pending = append(pending, p.diffPR(pr)...)
 	}
 
 	// --- Detect closed/deleted issues ---
@@ -224,8 +235,7 @@ func (p *Poller) poll(ctx context.Context) {
 		if openIssueNums[num] || openPRNums[num] {
 			continue
 		}
-		// This issue was in cache but not in current poll results — it was closed/deleted.
-		p.emit(ctx, ChangeEvent{
+		pending = append(pending, ChangeEvent{
 			Type:     EventIssueClosed,
 			Repo:     p.repo,
 			IssueNum: num,
@@ -235,21 +245,27 @@ func (p *Poller) poll(ctx context.Context) {
 			log.Printf("[poller] error deleting cache for closed issue %s#%d: %v", p.repo, num, err)
 		}
 	}
+	for _, ev := range pending {
+		if ctx.Err() != nil {
+			return
+		}
+		p.emit(ctx, ev)
+	}
 }
 
 // diffIssue compares a live issue against the cache and emits change events.
-func (p *Poller) diffIssue(ctx context.Context, iss Issue) {
+func (p *Poller) diffIssue(iss Issue) []ChangeEvent {
 	labelsJSON := labelsToJSON(iss.Labels)
+	var events []ChangeEvent
 
 	cached, err := p.store.QueryIssueCache(p.repo, iss.Number)
 	if err != nil {
 		log.Printf("[poller] error querying cache for %s#%d: %v", p.repo, iss.Number, err)
-		return
+		return nil
 	}
 
 	if cached == nil {
-		// New issue (or first sync after restart).
-		p.emit(ctx, ChangeEvent{
+		events = append(events, ChangeEvent{
 			Type:     EventIssueCreated,
 			Repo:     p.repo,
 			IssueNum: iss.Number,
@@ -261,7 +277,7 @@ func (p *Poller) diffIssue(ctx context.Context, iss Issue) {
 		oldLabels := labelsFromJSON(cached.Labels)
 		added, removed := diffLabels(oldLabels, iss.Labels)
 		for _, l := range added {
-			p.emit(ctx, ChangeEvent{
+			events = append(events, ChangeEvent{
 				Type:     EventLabelAdded,
 				Repo:     p.repo,
 				IssueNum: iss.Number,
@@ -270,7 +286,7 @@ func (p *Poller) diffIssue(ctx context.Context, iss Issue) {
 			})
 		}
 		for _, l := range removed {
-			p.emit(ctx, ChangeEvent{
+			events = append(events, ChangeEvent{
 				Type:     EventLabelRemoved,
 				Repo:     p.repo,
 				IssueNum: iss.Number,
@@ -285,14 +301,16 @@ func (p *Poller) diffIssue(ctx context.Context, iss Issue) {
 		Repo:     p.repo,
 		IssueNum: iss.Number,
 		Labels:   labelsJSON,
+		Body:     iss.Body,
 		State:    iss.State,
 	}); err != nil {
 		log.Printf("[poller] error upserting cache for %s#%d: %v", p.repo, iss.Number, err)
 	}
+	return events
 }
 
 // diffPR compares a live PR against the cache and emits change events.
-func (p *Poller) diffPR(ctx context.Context, pr PR) {
+func (p *Poller) diffPR(pr PR) []ChangeEvent {
 	// PRs are cached with negative number to avoid collision with issues.
 	// Actually, PR numbers are distinct from issue numbers on GitHub, but
 	// to be safe we use a "pr:" prefix in the state field.
@@ -301,19 +319,19 @@ func (p *Poller) diffPR(ctx context.Context, pr PR) {
 	cached, err := p.store.QueryIssueCache(p.repo, pr.Number)
 	if err != nil {
 		log.Printf("[poller] error querying cache for PR %s#%d: %v", p.repo, pr.Number, err)
-		return
+		return nil
 	}
+	var events []ChangeEvent
 
 	if cached == nil {
-		p.emit(ctx, ChangeEvent{
+		events = append(events, ChangeEvent{
 			Type:     EventPRCreated,
 			Repo:     p.repo,
 			IssueNum: pr.Number,
 			Detail:   pr.Branch,
 		})
 	} else if cached.State != stateVal {
-		// Detect state changes (checks, reviews show as state changes).
-		p.emit(ctx, ChangeEvent{
+		events = append(events, ChangeEvent{
 			Type:     EventPRStateChanged,
 			Repo:     p.repo,
 			IssueNum: pr.Number,
@@ -326,10 +344,12 @@ func (p *Poller) diffPR(ctx context.Context, pr PR) {
 		Repo:     p.repo,
 		IssueNum: pr.Number,
 		Labels:   "",
+		Body:     "",
 		State:    stateVal,
 	}); err != nil {
 		log.Printf("[poller] error upserting cache for PR %s#%d: %v", p.repo, pr.Number, err)
 	}
+	return events
 }
 
 // emit sends a ChangeEvent on the events channel, respecting context cancellation.

--- a/internal/poller/poller_test.go
+++ b/internal/poller/poller_test.go
@@ -550,6 +550,56 @@ func TestPollEmitsCycleDoneSentinel(t *testing.T) {
 	}
 }
 
+func TestPollTruncatedIssueListStillEmitsBufferedEvents(t *testing.T) {
+	st := testStore(t)
+	if err := st.UpsertIssueCache(store.IssueCache{
+		Repo:     "owner/repo",
+		IssueNum: 1,
+		Labels:   `["bug"]`,
+		State:    "open",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	issues := make([]Issue, 0, ghListLimit)
+	issues = append(issues, Issue{Number: 1, Title: "Bug report", State: "open", Labels: []string{"enhancement"}})
+	for i := 2; i <= ghListLimit; i++ {
+		issues = append(issues, Issue{Number: i, Title: fmt.Sprintf("Issue %d", i), State: "open"})
+	}
+
+	gh := &mockGHReader{
+		issues: issues,
+		prs: []PR{
+			{Number: 10, URL: "https://github.com/owner/repo/pull/10", Branch: "feature", State: "open"},
+		},
+	}
+	p := NewPoller(gh, st, "owner/repo", time.Hour)
+
+	ctx := context.Background()
+	p.poll(ctx)
+	events := drain(p.Events(), 500*time.Millisecond)
+
+	var sawLabelAdded, sawLabelRemoved, sawPREvent, sawUnexpectedClose bool
+	for _, ev := range events {
+		switch {
+		case ev.Type == EventLabelAdded && ev.IssueNum == 1 && ev.Detail == "enhancement":
+			sawLabelAdded = true
+		case ev.Type == EventLabelRemoved && ev.IssueNum == 1 && ev.Detail == "bug":
+			sawLabelRemoved = true
+		case (ev.Type == EventPRCreated || ev.Type == EventPRStateChanged) && ev.IssueNum == 10:
+			sawPREvent = true
+		case ev.Type == EventIssueClosed:
+			sawUnexpectedClose = true
+		}
+	}
+	if !sawLabelAdded || !sawLabelRemoved || !sawPREvent {
+		t.Fatalf("expected buffered label/pr events to flush under truncation, got %+v", events)
+	}
+	if sawUnexpectedClose {
+		t.Fatalf("unexpected issue_closed under truncated issue list: %+v", events)
+	}
+}
+
 func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }

--- a/internal/poller/poller_test.go
+++ b/internal/poller/poller_test.go
@@ -39,6 +39,10 @@ func (m *mockGHReader) CheckRepoAccess(_ string) error {
 	return m.accessErr
 }
 
+func (m *mockGHReader) ReadIssue(_ string, issueNum int) (IssueDetails, error) {
+	return IssueDetails{Number: issueNum, State: "open"}, nil
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -88,6 +88,17 @@ func (r *Router) handleDispatch(ctx context.Context, req statemachine.DispatchRe
 		log.Printf("[router] agent %q not found, skipping dispatch for %s#%d", req.AgentName, req.Repo, req.IssueNum)
 		return
 	}
+	if req.AgentName != "dependency-resolver-agent" {
+		depState, err := r.store.QueryIssueDependencyState(req.Repo, req.IssueNum)
+		if err != nil {
+			log.Printf("[router] failed to query dependency state for %s#%d: %v", req.Repo, req.IssueNum, err)
+			return
+		}
+		if depState != nil && (depState.Verdict == store.DependencyVerdictBlocked || depState.Verdict == store.DependencyVerdictNeedsHuman) {
+			log.Printf("[router] blocked dispatch for %s#%d due to dependency verdict %q", req.Repo, req.IssueNum, depState.Verdict)
+			return
+		}
+	}
 
 	taskID := uuid.New().String()
 

--- a/internal/statemachine/statemachine.go
+++ b/internal/statemachine/statemachine.go
@@ -272,6 +272,19 @@ func (sm *StateMachine) processWorkflowEvent(ctx context.Context, wf *config.Wor
 func (sm *StateMachine) dispatchAgent(ctx context.Context, repo string, issueNum int, agentName, workflow, state string) error {
 	issueKey := fmt.Sprintf("%s#%d", repo, issueNum)
 
+	depState, err := sm.store.QueryIssueDependencyState(repo, issueNum)
+	if err != nil {
+		return fmt.Errorf("statemachine: query dependency state: %w", err)
+	}
+	if depState != nil && (depState.Verdict == store.DependencyVerdictBlocked || depState.Verdict == store.DependencyVerdictNeedsHuman) {
+		sm.eventlog.Log(eventlog.TypeDependencyQueueQueued, repo, issueNum, map[string]string{
+			"reason":  "dispatch_blocked",
+			"verdict": depState.Verdict,
+			"agent":   agentName,
+		})
+		return nil
+	}
+
 	// Execution mutex: don't dispatch if agent is already running.
 	sm.inflightMu.Lock()
 	if sm.inflight[issueKey] {

--- a/internal/statemachine/statemachine_test.go
+++ b/internal/statemachine/statemachine_test.go
@@ -603,6 +603,34 @@ func TestDispatchRespectsContext(t *testing.T) {
 	}
 }
 
+func TestDispatchBlockedByDependencyVerdict(t *testing.T) {
+	sm, _, dispatch := newTestSM(t)
+	if err := sm.store.UpsertIssueDependencyState(store.IssueDependencyState{
+		Repo:     "test/repo",
+		IssueNum: 77,
+		Verdict:  store.DependencyVerdictBlocked,
+	}); err != nil {
+		t.Fatalf("UpsertIssueDependencyState: %v", err)
+	}
+
+	err := sm.HandleEvent(context.Background(), ChangeEvent{
+		Type:     poller.EventLabelAdded,
+		Repo:     "test/repo",
+		IssueNum: 77,
+		Labels:   []string{"workbuddy", "status:developing"},
+		Detail:   "status:developing",
+	})
+	if err != nil {
+		t.Fatalf("HandleEvent: %v", err)
+	}
+
+	select {
+	case req := <-dispatch:
+		t.Fatalf("unexpected dispatch: %+v", req)
+	default:
+	}
+}
+
 // Test 10: ResetDedup is safe for concurrent access
 func TestResetDedupConcurrent(t *testing.T) {
 	sm, _, _ := newTestSM(t)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	_ "modernc.org/sqlite" // sqlite driver
@@ -124,6 +125,7 @@ func (s *Store) createTables() error {
 			repo TEXT NOT NULL,
 			issue_num INTEGER NOT NULL,
 			labels TEXT,
+			body TEXT NOT NULL DEFAULT '',
 			state TEXT,
 			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 			PRIMARY KEY (repo, issue_num)
@@ -139,11 +141,51 @@ func (s *Store) createTables() error {
 			raw_path TEXT,
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 		)`,
+		`CREATE TABLE IF NOT EXISTS issue_dependencies (
+			repo TEXT NOT NULL,
+			issue_num INTEGER NOT NULL,
+			depends_on_repo TEXT NOT NULL,
+			depends_on_issue_num INTEGER NOT NULL,
+			source_hash TEXT NOT NULL,
+			status TEXT NOT NULL,
+			PRIMARY KEY (repo, issue_num, depends_on_repo, depends_on_issue_num)
+		)`,
+		`CREATE TABLE IF NOT EXISTS issue_dependency_state (
+			repo TEXT NOT NULL,
+			issue_num INTEGER NOT NULL,
+			verdict TEXT NOT NULL,
+			resume_label TEXT,
+			blocked_reason_hash TEXT,
+			override_active INTEGER NOT NULL DEFAULT 0,
+			graph_version INTEGER NOT NULL DEFAULT 0,
+			last_comment_hash TEXT,
+			last_comment_id TEXT,
+			last_evaluated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (repo, issue_num)
+		)`,
+		`CREATE TABLE IF NOT EXISTS dependency_reconcile_queue (
+			repo TEXT NOT NULL,
+			issue_num INTEGER NOT NULL,
+			generation INTEGER NOT NULL,
+			desired_blocked INTEGER NOT NULL DEFAULT 0,
+			desired_resume_label TEXT,
+			desired_needs_human INTEGER NOT NULL DEFAULT 0,
+			desired_comment_body TEXT,
+			desired_comment_hash TEXT,
+			status TEXT NOT NULL,
+			requested_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			applied_at DATETIME,
+			last_error TEXT,
+			PRIMARY KEY (repo, issue_num, generation)
+		)`,
 	}
 	for _, stmt := range stmts {
 		if _, err := s.db.Exec(stmt); err != nil {
 			return fmt.Errorf("exec %q: %w", stmt[:40], err)
 		}
+	}
+	if _, err := s.db.Exec(`ALTER TABLE issue_cache ADD COLUMN body TEXT NOT NULL DEFAULT ''`); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+		return fmt.Errorf("store: alter issue_cache add body: %w", err)
 	}
 	return nil
 }
@@ -380,11 +422,11 @@ func (s *Store) QueryTransitionCounts(repo string, issueNum int) ([]TransitionCo
 // UpsertIssueCache inserts or updates the cached state of an issue.
 func (s *Store) UpsertIssueCache(ic IssueCache) error {
 	_, err := s.db.Exec(
-		`INSERT INTO issue_cache (repo, issue_num, labels, state, updated_at)
-		 VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+		`INSERT INTO issue_cache (repo, issue_num, labels, body, state, updated_at)
+		 VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
 		 ON CONFLICT (repo, issue_num)
-		 DO UPDATE SET labels = excluded.labels, state = excluded.state, updated_at = CURRENT_TIMESTAMP`,
-		ic.Repo, ic.IssueNum, ic.Labels, ic.State,
+		 DO UPDATE SET labels = excluded.labels, body = excluded.body, state = excluded.state, updated_at = CURRENT_TIMESTAMP`,
+		ic.Repo, ic.IssueNum, ic.Labels, ic.Body, ic.State,
 	)
 	if err != nil {
 		return fmt.Errorf("store: upsert issue cache: %w", err)
@@ -432,9 +474,9 @@ func (s *Store) QueryIssueCache(repo string, issueNum int) (*IssueCache, error) 
 	var ic IssueCache
 	var updatedAt string
 	err := s.db.QueryRow(
-		`SELECT repo, issue_num, labels, state, updated_at FROM issue_cache WHERE repo = ? AND issue_num = ?`,
+		`SELECT repo, issue_num, labels, body, state, updated_at FROM issue_cache WHERE repo = ? AND issue_num = ?`,
 		repo, issueNum,
-	).Scan(&ic.Repo, &ic.IssueNum, &ic.Labels, &ic.State, &updatedAt)
+	).Scan(&ic.Repo, &ic.IssueNum, &ic.Labels, &ic.Body, &ic.State, &updatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -443,6 +485,33 @@ func (s *Store) QueryIssueCache(repo string, issueNum int) (*IssueCache, error) 
 	}
 	ic.UpdatedAt, _ = parseTimestamp(updatedAt, "issue_cache.updated_at")
 	return &ic, nil
+}
+
+// ListIssueCaches returns all non-PR cached issues for a repo.
+func (s *Store) ListIssueCaches(repo string) ([]IssueCache, error) {
+	rows, err := s.db.Query(
+		`SELECT repo, issue_num, labels, body, state, updated_at
+		 FROM issue_cache
+		 WHERE repo = ? AND (state IS NULL OR state NOT LIKE 'pr:%')
+		 ORDER BY issue_num`,
+		repo,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("store: list issue caches: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []IssueCache
+	for rows.Next() {
+		var ic IssueCache
+		var updatedAt string
+		if err := rows.Scan(&ic.Repo, &ic.IssueNum, &ic.Labels, &ic.Body, &ic.State, &updatedAt); err != nil {
+			return nil, fmt.Errorf("store: scan issue cache: %w", err)
+		}
+		ic.UpdatedAt, _ = parseTimestamp(updatedAt, "issue_cache.updated_at")
+		out = append(out, ic)
+	}
+	return out, rows.Err()
 }
 
 // ---------------------------------------------------------------------------
@@ -568,4 +637,302 @@ func (s *Store) GetAgentSession(sessionID string) (*AgentSession, error) {
 	}
 	sess.CreatedAt, _ = parseTimestamp(createdAt, "agent_session.created_at")
 	return &sess, nil
+}
+
+// ---------------------------------------------------------------------------
+// Issue Dependencies
+// ---------------------------------------------------------------------------
+
+func (s *Store) ReplaceIssueDependencies(repo string, issueNum int, deps []IssueDependency) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("store: begin replace issue dependencies: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.Exec(`UPDATE issue_dependencies SET status = ? WHERE repo = ? AND issue_num = ? AND status != ?`,
+		DependencyStatusRemoved, repo, issueNum, DependencyStatusRemoved,
+	); err != nil {
+		return fmt.Errorf("store: mark dependencies removed: %w", err)
+	}
+
+	for _, dep := range deps {
+		if _, err := tx.Exec(
+			`INSERT INTO issue_dependencies (repo, issue_num, depends_on_repo, depends_on_issue_num, source_hash, status)
+			 VALUES (?, ?, ?, ?, ?, ?)
+			 ON CONFLICT (repo, issue_num, depends_on_repo, depends_on_issue_num)
+			 DO UPDATE SET source_hash = excluded.source_hash, status = excluded.status`,
+			dep.Repo, dep.IssueNum, dep.DependsOnRepo, dep.DependsOnIssueNum, dep.SourceHash, dep.Status,
+		); err != nil {
+			return fmt.Errorf("store: upsert dependency: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("store: commit replace issue dependencies: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) ListIssueDependencies(repo string, issueNum int) ([]IssueDependency, error) {
+	rows, err := s.db.Query(
+		`SELECT repo, issue_num, depends_on_repo, depends_on_issue_num, source_hash, status
+		 FROM issue_dependencies
+		 WHERE repo = ? AND issue_num = ?
+		 ORDER BY depends_on_repo, depends_on_issue_num`,
+		repo, issueNum,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("store: list issue dependencies: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []IssueDependency
+	for rows.Next() {
+		var dep IssueDependency
+		if err := rows.Scan(&dep.Repo, &dep.IssueNum, &dep.DependsOnRepo, &dep.DependsOnIssueNum, &dep.SourceHash, &dep.Status); err != nil {
+			return nil, fmt.Errorf("store: scan issue dependency: %w", err)
+		}
+		out = append(out, dep)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) UpsertIssueDependencyState(state IssueDependencyState) error {
+	_, err := s.db.Exec(
+		`INSERT INTO issue_dependency_state
+		 (repo, issue_num, verdict, resume_label, blocked_reason_hash, override_active, graph_version, last_comment_hash, last_comment_id, last_evaluated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		 ON CONFLICT (repo, issue_num)
+		 DO UPDATE SET
+		   verdict = excluded.verdict,
+		   resume_label = excluded.resume_label,
+		   blocked_reason_hash = excluded.blocked_reason_hash,
+		   override_active = excluded.override_active,
+		   graph_version = excluded.graph_version,
+		   last_comment_hash = excluded.last_comment_hash,
+		   last_comment_id = excluded.last_comment_id,
+		   last_evaluated_at = CURRENT_TIMESTAMP`,
+		state.Repo, state.IssueNum, state.Verdict, state.ResumeLabel, state.BlockedReasonHash,
+		boolToInt(state.OverrideActive), state.GraphVersion, state.LastCommentHash, state.LastCommentID,
+	)
+	if err != nil {
+		return fmt.Errorf("store: upsert issue dependency state: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) QueryIssueDependencyState(repo string, issueNum int) (*IssueDependencyState, error) {
+	var state IssueDependencyState
+	var overrideActive int
+	var evaluatedAt string
+	err := s.db.QueryRow(
+		`SELECT repo, issue_num, verdict, resume_label, blocked_reason_hash, override_active, graph_version, last_comment_hash, last_comment_id, last_evaluated_at
+		 FROM issue_dependency_state
+		 WHERE repo = ? AND issue_num = ?`,
+		repo, issueNum,
+	).Scan(
+		&state.Repo, &state.IssueNum, &state.Verdict, &state.ResumeLabel, &state.BlockedReasonHash, &overrideActive,
+		&state.GraphVersion, &state.LastCommentHash, &state.LastCommentID, &evaluatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("store: query issue dependency state: %w", err)
+	}
+	state.OverrideActive = overrideActive != 0
+	state.LastEvaluatedAt, _ = parseTimestamp(evaluatedAt, "issue_dependency_state.last_evaluated_at")
+	return &state, nil
+}
+
+func (s *Store) UpsertDependencyReconcile(item DependencyReconcileQueueItem) (bool, error) {
+	current, err := s.LatestDependencyReconcile(item.Repo, item.IssueNum)
+	if err != nil {
+		return false, err
+	}
+	if current != nil &&
+		current.DesiredBlocked == item.DesiredBlocked &&
+		current.DesiredResumeLabel == item.DesiredResumeLabel &&
+		current.DesiredNeedsHuman == item.DesiredNeedsHuman &&
+		current.DesiredCommentHash == item.DesiredCommentHash &&
+		(current.Status == DependencyQueueStatusQueued || current.Status == DependencyQueueStatusApplied) {
+		return false, nil
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return false, fmt.Errorf("store: begin upsert dependency reconcile: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.Exec(
+		`UPDATE dependency_reconcile_queue
+		 SET status = ?
+		 WHERE repo = ? AND issue_num = ? AND status = ?`,
+		DependencyQueueStatusSuperseded, item.Repo, item.IssueNum, DependencyQueueStatusQueued,
+	); err != nil {
+		return false, fmt.Errorf("store: supersede dependency reconcile queue: %w", err)
+	}
+
+	var nextGen int64 = 1
+	if current != nil {
+		nextGen = current.Generation + 1
+	}
+	item.Generation = nextGen
+
+	if _, err := tx.Exec(
+		`INSERT INTO dependency_reconcile_queue
+		 (repo, issue_num, generation, desired_blocked, desired_resume_label, desired_needs_human, desired_comment_body, desired_comment_hash, status, requested_at, applied_at, last_error)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, NULL, '')`,
+		item.Repo, item.IssueNum, item.Generation, boolToInt(item.DesiredBlocked), item.DesiredResumeLabel,
+		boolToInt(item.DesiredNeedsHuman), item.DesiredCommentBody, item.DesiredCommentHash, DependencyQueueStatusQueued,
+	); err != nil {
+		return false, fmt.Errorf("store: insert dependency reconcile queue: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("store: commit dependency reconcile queue: %w", err)
+	}
+	return true, nil
+}
+
+func (s *Store) LatestDependencyReconcile(repo string, issueNum int) (*DependencyReconcileQueueItem, error) {
+	var item DependencyReconcileQueueItem
+	var desiredBlocked, desiredNeedsHuman int
+	var requestedAt, appliedAt sql.NullString
+	var lastError sql.NullString
+	err := s.db.QueryRow(
+		`SELECT repo, issue_num, generation, desired_blocked, desired_resume_label, desired_needs_human, desired_comment_body, desired_comment_hash, status, requested_at, applied_at, last_error
+		 FROM dependency_reconcile_queue
+		 WHERE repo = ? AND issue_num = ?
+		 ORDER BY generation DESC
+		 LIMIT 1`,
+		repo, issueNum,
+	).Scan(
+		&item.Repo, &item.IssueNum, &item.Generation, &desiredBlocked, &item.DesiredResumeLabel, &desiredNeedsHuman,
+		&item.DesiredCommentBody, &item.DesiredCommentHash, &item.Status, &requestedAt, &appliedAt, &lastError,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("store: latest dependency reconcile: %w", err)
+	}
+	item.DesiredBlocked = desiredBlocked != 0
+	item.DesiredNeedsHuman = desiredNeedsHuman != 0
+	if requestedAt.Valid {
+		item.RequestedAt, _ = parseTimestamp(requestedAt.String, "dependency_reconcile_queue.requested_at")
+	}
+	if appliedAt.Valid {
+		item.AppliedAt, _ = parseTimestamp(appliedAt.String, "dependency_reconcile_queue.applied_at")
+	}
+	item.LastError = lastError.String
+	return &item, nil
+}
+
+func (s *Store) ListQueuedDependencyReconciles(repo string, limit int) ([]DependencyReconcileQueueItem, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.db.Query(
+		`SELECT repo, issue_num, generation, desired_blocked, desired_resume_label, desired_needs_human, desired_comment_body, desired_comment_hash, status, requested_at, applied_at, last_error
+		 FROM dependency_reconcile_queue
+		 WHERE repo = ? AND status = ?
+		 ORDER BY requested_at, issue_num
+		 LIMIT ?`,
+		repo, DependencyQueueStatusQueued, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("store: list queued dependency reconciles: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []DependencyReconcileQueueItem
+	for rows.Next() {
+		var item DependencyReconcileQueueItem
+		var desiredBlocked, desiredNeedsHuman int
+		var requestedAt, appliedAt sql.NullString
+		var lastError sql.NullString
+		if err := rows.Scan(
+			&item.Repo, &item.IssueNum, &item.Generation, &desiredBlocked, &item.DesiredResumeLabel, &desiredNeedsHuman,
+			&item.DesiredCommentBody, &item.DesiredCommentHash, &item.Status, &requestedAt, &appliedAt, &lastError,
+		); err != nil {
+			return nil, fmt.Errorf("store: scan queued dependency reconcile: %w", err)
+		}
+		item.DesiredBlocked = desiredBlocked != 0
+		item.DesiredNeedsHuman = desiredNeedsHuman != 0
+		if requestedAt.Valid {
+			item.RequestedAt, _ = parseTimestamp(requestedAt.String, "dependency_reconcile_queue.requested_at")
+		}
+		if appliedAt.Valid {
+			item.AppliedAt, _ = parseTimestamp(appliedAt.String, "dependency_reconcile_queue.applied_at")
+		}
+		item.LastError = lastError.String
+		out = append(out, item)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) HasActiveTask(repo string, issueNum int, agentName string) (bool, error) {
+	var count int
+	err := s.db.QueryRow(
+		`SELECT COUNT(1)
+		 FROM task_queue
+		 WHERE repo = ? AND issue_num = ? AND agent_name = ? AND status IN (?, ?)`,
+		repo, issueNum, agentName, TaskStatusPending, TaskStatusRunning,
+	).Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("store: has active task: %w", err)
+	}
+	return count > 0, nil
+}
+
+func (s *Store) MarkDependencyReconcileApplied(repo string, issueNum int, generation int64, commentHash, commentID string) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("store: begin mark dependency reconcile applied: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.Exec(
+		`UPDATE dependency_reconcile_queue
+		 SET status = ?, applied_at = CURRENT_TIMESTAMP, last_error = ''
+		 WHERE repo = ? AND issue_num = ? AND generation = ?`,
+		DependencyQueueStatusApplied, repo, issueNum, generation,
+	); err != nil {
+		return fmt.Errorf("store: update dependency reconcile applied: %w", err)
+	}
+	if _, err := tx.Exec(
+		`UPDATE issue_dependency_state
+		 SET last_comment_hash = ?, last_comment_id = ?
+		 WHERE repo = ? AND issue_num = ?`,
+		commentHash, commentID, repo, issueNum,
+	); err != nil {
+		return fmt.Errorf("store: update dependency state comment anchor: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("store: commit dependency reconcile applied: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) MarkDependencyReconcileFailed(repo string, issueNum int, generation int64, lastErr string) error {
+	_, err := s.db.Exec(
+		`UPDATE dependency_reconcile_queue
+		 SET status = ?, last_error = ?
+		 WHERE repo = ? AND issue_num = ? AND generation = ?`,
+		DependencyQueueStatusFailed, lastErr, repo, issueNum, generation,
+	)
+	if err != nil {
+		return fmt.Errorf("store: mark dependency reconcile failed: %w", err)
+	}
+	return nil
+}
+
+func boolToInt(v bool) int {
+	if v {
+		return 1
+	}
+	return 0
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -129,13 +129,16 @@ func TestCreateAndReadWrite(t *testing.T) {
 		t.Fatalf("unexpected issue cache: %+v", ic)
 	}
 	// Upsert update.
-	err = s.UpsertIssueCache(IssueCache{Repo: "org/repo", IssueNum: 1, Labels: `["bug","wip"]`, State: "open"})
+	err = s.UpsertIssueCache(IssueCache{Repo: "org/repo", IssueNum: 1, Labels: `["bug","wip"]`, Body: "body", State: "open"})
 	if err != nil {
 		t.Fatalf("UpsertIssueCache update: %v", err)
 	}
 	ic, _ = s.QueryIssueCache("org/repo", 1)
 	if ic.Labels != `["bug","wip"]` {
 		t.Fatalf("expected updated labels, got %s", ic.Labels)
+	}
+	if ic.Body != "body" {
+		t.Fatalf("expected updated body, got %q", ic.Body)
 	}
 	// Cache miss.
 	ic, err = s.QueryIssueCache("org/repo", 999)
@@ -163,6 +166,76 @@ func TestCreateAndReadWrite(t *testing.T) {
 	}
 	if len(sessions) != 1 || sessions[0].Summary != "ok" {
 		t.Fatalf("unexpected sessions: %+v", sessions)
+	}
+
+	// --- Dependency tables ---
+	err = s.ReplaceIssueDependencies("org/repo", 1, []IssueDependency{{
+		Repo:              "org/repo",
+		IssueNum:          1,
+		DependsOnRepo:     "org/repo",
+		DependsOnIssueNum: 2,
+		SourceHash:        "hash-1",
+		Status:            DependencyStatusActive,
+	}})
+	if err != nil {
+		t.Fatalf("ReplaceIssueDependencies: %v", err)
+	}
+	deps, err := s.ListIssueDependencies("org/repo", 1)
+	if err != nil {
+		t.Fatalf("ListIssueDependencies: %v", err)
+	}
+	if len(deps) != 1 || deps[0].DependsOnIssueNum != 2 {
+		t.Fatalf("unexpected dependencies: %+v", deps)
+	}
+	err = s.UpsertIssueDependencyState(IssueDependencyState{
+		Repo:              "org/repo",
+		IssueNum:          1,
+		Verdict:           DependencyVerdictBlocked,
+		ResumeLabel:       "status:developing",
+		BlockedReasonHash: "reason",
+		GraphVersion:      1,
+		LastCommentHash:   "comment-hash",
+	})
+	if err != nil {
+		t.Fatalf("UpsertIssueDependencyState: %v", err)
+	}
+	depState, err := s.QueryIssueDependencyState("org/repo", 1)
+	if err != nil {
+		t.Fatalf("QueryIssueDependencyState: %v", err)
+	}
+	if depState == nil || depState.Verdict != DependencyVerdictBlocked {
+		t.Fatalf("unexpected dependency state: %+v", depState)
+	}
+	enqueued, err := s.UpsertDependencyReconcile(DependencyReconcileQueueItem{
+		Repo:               "org/repo",
+		IssueNum:           1,
+		DesiredBlocked:     true,
+		DesiredResumeLabel: "status:developing",
+		DesiredCommentBody: "comment",
+		DesiredCommentHash: "comment-hash",
+	})
+	if err != nil {
+		t.Fatalf("UpsertDependencyReconcile: %v", err)
+	}
+	if !enqueued {
+		t.Fatal("expected reconcile item to be enqueued")
+	}
+	queued, err := s.ListQueuedDependencyReconciles("org/repo", 10)
+	if err != nil {
+		t.Fatalf("ListQueuedDependencyReconciles: %v", err)
+	}
+	if len(queued) != 1 {
+		t.Fatalf("expected 1 queued reconcile item, got %d", len(queued))
+	}
+	if err := s.MarkDependencyReconcileApplied("org/repo", 1, queued[0].Generation, "comment-hash", "123"); err != nil {
+		t.Fatalf("MarkDependencyReconcileApplied: %v", err)
+	}
+	latest, err := s.LatestDependencyReconcile("org/repo", 1)
+	if err != nil {
+		t.Fatalf("LatestDependencyReconcile: %v", err)
+	}
+	if latest == nil || latest.Status != DependencyQueueStatusApplied {
+		t.Fatalf("unexpected latest reconcile item: %+v", latest)
 	}
 }
 

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -49,6 +49,61 @@ type IssueCache struct {
 	Repo      string
 	IssueNum  int
 	Labels    string // JSON array
+	Body      string
 	State     string
 	UpdatedAt time.Time
+}
+
+const (
+	DependencyStatusActive               = "active"
+	DependencyStatusUnsupportedCrossRepo = "unsupported_cross_repo"
+	DependencyStatusInvalid              = "invalid"
+	DependencyStatusRemoved              = "removed"
+
+	DependencyVerdictReady      = "ready"
+	DependencyVerdictBlocked    = "blocked"
+	DependencyVerdictOverride   = "override"
+	DependencyVerdictNeedsHuman = "needs_human"
+
+	DependencyQueueStatusQueued     = "queued"
+	DependencyQueueStatusApplied    = "applied"
+	DependencyQueueStatusSuperseded = "superseded"
+	DependencyQueueStatusFailed     = "failed"
+)
+
+type IssueDependency struct {
+	Repo              string
+	IssueNum          int
+	DependsOnRepo     string
+	DependsOnIssueNum int
+	SourceHash        string
+	Status            string
+}
+
+type IssueDependencyState struct {
+	Repo              string
+	IssueNum          int
+	Verdict           string
+	ResumeLabel       string
+	BlockedReasonHash string
+	OverrideActive    bool
+	GraphVersion      int64
+	LastCommentHash   string
+	LastCommentID     string
+	LastEvaluatedAt   time.Time
+}
+
+type DependencyReconcileQueueItem struct {
+	Repo               string
+	IssueNum           int
+	Generation         int64
+	DesiredBlocked     bool
+	DesiredResumeLabel string
+	DesiredNeedsHuman  bool
+	DesiredCommentBody string
+	DesiredCommentHash string
+	Status             string
+	RequestedAt        time.Time
+	AppliedAt          time.Time
+	LastError          string
 }

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -202,18 +202,20 @@ documentation:
         - internal/reporter/reporter.go
       notes: Phased migration path from one-shot runtime to session-oriented runtime.
 
-    - path: docs/planned/issue-dependencies.md
-      bucket: planned
-      status: proposed
+    - path: docs/implemented/issue-dependencies.md
+      bucket: implemented
+      status: current
       related_code:
         - cmd/serve.go
+        - internal/dependency/dependency.go
+        - internal/dependency/dependency_test.go
         - internal/poller/poller.go
         - internal/statemachine/statemachine.go
         - internal/router/router.go
         - internal/store/store.go
         - internal/store/types.go
-        - internal/webui/handler.go
-      notes: Proposed dependency declaration, gating, blocked-state visibility, auto-unblock, cycle detection, and future cross-repo extension path.
+        - .github/workbuddy/agents/dependency-resolver-agent.md
+      notes: Implemented dependency gating now includes parser normalization, queue-backed reconcile, schedule-driven resolver dispatch, and cycle detection.
 
     - path: docs/mismatch/index.md
       bucket: mismatch
@@ -955,3 +957,43 @@ requirements:
     tests:
       - internal/audit/audit_test.go
     deps: [REQ-006, REQ-024]
+
+  - id: REQ-031
+    title: Issue Dependency Mechanism
+    description: >
+      Parse `workbuddy.depends_on` declarations from issue bodies, persist
+      dependency graph state in SQLite, compute dependency verdicts each poll
+      cycle, hard-gate dispatch when blocked, and reconcile GitHub blocked
+      UX through a dedicated dependency-resolver agent.
+    priority: P0
+    version: v0.1.0
+    status: tested
+    acceptance_criteria:
+      - "AC-031-1: 解析 issue body 中第一个同时满足 `yaml` fence 且包含 `workbuddy.depends_on` 的代码块；`#N` 规范化为 `owner/repo#N`，忽略自然语言 mentions"
+      - "AC-031-2: 新增并迁移 SQLite 表 `issue_dependencies`、`issue_dependency_state`、`dependency_reconcile_queue`，对现有数据库保持 additive/backward-compatible"
+      - "AC-031-3: GH reader 支持读取单 issue 当前 state/body/labels/stateReason，并通过 gh GraphQL 判断 closed issue 是否由 linked PR 关闭"
+      - "AC-031-4: 每个 poll cycle 基于当前 open issue graph 计算 `ready` / `blocked` / `override` / `needs_human` verdict，并检测 cycle"
+      - "AC-031-5: `statemachine.dispatchAgent` 与 router pre-dispatch 都会在 verdict=`blocked`/`needs_human` 时拒绝派发；`override` 允许继续"
+      - "AC-031-6: 维护 schedule-driven `dependency-resolver-agent`，消费 reconcile queue 并用 managed comment marker `<!-- workbuddy:dependency-status -->` 对齐 GitHub surface"
+      - "AC-031-7: 依赖 verdict、queue、cycle、override 行为写入 event log 审计事件"
+      - "AC-031-8: 单元测试覆盖 parser、cycle detection、verdict 分类、dispatch gate；集成测试证明 dependent issue 在 upstream done 前不会派发"
+    code:
+      - cmd/serve.go
+      - internal/dependency/dependency.go
+      - internal/poller/poller.go
+      - internal/statemachine/statemachine.go
+      - internal/router/router.go
+      - internal/store/store.go
+      - internal/store/types.go
+      - internal/eventlog/eventlog.go
+      - .github/workbuddy/agents/dependency-resolver-agent.md
+      - .github/workbuddy/agents/schemas/dependency-resolver-agent-result.json
+      - docs/implemented/issue-dependencies.md
+    tests:
+      - internal/dependency/dependency_test.go
+      - internal/store/store_test.go
+      - internal/poller/poller_test.go
+      - internal/statemachine/statemachine_test.go
+      - cmd/serve_test.go
+      - docs_consistency_test.go
+    deps: [REQ-002, REQ-003, REQ-004, REQ-024]


### PR DESCRIPTION
## Summary
- add dependency declaration parsing, SQLite persistence, resolver verdict computation, and dispatch hard gates
- add schedule-driven dependency resolver agent wiring plus queue/result handling
- migrate the issue dependency design doc to implemented and update indexes/tests

## Testing
- `go build ./...`
- `go vet ./...`
- `go test ./... -count=1`
- `grep -n "add-label\|remove-label\|gh issue comment" $(git diff --name-only main -- '*.go')`

## Manual test recipe
1. Create issue `A` with `type:feature`, `workbuddy`, and a non-done status label.
2. Create issue `B` with `type:feature`, `workbuddy`, `status:developing`, and an issue body YAML block declaring `workbuddy.depends_on: ["#A"]`.
3. Run `workbuddy serve` and verify `B` does not dispatch while `A` is still open and not `status:done`.
4. Move `A` to `status:done` or close it through a linked PR, wait one poll interval plus one reconcile tick, and verify `B` becomes dispatchable again.
5. Add `override:force-unblock` to `B` and verify the local verdict flips to `override` and dispatch is no longer blocked.

Closes #37
