### PR TITLE
Address Copilot review on #130 (rowid tie-break + corrupted-cache fallback)

### DIFF
--- a/internal/statemachine/statemachine.go
+++ b/internal/statemachine/statemachine.go
@@ -424,8 +424,26 @@ func (sm *StateMachine) isBlockedByDone(repo string, issueNum int, agentForLog s
 		return false, nil
 	}
 	var labels []string
-	if err := json.Unmarshal([]byte(ic.Labels), &labels); err != nil {
-		// Malformed cache entry shouldn't wedge dispatch — skip the check.
+	if unmarshalErr := json.Unmarshal([]byte(ic.Labels), &labels); unmarshalErr != nil {
+		// Fall back to a quoted-substring scan of the raw cache entry so a
+		// corrupted labels row still blocks dispatch if it mentions the done
+		// label. Log the corruption separately so operators can fix the cache.
+		sm.eventlog.Log(eventlog.TypeError, repo, issueNum, map[string]any{
+			"source": "issue_cache_labels_unmarshal",
+			"error":  unmarshalErr.Error(),
+		})
+		if strings.Contains(ic.Labels, `"`+DoneLabel+`"`) {
+			sm.eventlog.Log(eventlog.TypeDispatchBlockedByDone, repo, issueNum, map[string]string{
+				"agent":    agentForLog,
+				"label":    DoneLabel,
+				"fallback": "substring_scan_after_unmarshal_error",
+			})
+			sm.publishAlert(alertbus.KindDispatchBlocked, alertbus.SeverityInfo, repo, issueNum, "", map[string]any{
+				"reason": "status_done",
+				"agent":  agentForLog,
+			})
+			return true, nil
+		}
 		return false, nil
 	}
 	for _, l := range labels {

--- a/internal/statemachine/statemachine_test.go
+++ b/internal/statemachine/statemachine_test.go
@@ -865,6 +865,38 @@ func TestDispatchAgentBlockedByDone(t *testing.T) {
 	}
 }
 
+func TestDispatchAgentBlockedByDoneCorruptedCacheFallback(t *testing.T) {
+	sm, rec, dispatch := newTestSM(t)
+	// Cached labels field is not valid JSON but still contains the quoted
+	// done-label substring. The fallback must block dispatch instead of
+	// silently letting the loop reignite.
+	if err := sm.store.UpsertIssueCache(store.IssueCache{
+		Repo:     "test/repo",
+		IssueNum: 404,
+		Labels:   `workbuddy,"status:done" <-- malformed JSON`,
+		State:    "open",
+	}); err != nil {
+		t.Fatalf("UpsertIssueCache: %v", err)
+	}
+
+	if err := sm.DispatchAgent(context.Background(), "test/repo", 404, "review-agent", "dev-flow", "reviewing"); err != nil {
+		t.Fatalf("DispatchAgent: %v", err)
+	}
+
+	select {
+	case req := <-dispatch:
+		t.Fatalf("dispatch should have been blocked by fallback substring scan, got: %+v", req)
+	default:
+	}
+
+	if got := rec.find(eventlog.TypeDispatchBlockedByDone); len(got) != 1 {
+		t.Fatalf("expected 1 dispatch_blocked_by_done event via fallback, got %d", len(got))
+	}
+	if got := rec.find(eventlog.TypeError); len(got) != 1 {
+		t.Fatalf("expected 1 error event for unmarshal, got %d", len(got))
+	}
+}
+
 func TestDispatchAgentBlockedByFailureCap(t *testing.T) {
 	sm, rec, dispatch := newTestSM(t)
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1108,11 +1108,16 @@ func (s *Store) IncrementTransition(repo string, issueNum int, fromState, toStat
 // repeatedly fails (launcher crashes, infra errors, or sustained agent
 // failures) without ever landing a successful run.
 func (s *Store) CountConsecutiveAgentFailures(repo string, issueNum int, agentName string) (int, error) {
+	// Order by rowid DESC for deterministic insertion-order recency. task_queue.id
+	// holds UUIDs (assigned by the router, not monotonic), so id DESC cannot be
+	// used as a tie-break within the same created_at second. SQLite's implicit
+	// rowid is auto-incrementing and unique per insert, so newest-first is
+	// unambiguous even when multiple tasks are recorded in the same second.
 	rows, err := s.db.Query(
 		`SELECT status FROM task_queue
 		 WHERE repo = ? AND issue_num = ? AND agent_name = ?
 		   AND status IN (?, ?, ?)
-		 ORDER BY created_at DESC, id DESC`,
+		 ORDER BY rowid DESC`,
 		repo, issueNum, agentName,
 		TaskStatusCompleted, TaskStatusFailed, TaskStatusTimeout,
 	)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -681,9 +681,10 @@ func TestCountConsecutiveAgentFailures(t *testing.T) {
 		}); err != nil {
 			t.Fatalf("InsertTask(%s): %v", id, err)
 		}
-		// Ensure created_at ordering is stable across fast inserts on SQLite's
-		// CURRENT_TIMESTAMP second resolution. InsertTask assigns created_at at
-		// insert time; id DESC provides the tie-break.
+		// Recency ordering in CountConsecutiveAgentFailures is by rowid DESC,
+		// which is SQLite's implicit monotonic insert counter. That gives a
+		// stable newest-first traversal even when multiple inserts land in the
+		// same CURRENT_TIMESTAMP second.
 	}
 
 	// No tasks yet → 0.


### PR DESCRIPTION
Follow-up to #130 addressing three Copilot review comments that arrived after merge.

## Changes

- **Deterministic recency ordering in `CountConsecutiveAgentFailures`.** `task_queue.id` is a UUID assigned by the router, not a monotonic counter, so `ORDER BY created_at DESC, id DESC` can miscount when multiple tasks land in the same `CURRENT_TIMESTAMP` second. Switched to `ORDER BY rowid DESC` — SQLite's implicit rowid is auto-incrementing and unique per insert, giving unambiguous newest-first traversal. Updated the test comment to match.
- **Corrupted-cache fallback in `isBlockedByDone`.** Previously a malformed JSON `labels` column caused the done-label check to silently skip, which would reintroduce the runaway redispatch loop #130 is meant to break if the cache row still mentioned `status:done`. Now we: (a) log a `TypeError` event with source `issue_cache_labels_unmarshal`, (b) fall back to a quoted-substring scan for `"status:done"`, and (c) block dispatch + emit the normal events if the substring hits. Added a regression test covering the malformed-JSON + substring-match path.

## Test plan

- [x] `go test ./internal/store/... ./internal/statemachine/... -count=1` — pass, including the new corrupted-cache test.
- [x] `go build ./... && go vet ./...` — clean.

## Not addressed here

Only comments on code paths introduced by #130. The other unresolved Copilot comment (test comment about `id DESC`) is updated as part of this change.