### PR TITLE
REQ-018: CLI - init command

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -100,7 +100,11 @@ func initDirs() []string {
 
 func initFiles(repo string) ([]scaffoldFile, error) {
 	configBuf := bytes.Buffer{}
-	if err := template.Must(template.New("config").Parse(initConfigTemplate)).Execute(&configBuf, struct {
+	tmpl, err := template.New("config").Parse(initConfigTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("init: parse config.yaml template: %w", err)
+	}
+	if err := tmpl.Execute(&configBuf, struct {
 		Repo string
 	}{Repo: repo}); err != nil {
 		return nil, fmt.Errorf("init: render config.yaml: %w", err)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,212 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"embed"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"text/template"
+
+	"github.com/spf13/cobra"
+)
+
+//go:embed initdata/* initdata/agents/* initdata/workflows/*
+var initTemplates embed.FS
+
+type initOpts struct {
+	repo  string
+	force bool
+}
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Scaffold workbuddy configuration for a repository",
+	RunE:  runInitCmd,
+}
+
+func init() {
+	initCmd.Flags().String("repo", "", "Repository in OWNER/NAME form; defaults to the local git origin when available")
+	initCmd.Flags().Bool("force", false, "Overwrite existing scaffold files")
+	rootCmd.AddCommand(initCmd)
+}
+
+func runInitCmd(cmd *cobra.Command, _ []string) error {
+	opts, err := parseInitFlags(cmd)
+	if err != nil {
+		return err
+	}
+	return runInitWithOpts(cmd.Context(), ".", opts, cmd.OutOrStdout())
+}
+
+func parseInitFlags(cmd *cobra.Command) (*initOpts, error) {
+	repo, _ := cmd.Flags().GetString("repo")
+	force, _ := cmd.Flags().GetBool("force")
+	return &initOpts{repo: strings.TrimSpace(repo), force: force}, nil
+}
+
+func runInitWithOpts(ctx context.Context, root string, opts *initOpts, stdout io.Writer) error {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return fmt.Errorf("init: resolve root: %w", err)
+	}
+	repo, err := resolveInitRepo(ctx, absRoot, opts.repo)
+	if err != nil {
+		return err
+	}
+
+	files, err := initFiles(repo)
+	if err != nil {
+		return err
+	}
+	if err := writeInitFiles(absRoot, files, opts.force); err != nil {
+		return err
+	}
+
+	for _, dir := range initDirs() {
+		if _, err := fmt.Fprintf(stdout, "created %s\n", filepath.ToSlash(dir)); err != nil {
+			return fmt.Errorf("init: write output: %w", err)
+		}
+	}
+	for _, file := range files {
+		if _, err := fmt.Fprintf(stdout, "wrote %s\n", filepath.ToSlash(file.path)); err != nil {
+			return fmt.Errorf("init: write output: %w", err)
+		}
+	}
+	return nil
+}
+
+type scaffoldFile struct {
+	path    string
+	mode    fs.FileMode
+	content []byte
+}
+
+func initDirs() []string {
+	return []string{
+		".github/workbuddy/agents",
+		".github/workbuddy/workflows",
+		".workbuddy/logs",
+		".workbuddy/sessions",
+		".workbuddy/worktrees",
+	}
+}
+
+func initFiles(repo string) ([]scaffoldFile, error) {
+	configBuf := bytes.Buffer{}
+	if err := template.Must(template.New("config").Parse(initConfigTemplate)).Execute(&configBuf, struct {
+		Repo string
+	}{Repo: repo}); err != nil {
+		return nil, fmt.Errorf("init: render config.yaml: %w", err)
+	}
+
+	devAgent, err := fs.ReadFile(initTemplates, "initdata/agents/dev-agent.md")
+	if err != nil {
+		return nil, fmt.Errorf("init: load dev-agent template: %w", err)
+	}
+	reviewAgent, err := fs.ReadFile(initTemplates, "initdata/agents/review-agent.md")
+	if err != nil {
+		return nil, fmt.Errorf("init: load review-agent template: %w", err)
+	}
+	workflow, err := fs.ReadFile(initTemplates, "initdata/workflows/default.md")
+	if err != nil {
+		return nil, fmt.Errorf("init: load workflow template: %w", err)
+	}
+	runtimeGitignore, err := fs.ReadFile(initTemplates, "initdata/workbuddy.gitignore")
+	if err != nil {
+		return nil, fmt.Errorf("init: load runtime gitignore template: %w", err)
+	}
+
+	return []scaffoldFile{
+		{path: ".github/workbuddy/config.yaml", mode: 0o644, content: configBuf.Bytes()},
+		{path: ".github/workbuddy/agents/dev-agent.md", mode: 0o644, content: devAgent},
+		{path: ".github/workbuddy/agents/review-agent.md", mode: 0o644, content: reviewAgent},
+		{path: ".github/workbuddy/workflows/default.md", mode: 0o644, content: workflow},
+		{path: ".workbuddy/.gitignore", mode: 0o644, content: runtimeGitignore},
+	}, nil
+}
+
+func writeInitFiles(root string, files []scaffoldFile, force bool) error {
+	for _, dir := range initDirs() {
+		if err := os.MkdirAll(filepath.Join(root, dir), 0o755); err != nil {
+			return fmt.Errorf("init: create directory %q: %w", dir, err)
+		}
+	}
+
+	for _, file := range files {
+		target := filepath.Join(root, file.path)
+		if !force {
+			if _, err := os.Stat(target); err == nil {
+				return fmt.Errorf("init: target %q already exists (use --force to overwrite)", file.path)
+			} else if !os.IsNotExist(err) {
+				return fmt.Errorf("init: stat %q: %w", file.path, err)
+			}
+		}
+		if err := os.WriteFile(target, file.content, file.mode); err != nil {
+			return fmt.Errorf("init: write %q: %w", file.path, err)
+		}
+	}
+	return nil
+}
+
+var repoSlugRe = regexp.MustCompile(`^[^/\s]+/[^/\s]+$`)
+
+func resolveInitRepo(ctx context.Context, root, explicit string) (string, error) {
+	if explicit != "" {
+		if !repoSlugRe.MatchString(explicit) {
+			return "", fmt.Errorf("init: --repo must be in OWNER/NAME form")
+		}
+		return explicit, nil
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "-C", root, "config", "--get", "remote.origin.url")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("init: could not infer repo from git origin; pass --repo OWNER/NAME")
+	}
+	repo := parseGitRemoteURL(strings.TrimSpace(string(out)))
+	if repo == "" {
+		return "", fmt.Errorf("init: could not parse git origin %q; pass --repo OWNER/NAME", strings.TrimSpace(string(out)))
+	}
+	return repo, nil
+}
+
+func parseGitRemoteURL(remote string) string {
+	remote = strings.TrimSpace(remote)
+	remote = strings.TrimSuffix(remote, ".git")
+	switch {
+	case strings.HasPrefix(remote, "git@"):
+		if idx := strings.Index(remote, ":"); idx >= 0 && idx+1 < len(remote) {
+			candidate := remote[idx+1:]
+			if repoSlugRe.MatchString(candidate) {
+				return candidate
+			}
+		}
+	case strings.HasPrefix(remote, "ssh://"), strings.HasPrefix(remote, "https://"), strings.HasPrefix(remote, "http://"):
+		if idx := strings.Index(remote, "://"); idx >= 0 {
+			path := remote[idx+3:]
+			if slash := strings.Index(path, "/"); slash >= 0 && slash+1 < len(path) {
+				candidate := path[slash+1:]
+				if repoSlugRe.MatchString(candidate) {
+					return candidate
+				}
+			}
+		}
+	}
+	return ""
+}
+
+const initConfigTemplate = `# Workbuddy environment configuration
+# Each workbuddy instance runs with its own config.
+
+environment: dev          # dev | staging | prod
+repo: {{ .Repo }}
+poll_interval: 30s
+port: 8080                # HTTP audit server port
+`

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,0 +1,123 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Lincyaw/workbuddy/internal/config"
+)
+
+func TestRunInitWithOpts_CreatesFunctionalServeScaffold(t *testing.T) {
+	root := t.TempDir()
+	var out bytes.Buffer
+
+	err := runInitWithOpts(context.Background(), root, &initOpts{repo: "octo/workbuddy"}, &out)
+	if err != nil {
+		t.Fatalf("runInitWithOpts: %v", err)
+	}
+
+	cfgDir := filepath.Join(root, ".github", "workbuddy")
+	cfg, warnings, err := config.LoadConfig(cfgDir)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got %v", warnings)
+	}
+	if cfg.Global.Repo != "octo/workbuddy" {
+		t.Fatalf("repo = %q", cfg.Global.Repo)
+	}
+	if _, ok := cfg.Agents["dev-agent"]; !ok {
+		t.Fatalf("dev-agent missing from config")
+	}
+	if _, ok := cfg.Agents["review-agent"]; !ok {
+		t.Fatalf("review-agent missing from config")
+	}
+	if _, ok := cfg.Workflows["default"]; !ok {
+		t.Fatalf("default workflow missing from config")
+	}
+
+	for _, rel := range []string{
+		".workbuddy/logs",
+		".workbuddy/sessions",
+		".workbuddy/worktrees",
+		".workbuddy/.gitignore",
+	} {
+		if _, err := os.Stat(filepath.Join(root, rel)); err != nil {
+			t.Fatalf("missing %s: %v", rel, err)
+		}
+	}
+	if got := out.String(); !strings.Contains(got, "wrote .github/workbuddy/config.yaml") {
+		t.Fatalf("stdout missing scaffold summary: %q", got)
+	}
+}
+
+func TestRunInitWithOpts_FailsOnConflictWithoutForce(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, ".github", "workbuddy", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("repo: keep/me\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runInitWithOpts(context.Background(), root, &initOpts{repo: "octo/workbuddy"}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected conflict error")
+	}
+	if !strings.Contains(err.Error(), "config.yaml") || !strings.Contains(err.Error(), "--force") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "repo: keep/me\n" {
+		t.Fatalf("config.yaml unexpectedly changed: %q", string(data))
+	}
+}
+
+func TestRunInitWithOpts_ForceOverwritesExistingFiles(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, ".github", "workbuddy", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("repo: keep/me\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runInitWithOpts(context.Background(), root, &initOpts{repo: "octo/workbuddy", force: true}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("runInitWithOpts: %v", err)
+	}
+
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "repo: octo/workbuddy") {
+		t.Fatalf("config.yaml not overwritten: %q", string(data))
+	}
+}
+
+func TestParseGitRemoteURL(t *testing.T) {
+	tests := map[string]string{
+		"git@github.com:Lincyaw/workbuddy.git":       "Lincyaw/workbuddy",
+		"https://github.com/Lincyaw/workbuddy.git":   "Lincyaw/workbuddy",
+		"ssh://git@github.com/Lincyaw/workbuddy.git": "Lincyaw/workbuddy",
+		"http://github.com/Lincyaw/workbuddy.git":    "Lincyaw/workbuddy",
+		"not-a-remote": "",
+		"https://github.com/Lincyaw/workbuddy/extra": "",
+	}
+	for remote, want := range tests {
+		if got := parseGitRemoteURL(remote); got != want {
+			t.Fatalf("parseGitRemoteURL(%q) = %q, want %q", remote, got, want)
+		}
+	}
+}

--- a/cmd/initdata/agents/dev-agent.md
+++ b/cmd/initdata/agents/dev-agent.md
@@ -1,0 +1,42 @@
+---
+name: dev-agent
+description: Development agent - produces artifacts satisfying issue acceptance criteria
+triggers:
+  - label: "status:developing"
+    event: labeled
+role: dev
+runtime: claude-code
+policy:
+  sandbox: danger-full-access
+  approval: never
+  timeout: 30m
+prompt: |
+  You are the dev agent for repo {{.Repo}}, working on issue #{{.Issue.Number}}.
+
+  Title: {{.Issue.Title}}
+  Body:
+  {{.Issue.Body}}
+
+  Read the issue body for a `## Acceptance Criteria` section.
+
+  - If the section is missing or lists no verifiable criteria: add label
+    `status:blocked`, remove `status:developing`, post a comment explaining
+    exactly what acceptance criteria are needed, then stop.
+  - Otherwise: produce the artifact that satisfies every criterion — code,
+    docs, dependency bump, investigation report, whatever fits. For any
+    verifiable criterion, include tests or checks that demonstrate it holds.
+  - When the artifact is ready: remove `status:developing`, add
+    `status:reviewing`.
+
+  Use the repo's own CLAUDE.md / skills for project-specific dev-loop, PR conventions, and tooling. Report the artifact link when finished.
+---
+
+## Dev Agent
+
+Picks up issues in `status:developing`. Reads the issue's `## Acceptance Criteria`,
+produces an artifact satisfying every criterion (code / docs / deps / report),
+then flips the label to `status:reviewing`. If criteria are missing, it flips to
+`status:blocked` and waits for a human to rewrite the issue.
+
+Project-specific dev-loop, tooling, and PR conventions live in the target
+repo's own `CLAUDE.md` and `.claude/skills/`.

--- a/cmd/initdata/agents/review-agent.md
+++ b/cmd/initdata/agents/review-agent.md
@@ -1,0 +1,42 @@
+---
+name: review-agent
+description: Review agent - verifies the artifact against issue acceptance criteria
+triggers:
+  - label: "status:reviewing"
+    event: labeled
+role: review
+runtime: claude-code
+policy:
+  sandbox: danger-full-access
+  approval: never
+  timeout: 15m
+prompt: |
+  You are the review agent for repo {{.Repo}}, verifying the artifact produced for issue #{{.Issue.Number}}.
+
+  Title: {{.Issue.Title}}
+  Body:
+  {{.Issue.Body}}
+
+  Read the issue's `## Acceptance Criteria` section AND the artifact (PR,
+  comment, or report linked to the issue).
+
+  Evaluate EACH criterion as pass / fail / cannot-judge, with concrete
+  evidence (file:line, test name, or quoted text).
+
+  - If every criterion passes: remove `status:reviewing`, add `status:done`,
+    and post a comment with the criterion-by-criterion verdict.
+  - If any criterion fails: remove `status:reviewing`, add
+    `status:developing`, and post a comment listing the failing criteria plus
+    what the dev agent needs to address on the next pass.
+
+  Use the repo's own CLAUDE.md / skills for project-specific review conventions.
+---
+
+## Review Agent
+
+Picks up issues in `status:reviewing`. Checks each acceptance criterion
+against the produced artifact; flips to `status:done` if all green, or back to
+`status:developing` (with feedback) if anything fails.
+
+Project-specific review tooling and conventions live in the target repo's own
+`CLAUDE.md` and `.claude/skills/`.

--- a/cmd/initdata/workbuddy.gitignore
+++ b/cmd/initdata/workbuddy.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/cmd/initdata/workflows/default.md
+++ b/cmd/initdata/workflows/default.md
@@ -1,0 +1,78 @@
+---
+name: default
+description: Default 2-agent lifecycle for any workbuddy-tracked issue
+trigger:
+  issue_label: "workbuddy"
+max_retries: 3
+---
+
+## Default Workflow
+
+Two-agent state machine applied to every issue labeled `workbuddy`. Humans
+author issues with a `## Acceptance Criteria` section; agents decide
+transitions by modifying issue labels via `gh issue edit`. The state machine
+only reacts to label changes — it doesn't care whether a human or an agent
+changed the label. Bug vs feature distinction lives in optional `type:*`
+classification labels, not in separate workflows — the execution path is the
+same either way.
+
+```yaml
+states:
+  developing:
+    enter_label: "status:developing"
+    agent: dev-agent
+    transitions:
+      - to: reviewing
+        when: labeled "status:reviewing"
+      - to: blocked
+        when: labeled "status:blocked"
+
+  reviewing:
+    enter_label: "status:reviewing"
+    agent: review-agent
+    transitions:
+      - to: done
+        when: labeled "status:done"
+      - to: developing
+        when: labeled "status:developing"
+
+  blocked:
+    enter_label: "status:blocked"
+    # no agent runs; waits for a human to rewrite the issue
+    # (typically adding a proper `## Acceptance Criteria` section)
+    # and flip the label back to status:developing.
+    transitions:
+      - to: developing
+        when: labeled "status:developing"
+
+  done:
+    enter_label: "status:done"
+    action: close_issue
+
+  failed:
+    enter_label: "status:failed"
+```
+
+`failed` 仍然是 workflow schema 中可识别的终态 label，但当前 Go runtime 不会在 retry 超限时直接写入
+`status:failed` 或 `needs-human`；它只记录 retry/failure intent，后续 label 写回仍由 agent 或人工执行。
+
+### State graph
+
+```
+         ┌──────────── blocked ◄──── (dev: missing criteria)
+         │                │
+         │      (human rewrites issue)
+         ▼                │
+    developing ◄──────────┘
+         │  ▲
+         │  │ (review: any criterion fails; retry, max 3)
+         ▼  │
+     reviewing ──► done (all criteria pass; close_issue)
+
+Dev agent: reads `## Acceptance Criteria`, produces the artifact, flips to
+reviewing (or to blocked if criteria missing).
+Review agent: verifies each criterion against the artifact, flips to done or
+back to developing.
+Any revisit of a state — including developing↔blocked — counts toward
+max_retries; exceeding the limit will record retry/failure intent.
+```

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -713,19 +713,26 @@ requirements:
   - id: REQ-018
     title: CLI - init command
     description: >
-      `workbuddy init` — scaffold config directory with examples.
+      `workbuddy init` — scaffold the repository config and runtime directories
+      needed for a new workbuddy setup.
     priority: P1
     version: v0.2.0
-    status: pending
+    status: tested
     acceptance_criteria:
-      - "AC-018-1: 创建 .github/workbuddy/{agents,workflows} 目录"
-      - "AC-018-2: 生成示例 config.yaml（含 repo 字段）、agent 定义（含 role 字段）、workflow（含 max_retries 和 failed 状态）"
-      - "AC-018-3: 如果 .workbuddy 不在 .gitignore 中，追加"
-      - "AC-018-4: 目录已存在时报错，除非 --force"
-      - "AC-018-5: 单元测试：正常创建、已存在报错、--force 覆盖"
-    code: []
-    tests: []
-    deps: [REQ-001]
+      - "AC-018-1: `workbuddy init [--repo OWNER/NAME] [--force]` scaffolds `.github/workbuddy/{config.yaml,agents/,workflows/}`"
+      - "AC-018-2: init writes the canonical `dev-agent.md`, `review-agent.md`, and default workflow, and renders `config.yaml` with the target repo"
+      - "AC-018-3: init creates `.workbuddy/{logs,sessions,worktrees}` plus `.workbuddy/.gitignore` for local runtime state"
+      - "AC-018-4: existing target files fail with a non-zero error unless `--force` is set, in which case scaffold files are overwritten"
+      - "AC-018-5: unit tests cover clean initialization, conflict failure, and `--force` overwrite using a temporary filesystem"
+    code:
+      - cmd/init.go
+      - cmd/initdata/agents/dev-agent.md
+      - cmd/initdata/agents/review-agent.md
+      - cmd/initdata/workflows/default.md
+      - cmd/initdata/workbuddy.gitignore
+    tests:
+      - cmd/init_test.go
+    deps: []
 
   - id: REQ-019
     title: CLI - status command


### PR DESCRIPTION
Implement `workbuddy init` which scaffolds `.github/workbuddy/{config.yaml, agents/, workflows/}` and the `.workbuddy/` runtime directory for a new repo.

## Scope
- `workbuddy init [--repo OWNER/NAME] [--force]` under `cmd/init.go`
- Writes default `config.yaml`, copies canonical `dev-agent.md` + `review-agent.md`, default workflow
- Creates `.workbuddy/` with `logs/`, `sessions/`, `worktrees/`, `.gitignore`
- Refuses to overwrite existing files unless `--force`

## Acceptance Criteria
- Running `workbuddy init` in a clean dir produces a fully functional `workbuddy serve` setup
- `--force` correctly overwrites; without it, conflict → non-zero exit + diagnostic
- Unit test over an in-memory / tmpdir filesystem
- `project-index.yaml` REQ-018: status=tested

Closes #42