### PR TITLE
Cap dispatch on status:done label and consecutive agent failures (#129)

### DIFF
--- a/internal/alertbus/alertbus.go
+++ b/internal/alertbus/alertbus.go
@@ -22,6 +22,7 @@ const (
 	KindAgentExitNonZero       = "agent_exit_non_zero"
 	KindRepeatedFailure        = "repeated_failure"
 	KindTaskCompletedSuccess    = "task_completed"
+	KindDispatchBlocked         = "dispatch_blocked"
 )
 
 // AlertEvent is the payload emitted by system components for notification.

--- a/internal/eventlog/eventlog.go
+++ b/internal/eventlog/eventlog.go
@@ -39,6 +39,8 @@ const (
 	TypeConfigReloaded              = "config_reloaded"
 	TypeConfigReloadFailed          = "config_reload_failed"
 	TypeReportOverflow              = "report_overflow"
+	TypeDispatchBlockedByFailureCap = "dispatch_blocked_by_failure_cap"
+	TypeDispatchBlockedByDone       = "dispatch_blocked_by_done"
 )
 
 // AllEventTypes lists every recognised event type.
@@ -70,6 +72,8 @@ var AllEventTypes = []string{
 	TypeConfigReloaded,
 	TypeConfigReloadFailed,
 	TypeReportOverflow,
+	TypeDispatchBlockedByFailureCap,
+	TypeDispatchBlockedByDone,
 }
 
 // EventFilter specifies optional criteria for querying events.

--- a/internal/statemachine/statemachine.go
+++ b/internal/statemachine/statemachine.go
@@ -47,6 +47,19 @@ const StuckTimeout = 5 * time.Minute
 
 const defaultJoinStrategy = config.JoinAllPassed
 
+// MaxConsecutiveAgentFailures is the number of back-to-back failed or timed-out
+// tasks the same agent may accumulate on one issue before the coordinator
+// refuses to dispatch again. It exists to break runaway re-dispatch cycles
+// caused by launcher-layer crashes, sustained infra errors, or agents whose
+// verdict flips failure-pass-failure on repeat. Humans must intervene to
+// clear the condition (fix the worker, change labels, or close the issue).
+const MaxConsecutiveAgentFailures = 3
+
+// DoneLabel is the canonical terminal label for completed issues. Dispatch
+// for any agent is refused when this label is present, regardless of the
+// stale workflow state captured in a retry request.
+const DoneLabel = "status:done"
+
 type dispatchGroup struct {
 	workflow string
 	state    string
@@ -378,12 +391,85 @@ func (sm *StateMachine) ensureWorkflowInstance(workflowName, repo string, issueN
 
 // DispatchAgent sends a dispatch request for the given agent, respecting in-flight group locking.
 func (sm *StateMachine) DispatchAgent(ctx context.Context, repo string, issueNum int, agentName, workflow, state string) error {
+	if blocked, err := sm.isBlockedByDone(repo, issueNum, agentName); err != nil {
+		return err
+	} else if blocked {
+		return nil
+	}
+	if blocked, err := sm.isBlockedByFailureCap(repo, issueNum, agentName); err != nil {
+		return err
+	} else if blocked {
+		return nil
+	}
 	if blocked, err := sm.isBlockedByDependency(repo, issueNum, agentName); err != nil {
 		return err
 	} else if blocked {
 		return nil
 	}
 	return sm.dispatchSingleAgent(ctx, repo, issueNum, agentName, workflow, state)
+}
+
+// isBlockedByDone refuses dispatch when the issue already carries the
+// terminal DoneLabel in the cached label snapshot. This guards against stale
+// redispatch paths that carry a pre-completion state value.
+func (sm *StateMachine) isBlockedByDone(repo string, issueNum int, agentForLog string) (bool, error) {
+	if sm.store == nil {
+		return false, nil
+	}
+	ic, err := sm.store.QueryIssueCache(repo, issueNum)
+	if err != nil {
+		return false, fmt.Errorf("statemachine: query issue cache: %w", err)
+	}
+	if ic == nil || ic.Labels == "" {
+		return false, nil
+	}
+	var labels []string
+	if err := json.Unmarshal([]byte(ic.Labels), &labels); err != nil {
+		// Malformed cache entry shouldn't wedge dispatch — skip the check.
+		return false, nil
+	}
+	for _, l := range labels {
+		if l == DoneLabel {
+			sm.eventlog.Log(eventlog.TypeDispatchBlockedByDone, repo, issueNum, map[string]string{
+				"agent": agentForLog,
+				"label": DoneLabel,
+			})
+			sm.publishAlert(alertbus.KindDispatchBlocked, alertbus.SeverityInfo, repo, issueNum, "", map[string]any{
+				"reason": "status_done",
+				"agent":  agentForLog,
+			})
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// isBlockedByFailureCap refuses dispatch when this agent has accumulated
+// MaxConsecutiveAgentFailures back-to-back failed or timed-out tasks on
+// the issue since its last successful run.
+func (sm *StateMachine) isBlockedByFailureCap(repo string, issueNum int, agentName string) (bool, error) {
+	if sm.store == nil {
+		return false, nil
+	}
+	count, err := sm.store.CountConsecutiveAgentFailures(repo, issueNum, agentName)
+	if err != nil {
+		return false, fmt.Errorf("statemachine: count consecutive failures: %w", err)
+	}
+	if count < MaxConsecutiveAgentFailures {
+		return false, nil
+	}
+	sm.eventlog.Log(eventlog.TypeDispatchBlockedByFailureCap, repo, issueNum, map[string]any{
+		"agent":             agentName,
+		"consecutive_fails": count,
+		"cap":               MaxConsecutiveAgentFailures,
+	})
+	sm.publishAlert(alertbus.KindDispatchBlocked, alertbus.SeverityError, repo, issueNum, "", map[string]any{
+		"reason":            "failure_cap",
+		"agent":             agentName,
+		"consecutive_fails": count,
+		"cap":               MaxConsecutiveAgentFailures,
+	})
+	return true, nil
 }
 
 // isBlockedByDependency checks if the issue is blocked by a dependency.

--- a/internal/statemachine/statemachine_test.go
+++ b/internal/statemachine/statemachine_test.go
@@ -839,6 +839,112 @@ func TestDispatchBlockedByDependencyVerdict(t *testing.T) {
 	}
 }
 
+func TestDispatchAgentBlockedByDone(t *testing.T) {
+	sm, rec, dispatch := newTestSM(t)
+	if err := sm.store.UpsertIssueCache(store.IssueCache{
+		Repo:     "test/repo",
+		IssueNum: 101,
+		Labels:   `["workbuddy","status:done"]`,
+		State:    "open",
+	}); err != nil {
+		t.Fatalf("UpsertIssueCache: %v", err)
+	}
+
+	if err := sm.DispatchAgent(context.Background(), "test/repo", 101, "review-agent", "dev-flow", "reviewing"); err != nil {
+		t.Fatalf("DispatchAgent: %v", err)
+	}
+
+	select {
+	case req := <-dispatch:
+		t.Fatalf("dispatch should have been blocked for done issue, got: %+v", req)
+	default:
+	}
+
+	if got := rec.find(eventlog.TypeDispatchBlockedByDone); len(got) != 1 {
+		t.Fatalf("expected 1 dispatch_blocked_by_done event, got %d", len(got))
+	}
+}
+
+func TestDispatchAgentBlockedByFailureCap(t *testing.T) {
+	sm, rec, dispatch := newTestSM(t)
+
+	// Seed exactly MaxConsecutiveAgentFailures failures for review-agent on the issue.
+	for i := 0; i < MaxConsecutiveAgentFailures; i++ {
+		if err := sm.store.InsertTask(store.TaskRecord{
+			ID:        fmt.Sprintf("task-%d", i),
+			Repo:      "test/repo",
+			IssueNum:  202,
+			AgentName: "review-agent",
+			Status:    store.TaskStatusFailed,
+		}); err != nil {
+			t.Fatalf("InsertTask: %v", err)
+		}
+	}
+
+	if err := sm.DispatchAgent(context.Background(), "test/repo", 202, "review-agent", "dev-flow", "reviewing"); err != nil {
+		t.Fatalf("DispatchAgent: %v", err)
+	}
+
+	select {
+	case req := <-dispatch:
+		t.Fatalf("dispatch should have been blocked by failure cap, got: %+v", req)
+	default:
+	}
+
+	events := rec.find(eventlog.TypeDispatchBlockedByFailureCap)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 dispatch_blocked_by_failure_cap event, got %d", len(events))
+	}
+	payload, ok := events[0].Payload.(map[string]any)
+	if !ok {
+		t.Fatalf("payload type = %T, want map[string]any", events[0].Payload)
+	}
+	if payload["agent"] != "review-agent" {
+		t.Fatalf("payload agent = %v, want review-agent", payload["agent"])
+	}
+	if payload["consecutive_fails"] != MaxConsecutiveAgentFailures {
+		t.Fatalf("payload consecutive_fails = %v, want %d", payload["consecutive_fails"], MaxConsecutiveAgentFailures)
+	}
+}
+
+func TestDispatchAgentResetsFailureCountAfterSuccess(t *testing.T) {
+	sm, _, dispatch := newTestSM(t)
+
+	// Past failures, followed by a success, followed by one more failure.
+	// The cap should not fire because the success reset the count.
+	statuses := []string{
+		store.TaskStatusFailed,
+		store.TaskStatusFailed,
+		store.TaskStatusFailed,
+		store.TaskStatusCompleted,
+		store.TaskStatusFailed,
+	}
+	for i, st := range statuses {
+		if err := sm.store.InsertTask(store.TaskRecord{
+			ID:        fmt.Sprintf("task-%d", i),
+			Repo:      "test/repo",
+			IssueNum:  303,
+			AgentName: "review-agent",
+			Status:    st,
+		}); err != nil {
+			t.Fatalf("InsertTask: %v", err)
+		}
+	}
+
+	if err := sm.DispatchAgent(context.Background(), "test/repo", 303, "review-agent", "dev-flow", "reviewing"); err != nil {
+		t.Fatalf("DispatchAgent: %v", err)
+	}
+
+	select {
+	case req := <-dispatch:
+		if req.AgentName != "review-agent" || req.IssueNum != 303 {
+			t.Fatalf("unexpected dispatch: %+v", req)
+		}
+	default:
+		t.Fatal("expected dispatch to be sent when failure count reset after success")
+	}
+}
+
 // Test 10: ResetDedup is safe for concurrent access
 func TestResetDedupConcurrent(t *testing.T) {
 	sm, _, _ := newTestSM(t)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1099,6 +1099,45 @@ func (s *Store) IncrementTransition(repo string, issueNum int, fromState, toStat
 	return count, nil
 }
 
+// CountConsecutiveAgentFailures returns the number of most-recent tasks for
+// (repo, issueNum, agentName) whose status is failed or timeout, stopping as
+// soon as a task with status = completed is seen. The count resets to 0 once
+// the agent has a successful run.
+//
+// Used by the coordinator to cap runaway re-dispatch cycles when an agent
+// repeatedly fails (launcher crashes, infra errors, or sustained agent
+// failures) without ever landing a successful run.
+func (s *Store) CountConsecutiveAgentFailures(repo string, issueNum int, agentName string) (int, error) {
+	rows, err := s.db.Query(
+		`SELECT status FROM task_queue
+		 WHERE repo = ? AND issue_num = ? AND agent_name = ?
+		   AND status IN (?, ?, ?)
+		 ORDER BY created_at DESC, id DESC`,
+		repo, issueNum, agentName,
+		TaskStatusCompleted, TaskStatusFailed, TaskStatusTimeout,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("store: count consecutive agent failures: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	count := 0
+	for rows.Next() {
+		var status string
+		if err := rows.Scan(&status); err != nil {
+			return 0, fmt.Errorf("store: scan task status: %w", err)
+		}
+		if status == TaskStatusCompleted {
+			break
+		}
+		count++
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("store: iterate task statuses: %w", err)
+	}
+	return count, nil
+}
+
 // QueryTransitionCounts returns all transition counts for a repo+issue.
 func (s *Store) QueryTransitionCounts(repo string, issueNum int) ([]TransitionCount, error) {
 	rows, err := s.db.Query(

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -667,6 +667,74 @@ func TestQueryTasksFilteredAndDeleteIssueDependencyState(t *testing.T) {
 	}
 }
 
+func TestCountConsecutiveAgentFailures(t *testing.T) {
+	s := newTestStore(t)
+
+	insert := func(id, agent, status string) {
+		t.Helper()
+		if err := s.InsertTask(TaskRecord{
+			ID:        id,
+			Repo:      "owner/repo",
+			IssueNum:  1,
+			AgentName: agent,
+			Status:    status,
+		}); err != nil {
+			t.Fatalf("InsertTask(%s): %v", id, err)
+		}
+		// Ensure created_at ordering is stable across fast inserts on SQLite's
+		// CURRENT_TIMESTAMP second resolution. InsertTask assigns created_at at
+		// insert time; id DESC provides the tie-break.
+	}
+
+	// No tasks yet → 0.
+	n, err := s.CountConsecutiveAgentFailures("owner/repo", 1, "review-agent")
+	if err != nil {
+		t.Fatalf("CountConsecutiveAgentFailures: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("empty = %d, want 0", n)
+	}
+
+	// Chronological sequence for review-agent:
+	//   1: failed, 2: failed, 3: completed, 4: failed, 5: timeout, 6: failed
+	// Only the trailing 3 failures after task 3 should be counted.
+	insert("t1", "review-agent", TaskStatusFailed)
+	insert("t2", "review-agent", TaskStatusFailed)
+	insert("t3", "review-agent", TaskStatusCompleted)
+	insert("t4", "review-agent", TaskStatusFailed)
+	insert("t5", "review-agent", TaskStatusTimeout)
+	insert("t6", "review-agent", TaskStatusFailed)
+
+	// Unrelated agent and pending rows must not affect the count.
+	insert("t7", "dev-agent", TaskStatusFailed)
+	insert("t8", "review-agent", TaskStatusPending)
+	insert("t9", "review-agent", TaskStatusRunning)
+
+	n, err = s.CountConsecutiveAgentFailures("owner/repo", 1, "review-agent")
+	if err != nil {
+		t.Fatalf("CountConsecutiveAgentFailures: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("count = %d, want 3", n)
+	}
+
+	// Filters by repo + issue + agent.
+	n, err = s.CountConsecutiveAgentFailures("owner/repo", 1, "dev-agent")
+	if err != nil {
+		t.Fatalf("CountConsecutiveAgentFailures(dev-agent): %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("dev-agent count = %d, want 1", n)
+	}
+	n, err = s.CountConsecutiveAgentFailures("owner/repo", 2, "review-agent")
+	if err != nil {
+		t.Fatalf("CountConsecutiveAgentFailures(issue 2): %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("other-issue count = %d, want 0", n)
+	}
+}
+
 // TestWALMode verifies that WAL mode is enabled.
 func TestWALMode(t *testing.T) {
 	s := newTestStore(t)

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -1766,3 +1766,34 @@ requirements:
       - internal/reporter/format_test.go
       - cmd/serve_test.go
     deps: [REQ-005, REQ-006, REQ-024]
+
+  - id: REQ-055
+    title: Dispatch cap on status:done and consecutive agent failures
+    description: >
+      Break runaway re-dispatch loops observed on issues whose agents crash
+      repeatedly at the launcher layer or flip verdicts back and forth. The
+      coordinator now refuses to dispatch an agent when (a) the issue already
+      carries the terminal status:done label, or (b) the same agent has
+      accumulated MaxConsecutiveAgentFailures back-to-back failed/timed-out
+      tasks on the issue since its last successful run. Blocked dispatches
+      emit a typed event and publish a dispatch_blocked alert so operators
+      see the condition instead of quietly piling up comments.
+    priority: P0
+    version: v0.2.0
+    status: tested
+    acceptance_criteria:
+      - "AC-055-1: Store exposes CountConsecutiveAgentFailures(repo, issue, agent) that counts failed/timeout tasks, resetting on the first completed task"
+      - "AC-055-2: DispatchAgent refuses to dispatch when the cached issue labels include status:done, emitting eventlog.TypeDispatchBlockedByDone"
+      - "AC-055-3: DispatchAgent refuses to dispatch when consecutive failures >= MaxConsecutiveAgentFailures, emitting eventlog.TypeDispatchBlockedByFailureCap"
+      - "AC-055-4: Both block paths publish an alertbus.KindDispatchBlocked alert with reason and agent fields"
+      - "AC-055-5: A successful task resets the failure count so the cap does not persist across recoveries"
+      - "AC-055-6: Unit tests cover each block path and the reset-after-success case"
+    code:
+      - internal/statemachine/statemachine.go
+      - internal/store/store.go
+      - internal/eventlog/eventlog.go
+      - internal/alertbus/alertbus.go
+    tests:
+      - internal/statemachine/statemachine_test.go
+      - internal/store/store_test.go
+    deps: [REQ-001, REQ-017, REQ-030]


### PR DESCRIPTION
Fixes #129

## Summary

- `StateMachine.DispatchAgent` now refuses to dispatch when the cached issue labels already contain `status:done`, or when the agent has accumulated ≥ 3 back-to-back failed/timed-out tasks on the issue since its last successful run.
- Both block paths emit a dedicated `eventlog` type and publish a `dispatch_blocked` alert so the coordinator's health story stays observable when the cap fires.
- A successful task resets the consecutive-failure counter, so transient infra hiccups that eventually recover don't poison future attempts.

Motivation: issue #120 accumulated 107 agent comments over 8+ hours because nothing stopped the coordinator from redispatching after launcher-layer crashes (`fork/exec ... no such file or directory`, `plugin cache root should be absolute`, 15m codex timeouts). With this change those events still happen, but each agent hits the cap after 3 attempts and the coordinator emits a dispatch_blocked alert instead of silently looping.

## Test plan

- [x] `go test ./internal/store/... -run TestCountConsecutiveAgentFailures` — new store test covering reset-on-success and per-(repo,issue,agent) scoping.
- [x] `go test ./internal/statemachine/... -run TestDispatchAgent` — three new tests covering the done-label block, the failure-cap block, and the reset-after-success path.
- [x] `go build ./... && go vet ./...` — clean.
- [ ] Post-merge: observe a real repeated-failure scenario on a test issue; confirm the block fires at attempt 4 and an alert is emitted.

## Out of scope

Two follow-up issues will be filed for:
1. Distinguishing launcher-layer crashes from real agent FAIL verdicts in the reporter (so infra errors never produce a FAIL-looking GitHub comment).
2. Per-issue worker claim with TTL to prevent two workers from racing on the same issue within the cap window.