### PR TITLE
Add per-issue dispatch claim with TTL (REQ-057)

### DIFF
--- a/cmd/repo_runtime.go
+++ b/cmd/repo_runtime.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -227,6 +228,13 @@ func (pm *pollerManager) StartOrUpdate(rec store.RepoRegistrationRecord) error {
 
 	dispatchCh := make(chan statemachine.DispatchRequest, dispatchChanSize)
 	sm := statemachine.NewStateMachine(cfg.Workflows, pm.store, dispatchCh, pm.eventlog, pm.alertBus)
+	// Enable the per-issue dispatch claim (REQ-057) so concurrent coordinators
+	// on different machines cannot race each other through the same SQLite DB.
+	hostname, _ := os.Hostname()
+	if hostname == "" {
+		hostname = "unknown"
+	}
+	sm.SetIssueClaim("coordinator-"+hostname, statemachine.DefaultIssueClaimLease)
 	depResolver := dependency.NewResolver(pm.store, pm.ghReader, pm.eventlog, pm.alertBus)
 	rt := router.NewRouter(cfg.Agents, pm.registry, pm.store, rec.Repo, pm.repoRoot, nil, nil, false)
 	runCtx, cancel := context.WithCancel(pm.rootCtx)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -525,6 +525,19 @@ func runServeWithOpts(opts *serveOpts, ghReader poller.GHReader, launcherOverrid
 
 	// State machine
 	sm := statemachine.NewStateMachine(cfg.Workflows, st, dispatchCh, evlog, alertBus)
+	// Enable persistent per-issue dispatch claim (REQ-057). In embedded serve
+	// mode the claim holder is the in-process worker so a second serve process
+	// sharing the same SQLite DB cannot race on redispatch of the same issue.
+	// Pure coordinator mode (opts.coordinatorAPI) uses a coordinator-scoped id.
+	claimerID := workerID
+	if claimerID == "" {
+		hostname, _ := os.Hostname()
+		if hostname == "" {
+			hostname = "unknown"
+		}
+		claimerID = "coordinator-" + hostname
+	}
+	sm.SetIssueClaim(claimerID, statemachine.DefaultIssueClaimLease)
 	depResolver := dependency.NewResolver(st, ghReader, evlog, alertBus)
 
 	// Workspace isolation is only needed for the embedded worker path.

--- a/internal/eventlog/eventlog.go
+++ b/internal/eventlog/eventlog.go
@@ -41,6 +41,8 @@ const (
 	TypeReportOverflow              = "report_overflow"
 	TypeDispatchBlockedByFailureCap = "dispatch_blocked_by_failure_cap"
 	TypeDispatchBlockedByDone       = "dispatch_blocked_by_done"
+	TypeDispatchSkippedClaim        = "dispatch_skipped_claim"
+	TypeIssueClaimExpired           = "issue_claim_expired"
 )
 
 // AllEventTypes lists every recognised event type.
@@ -74,6 +76,8 @@ var AllEventTypes = []string{
 	TypeReportOverflow,
 	TypeDispatchBlockedByFailureCap,
 	TypeDispatchBlockedByDone,
+	TypeDispatchSkippedClaim,
+	TypeIssueClaimExpired,
 }
 
 // EventFilter specifies optional criteria for querying events.

--- a/internal/statemachine/statemachine.go
+++ b/internal/statemachine/statemachine.go
@@ -3,6 +3,7 @@ package statemachine
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -59,6 +60,11 @@ const MaxConsecutiveAgentFailures = 3
 // for any agent is refused when this label is present, regardless of the
 // stale workflow state captured in a retry request.
 const DoneLabel = "status:done"
+
+// DefaultIssueClaimLease is the fallback lease duration for per-issue dispatch
+// claims (AC-7 of REQ-057). Long enough to accommodate a dev-agent run, short
+// enough to recover from a crashed coordinator.
+const DefaultIssueClaimLease = 30 * time.Minute
 
 type dispatchGroup struct {
 	workflow string
@@ -117,6 +123,16 @@ type StateMachine struct {
 	completionTimes map[string]completionRecord
 
 	workflowManager *workflow.Manager
+
+	// issueClaim configuration (REQ-057). When claimerID is empty, per-issue
+	// claim acquisition is skipped — useful for tests that don't care and for
+	// backwards compatibility with the existing NewStateMachine signature.
+	// claimTokens tracks the active claim token per issue so MarkAgentCompleted
+	// can release the lease it acquired.
+	issueClaimerID  string
+	issueClaimLease time.Duration
+	claimTokensMu   sync.Mutex
+	claimTokens     map[string]string // key: "repo#issueNum" → active claim token
 }
 
 type completionRecord struct {
@@ -146,7 +162,19 @@ func NewStateMachine(
 		stuckTimeout:    StuckTimeout,
 		completionTimes: make(map[string]completionRecord),
 		workflowManager: workflowManager,
+		claimTokens:     make(map[string]string),
 	}
+}
+
+// SetIssueClaim enables per-issue dispatch-claim acquisition (REQ-057). When
+// claimerID is empty the feature is disabled (useful for tests). When lease is
+// zero or negative, DefaultIssueClaimLease is used.
+func (sm *StateMachine) SetIssueClaim(claimerID string, lease time.Duration) {
+	sm.issueClaimerID = strings.TrimSpace(claimerID)
+	if lease <= 0 {
+		lease = DefaultIssueClaimLease
+	}
+	sm.issueClaimLease = lease
 }
 
 // SetStuckTimeout overrides the stuck timeout (useful for tests).
@@ -406,7 +434,76 @@ func (sm *StateMachine) DispatchAgent(ctx context.Context, repo string, issueNum
 	} else if blocked {
 		return nil
 	}
+	if blocked, err := sm.isBlockedByIssueClaim(repo, issueNum, agentName, workflow, state); err != nil {
+		return err
+	} else if blocked {
+		return nil
+	}
 	return sm.dispatchSingleAgent(ctx, repo, issueNum, agentName, workflow, state)
+}
+
+// isBlockedByIssueClaim acquires (or extends) the persistent per-issue claim
+// for this coordinator so that concurrent coordinators sharing the same SQLite
+// database cannot dispatch overlapping tasks on the same issue. A successful
+// self-extension is transparent; a fresh acquisition on an expired prior
+// holder logs TypeIssueClaimExpired; contention with another live holder logs
+// TypeDispatchSkippedClaim and blocks dispatch.
+func (sm *StateMachine) isBlockedByIssueClaim(repo string, issueNum int, agentName, workflow, state string) (bool, error) {
+	if sm.store == nil || sm.issueClaimerID == "" {
+		return false, nil
+	}
+	lease := sm.issueClaimLease
+	if lease <= 0 {
+		lease = DefaultIssueClaimLease
+	}
+	res, err := sm.store.AcquireIssueClaim(repo, issueNum, sm.issueClaimerID, lease)
+	if err != nil {
+		if errors.Is(err, store.ErrIssueClaimHeldByOther) {
+			other := ""
+			if claim, qErr := sm.store.QueryIssueClaim(repo, issueNum); qErr == nil && claim != nil {
+				other = claim.WorkerID
+			}
+			sm.eventlog.Log(eventlog.TypeDispatchSkippedClaim, repo, issueNum, map[string]any{
+				"agent":    agentName,
+				"workflow": workflow,
+				"state":    state,
+				"claimer":  sm.issueClaimerID,
+				"held_by":  other,
+				"reason":   "issue_claim_held_by_other",
+			})
+			return true, nil
+		}
+		return false, fmt.Errorf("statemachine: acquire issue claim: %w", err)
+	}
+	if res.OverwrotePrior {
+		sm.eventlog.Log(eventlog.TypeIssueClaimExpired, repo, issueNum, map[string]any{
+			"agent":       agentName,
+			"workflow":    workflow,
+			"state":       state,
+			"claimer":     sm.issueClaimerID,
+			"prior_owner": res.PriorWorkerID,
+		})
+	}
+	sm.claimTokensMu.Lock()
+	sm.claimTokens[sm.issueKey(repo, issueNum)] = res.ClaimToken
+	sm.claimTokensMu.Unlock()
+	return false, nil
+}
+
+// releaseIssueClaim drops the persistent claim for (repo, issueNum) when the
+// state machine has finished dispatching work for the current group. No-ops
+// when the feature is disabled.
+func (sm *StateMachine) releaseIssueClaim(repo string, issueNum int) {
+	if sm.store == nil || sm.issueClaimerID == "" {
+		return
+	}
+	key := sm.issueKey(repo, issueNum)
+	sm.claimTokensMu.Lock()
+	delete(sm.claimTokens, key)
+	sm.claimTokensMu.Unlock()
+	if _, err := sm.store.ReleaseIssueClaim(repo, issueNum, sm.issueClaimerID); err != nil {
+		log.Printf("[statemachine] release issue claim for %s#%d failed: %v", repo, issueNum, err)
+	}
 }
 
 // isBlockedByDone refuses dispatch when the issue already carries the
@@ -553,14 +650,21 @@ func (sm *StateMachine) dispatchSingleAgent(ctx context.Context, repo string, is
 		// Context cancelled before dispatch sent. Remove this agent from
 		// the group. If no agents were successfully dispatched, clean up
 		// the entire group.
+		released := false
 		sm.inflightMu.Lock()
 		if g, ok := sm.inflight[issueKey]; ok {
 			delete(g.dispatchedAgents, agentName)
 			if len(g.dispatchedAgents) == 0 {
 				delete(sm.inflight, issueKey)
+				released = true
 			}
 		}
 		sm.inflightMu.Unlock()
+		if released {
+			// Nothing else is pending for this issue — release the lease so
+			// another coordinator/cycle can pick it up.
+			sm.releaseIssueClaim(repo, issueNum)
+		}
 		return ctx.Err()
 	}
 	return nil
@@ -658,6 +762,7 @@ func (sm *StateMachine) MarkAgentCompleted(repo string, issueNum int, taskID, ag
 	group := sm.inflight[issueKey]
 	if group == nil {
 		sm.inflightMu.Unlock()
+		sm.releaseIssueClaim(repo, issueNum)
 		sm.recordStuckCandidate(issueKey, currentLabels)
 		sm.logCompletionEvent(repo, issueNum, taskID, agentName, exitCode)
 		return
@@ -736,6 +841,10 @@ func (sm *StateMachine) MarkAgentCompleted(repo string, issueNum int, taskID, ag
 		delete(sm.inflight, issueKey)
 	}
 	sm.inflightMu.Unlock()
+
+	if shouldAdvance {
+		sm.releaseIssueClaim(repo, issueNum)
+	}
 
 	sm.logCompletionEvent(repo, issueNum, taskID, agentName, exitCode)
 

--- a/internal/statemachine/statemachine.go
+++ b/internal/statemachine/statemachine.go
@@ -683,6 +683,16 @@ func (sm *StateMachine) dispatchStateAgents(ctx context.Context, repo string, is
 		return nil
 	}
 
+	// Acquire the per-issue claim once for the whole group so concurrent
+	// coordinators sharing the same SQLite database cannot both dispatch a
+	// workflow state onto the same issue. The claim is released together
+	// with the dispatch group in MarkAgentCompleted.
+	if blocked, err := sm.isBlockedByIssueClaim(repo, issueNum, agents[0], wfName, state); err != nil {
+		return err
+	} else if blocked {
+		return nil
+	}
+
 	issueKey := sm.issueKey(repo, issueNum)
 	join := stateDef.Join // already normalized by config loader
 	if join == "" {

--- a/internal/statemachine/statemachine_test.go
+++ b/internal/statemachine/statemachine_test.go
@@ -1069,6 +1069,72 @@ func TestDispatchAgentRespectsIssueClaim(t *testing.T) {
 	}
 }
 
+// TestDispatchStateAgentsRespectsIssueClaim covers the Copilot-flagged gap:
+// workflow-driven multi-agent dispatch goes through dispatchStateAgents, not
+// DispatchAgent. Without the claim check on that path, two coordinators
+// sharing the same DB could both dispatch the same state group. This test
+// exercises the path by triggering a label event that maps to a parallel
+// state; the second coordinator must be blocked.
+func TestDispatchStateAgentsRespectsIssueClaim(t *testing.T) {
+	st := newTestStore(t)
+
+	rec1 := &fakeRecorder{}
+	dispatch1 := make(chan DispatchRequest, 4)
+	sm1 := NewStateMachine(
+		map[string]*config.WorkflowConfig{"parallel-flow": newParallelWorkflow(config.JoinAllPassed)},
+		st,
+		dispatch1,
+		rec1,
+		nil,
+	)
+	sm1.SetIssueClaim("coordinator-a", 5*time.Minute)
+
+	rec2 := &fakeRecorder{}
+	dispatch2 := make(chan DispatchRequest, 4)
+	sm2 := NewStateMachine(
+		map[string]*config.WorkflowConfig{"parallel-flow": newParallelWorkflow(config.JoinAllPassed)},
+		st,
+		dispatch2,
+		rec2,
+		nil,
+	)
+	sm2.SetIssueClaim("coordinator-b", 5*time.Minute)
+
+	event := ChangeEvent{
+		Type:     poller.EventLabelAdded,
+		Repo:     "test/repo",
+		IssueNum: 88,
+		Labels:   []string{"workbuddy", "status:developing"},
+		Detail:   "status:developing",
+	}
+
+	if err := sm1.HandleEvent(context.Background(), event); err != nil {
+		t.Fatalf("coord-a HandleEvent: %v", err)
+	}
+	// Drain whatever coord-a dispatched.
+	deadline := time.After(500 * time.Millisecond)
+drain:
+	for {
+		select {
+		case <-dispatch1:
+		case <-deadline:
+			break drain
+		}
+	}
+
+	if err := sm2.HandleEvent(context.Background(), event); err != nil {
+		t.Fatalf("coord-b HandleEvent: %v", err)
+	}
+	select {
+	case req := <-dispatch2:
+		t.Fatalf("coord-b should be blocked by issue claim, got %+v", req)
+	case <-time.After(200 * time.Millisecond):
+	}
+	if got := rec2.find(eventlog.TypeDispatchSkippedClaim); len(got) != 1 {
+		t.Fatalf("expected 1 dispatch_skipped_claim event on coord-b via dispatchStateAgents, got %d", len(got))
+	}
+}
+
 // TestDispatchAgentReleasesOnContextCancel ensures a cancelled dispatch does
 // not leave the issue claim stuck — another coordinator can acquire afterwards.
 func TestDispatchAgentReleasesOnContextCancel(t *testing.T) {

--- a/internal/statemachine/statemachine_test.go
+++ b/internal/statemachine/statemachine_test.go
@@ -1004,6 +1004,100 @@ func TestResetDedupConcurrent(t *testing.T) {
 	wg.Wait()
 }
 
+// TestDispatchAgentRespectsIssueClaim covers the integration of
+// SetIssueClaim + DispatchAgent: a concurrent claimer must see the dispatch
+// blocked (with a typed event) while the holder's own dispatch proceeds. This
+// guards REQ-057 AC-5 (coordinator-side acquisition) end-to-end.
+func TestDispatchAgentRespectsIssueClaim(t *testing.T) {
+	// State machine #1 represents the coordinator that holds the claim.
+	sm1, _, dispatch1 := newTestSM(t)
+	sm1.SetIssueClaim("coordinator-a", 5*time.Minute)
+
+	// State machine #2 shares the same Store — simulating a second
+	// coordinator process attached to the same DB — and must be blocked.
+	rec2 := &fakeRecorder{}
+	dispatch2 := make(chan DispatchRequest, 4)
+	wf := testWorkflow()
+	sm2 := NewStateMachine(
+		map[string]*config.WorkflowConfig{"dev-flow": wf},
+		sm1.store,
+		dispatch2,
+		rec2,
+		nil,
+	)
+	sm2.SetIssueClaim("coordinator-b", 5*time.Minute)
+
+	repo := "test/repo"
+	issueNum := 77
+
+	if err := sm1.DispatchAgent(context.Background(), repo, issueNum, "dev-agent", "dev-flow", "developing"); err != nil {
+		t.Fatalf("coord-a DispatchAgent: %v", err)
+	}
+	select {
+	case <-dispatch1:
+		// coord-a's dispatch went through.
+	case <-time.After(time.Second):
+		t.Fatal("expected dispatch from coord-a")
+	}
+
+	// coord-b must be blocked by the persisted claim.
+	if err := sm2.DispatchAgent(context.Background(), repo, issueNum, "dev-agent", "dev-flow", "developing"); err != nil {
+		t.Fatalf("coord-b DispatchAgent: %v", err)
+	}
+	select {
+	case req := <-dispatch2:
+		t.Fatalf("coord-b dispatch should have been blocked, got %+v", req)
+	default:
+	}
+	skipped := rec2.find(eventlog.TypeDispatchSkippedClaim)
+	if len(skipped) != 1 {
+		t.Fatalf("expected 1 dispatch_skipped_claim event on coord-b, got %d", len(skipped))
+	}
+
+	// When coord-a completes the group, it releases the claim so coord-b's
+	// next attempt succeeds.
+	sm1.MarkAgentCompleted(repo, issueNum, "task-1", "dev-agent", 0, []string{"workbuddy", "status:reviewing"})
+
+	if err := sm2.DispatchAgent(context.Background(), repo, issueNum, "dev-agent", "dev-flow", "developing"); err != nil {
+		t.Fatalf("coord-b DispatchAgent after release: %v", err)
+	}
+	select {
+	case <-dispatch2:
+		// coord-b now has the claim.
+	case <-time.After(time.Second):
+		t.Fatal("expected dispatch from coord-b after release")
+	}
+}
+
+// TestDispatchAgentReleasesOnContextCancel ensures a cancelled dispatch does
+// not leave the issue claim stuck — another coordinator can acquire afterwards.
+func TestDispatchAgentReleasesOnContextCancel(t *testing.T) {
+	sm, _, dispatch := newTestSM(t)
+	sm.SetIssueClaim("coord-a", time.Minute)
+
+	// Fill the dispatch channel so the next send blocks.
+	for i := 0; i < cap(dispatch); i++ {
+		dispatch <- DispatchRequest{}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := sm.DispatchAgent(ctx, "test/repo", 1, "dev-agent", "dev-flow", "developing")
+	if err == nil {
+		t.Fatal("expected context.Canceled error from DispatchAgent")
+	}
+
+	// After cancellation the claim should have been released.
+	claim, err := sm.store.QueryIssueClaim("test/repo", 1)
+	if err != nil {
+		t.Fatalf("QueryIssueClaim: %v", err)
+	}
+	if claim != nil {
+		t.Fatalf("expected claim to be released after cancelled dispatch, got %+v", claim)
+	}
+}
+
 func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2,7 +2,9 @@
 package store
 
 import (
+	"crypto/rand"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -49,6 +51,9 @@ var (
 	ErrTaskAlreadyCompleted   = errors.New("task already completed")
 	ErrTaskNotClaimedByWorker = errors.New("task not claimed by worker")
 	ErrWorkerNotFound         = errors.New("worker not found")
+	// ErrIssueClaimHeldByOther is returned by AcquireIssueClaim when another
+	// worker already holds an unexpired lease on the issue.
+	ErrIssueClaimHeldByOther = errors.New("issue claim held by other worker")
 )
 
 // Store provides typed CRUD access to the workbuddy SQLite database.
@@ -243,6 +248,15 @@ func (s *Store) createTables() error {
 			graph_version INTEGER NOT NULL DEFAULT 0,
 			last_reaction_blocked INTEGER NOT NULL DEFAULT 0,
 			last_evaluated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (repo, issue_num)
+		)`,
+		`CREATE TABLE IF NOT EXISTS issue_claim (
+			repo TEXT NOT NULL,
+			issue_num INTEGER NOT NULL,
+			worker_id TEXT NOT NULL,
+			claim_token TEXT NOT NULL,
+			acquired_at DATETIME NOT NULL,
+			expires_at DATETIME NOT NULL,
 			PRIMARY KEY (repo, issue_num)
 		)`,
 	}
@@ -1673,6 +1687,230 @@ func (s *Store) HasAnyActiveTask(repo string, issueNum int) (bool, error) {
 		return false, fmt.Errorf("store: has any active task: %w", err)
 	}
 	return count > 0, nil
+}
+
+// ---------------------------------------------------------------------------
+// Issue claim (per-issue dispatch lease, REQ-057)
+// ---------------------------------------------------------------------------
+
+// IssueClaimRecord is the snapshot returned by QueryIssueClaim.
+type IssueClaimRecord struct {
+	Repo       string
+	IssueNum   int
+	WorkerID   string
+	ClaimToken string
+	AcquiredAt time.Time
+	ExpiresAt  time.Time
+}
+
+// AcquireIssueClaimResult reports the outcome of AcquireIssueClaim so callers
+// can distinguish a brand-new acquisition, a self-held extension, and an
+// overwrite of a previously-expired claim (for event logging).
+type AcquireIssueClaimResult struct {
+	// ClaimToken is the token that identifies this lease. Callers should store
+	// it if they want to release/refresh later.
+	ClaimToken string
+	// Extended is true when workerID already held the claim and the lease was
+	// extended in place (no overwrite).
+	Extended bool
+	// OverwrotePrior is true when the prior holder's lease had expired and was
+	// replaced by this acquisition.
+	OverwrotePrior bool
+	// PriorWorkerID, when OverwrotePrior is true, identifies the previous
+	// (expired) holder for diagnostic logging.
+	PriorWorkerID string
+}
+
+func generateClaimToken() (string, error) {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("store: generate claim token: %w", err)
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// AcquireIssueClaim atomically inserts a new claim on (repo, issueNum) for
+// workerID, or extends the lease when workerID already holds the claim, or
+// overwrites an expired claim held by another worker.
+//
+// It returns ErrIssueClaimHeldByOther when another worker currently holds an
+// unexpired claim. The returned token is non-empty on success.
+func (s *Store) AcquireIssueClaim(repo string, issueNum int, workerID string, lease time.Duration) (AcquireIssueClaimResult, error) {
+	if strings.TrimSpace(workerID) == "" {
+		return AcquireIssueClaimResult{}, errors.New("store: acquire issue claim: worker_id is required")
+	}
+	if lease <= 0 {
+		lease = 30 * time.Minute
+	}
+	now := time.Now().UTC()
+	expiresAt := now.Add(lease)
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return AcquireIssueClaimResult{}, fmt.Errorf("store: begin acquire issue claim tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var (
+		holderWorker string
+		holderToken  string
+		holderExpRaw string
+	)
+	row := tx.QueryRow(
+		`SELECT worker_id, claim_token, expires_at
+		 FROM issue_claim
+		 WHERE repo = ? AND issue_num = ?`,
+		repo, issueNum,
+	)
+	err = row.Scan(&holderWorker, &holderToken, &holderExpRaw)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		token, tokErr := generateClaimToken()
+		if tokErr != nil {
+			return AcquireIssueClaimResult{}, tokErr
+		}
+		if _, insErr := tx.Exec(
+			`INSERT INTO issue_claim (repo, issue_num, worker_id, claim_token, acquired_at, expires_at)
+			 VALUES (?, ?, ?, ?, ?, ?)`,
+			repo, issueNum, workerID, token, now.Format("2006-01-02 15:04:05"), expiresAt.Format("2006-01-02 15:04:05"),
+		); insErr != nil {
+			return AcquireIssueClaimResult{}, fmt.Errorf("store: insert issue claim: %w", insErr)
+		}
+		if commitErr := tx.Commit(); commitErr != nil {
+			return AcquireIssueClaimResult{}, fmt.Errorf("store: commit acquire issue claim: %w", commitErr)
+		}
+		return AcquireIssueClaimResult{ClaimToken: token}, nil
+	case err != nil:
+		return AcquireIssueClaimResult{}, fmt.Errorf("store: query issue claim: %w", err)
+	}
+
+	holderExp, ok := ParseTimestamp(holderExpRaw, "issue_claim.expires_at")
+	if !ok {
+		// Treat unparseable timestamp as expired so we can recover.
+		holderExp = time.Time{}
+	}
+	expired := holderExp.IsZero() || !holderExp.After(now)
+
+	if holderWorker == workerID && !expired {
+		// Self-held: extend in place, keeping the same token for idempotency.
+		if _, updErr := tx.Exec(
+			`UPDATE issue_claim
+			 SET expires_at = ?
+			 WHERE repo = ? AND issue_num = ? AND worker_id = ? AND claim_token = ?`,
+			expiresAt.Format("2006-01-02 15:04:05"), repo, issueNum, workerID, holderToken,
+		); updErr != nil {
+			return AcquireIssueClaimResult{}, fmt.Errorf("store: extend issue claim: %w", updErr)
+		}
+		if commitErr := tx.Commit(); commitErr != nil {
+			return AcquireIssueClaimResult{}, fmt.Errorf("store: commit extend issue claim: %w", commitErr)
+		}
+		return AcquireIssueClaimResult{ClaimToken: holderToken, Extended: true}, nil
+	}
+
+	if !expired {
+		// Held by someone else, not yet expired.
+		if commitErr := tx.Commit(); commitErr != nil {
+			return AcquireIssueClaimResult{}, fmt.Errorf("store: commit conflict rollback: %w", commitErr)
+		}
+		return AcquireIssueClaimResult{}, ErrIssueClaimHeldByOther
+	}
+
+	// Expired — overwrite with a fresh token and the new holder.
+	token, tokErr := generateClaimToken()
+	if tokErr != nil {
+		return AcquireIssueClaimResult{}, tokErr
+	}
+	if _, updErr := tx.Exec(
+		`UPDATE issue_claim
+		 SET worker_id = ?, claim_token = ?, acquired_at = ?, expires_at = ?
+		 WHERE repo = ? AND issue_num = ?`,
+		workerID, token, now.Format("2006-01-02 15:04:05"), expiresAt.Format("2006-01-02 15:04:05"),
+		repo, issueNum,
+	); updErr != nil {
+		return AcquireIssueClaimResult{}, fmt.Errorf("store: overwrite expired issue claim: %w", updErr)
+	}
+	if commitErr := tx.Commit(); commitErr != nil {
+		return AcquireIssueClaimResult{}, fmt.Errorf("store: commit overwrite issue claim: %w", commitErr)
+	}
+	return AcquireIssueClaimResult{
+		ClaimToken:     token,
+		OverwrotePrior: true,
+		PriorWorkerID:  holderWorker,
+	}, nil
+}
+
+// ReleaseIssueClaim removes the claim on (repo, issueNum) if it belongs to
+// workerID. Returns true when a row was deleted.
+func (s *Store) ReleaseIssueClaim(repo string, issueNum int, workerID string) (bool, error) {
+	res, err := s.db.Exec(
+		`DELETE FROM issue_claim
+		 WHERE repo = ? AND issue_num = ? AND worker_id = ?`,
+		repo, issueNum, workerID,
+	)
+	if err != nil {
+		return false, fmt.Errorf("store: release issue claim: %w", err)
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("store: release issue claim rows affected: %w", err)
+	}
+	return rows > 0, nil
+}
+
+// RefreshIssueClaim extends expires_at for the current holder. Returns true
+// when the row was updated (false when not held by workerID or already expired).
+func (s *Store) RefreshIssueClaim(repo string, issueNum int, workerID string, lease time.Duration) (bool, error) {
+	if lease <= 0 {
+		lease = 30 * time.Minute
+	}
+	now := time.Now().UTC()
+	expiresAt := now.Add(lease).Format("2006-01-02 15:04:05")
+	res, err := s.db.Exec(
+		`UPDATE issue_claim
+		 SET expires_at = ?
+		 WHERE repo = ? AND issue_num = ? AND worker_id = ?
+		   AND expires_at > ?`,
+		expiresAt, repo, issueNum, workerID, now.Format("2006-01-02 15:04:05"),
+	)
+	if err != nil {
+		return false, fmt.Errorf("store: refresh issue claim: %w", err)
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("store: refresh issue claim rows affected: %w", err)
+	}
+	return rows > 0, nil
+}
+
+// QueryIssueClaim returns the current claim for (repo, issueNum), or nil when
+// no row exists.
+func (s *Store) QueryIssueClaim(repo string, issueNum int) (*IssueClaimRecord, error) {
+	var (
+		workerID, token string
+		acquiredRaw     string
+		expiresRaw      string
+	)
+	err := s.db.QueryRow(
+		`SELECT worker_id, claim_token, acquired_at, expires_at
+		 FROM issue_claim
+		 WHERE repo = ? AND issue_num = ?`,
+		repo, issueNum,
+	).Scan(&workerID, &token, &acquiredRaw, &expiresRaw)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("store: query issue claim: %w", err)
+	}
+	rec := &IssueClaimRecord{
+		Repo:       repo,
+		IssueNum:   issueNum,
+		WorkerID:   workerID,
+		ClaimToken: token,
+	}
+	rec.AcquiredAt, _ = ParseTimestamp(acquiredRaw, "issue_claim.acquired_at")
+	rec.ExpiresAt, _ = ParseTimestamp(expiresRaw, "issue_claim.expires_at")
+	return rec, nil
 }
 
 func boolToInt(v bool) int {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -743,6 +743,19 @@ func isSQLiteBusyError(err error) bool {
 		strings.Contains(msg, "sqlite_busy")
 }
 
+// isSQLiteUniqueConstraint reports whether err came from a primary-key or
+// unique-index violation. modernc/sqlite surfaces these as textual errors
+// containing phrases like "UNIQUE constraint failed" or "constraint failed".
+func isSQLiteUniqueConstraint(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "unique constraint failed") ||
+		strings.Contains(msg, "primary key") ||
+		strings.Contains(msg, "constraint failed")
+}
+
 func (s *Store) ensureTaskOwnership(tx *sql.Tx, taskID, workerID string) (*TaskRecord, error) {
 	row := tx.QueryRow(`SELECT
 		id, repo, issue_num, agent_name, NULL, role, runtime, workflow, state,
@@ -1735,6 +1748,12 @@ func generateClaimToken() (string, error) {
 //
 // It returns ErrIssueClaimHeldByOther when another worker currently holds an
 // unexpired claim. The returned token is non-empty on success.
+//
+// Under contention (multiple processes racing on the same row) SQLite can
+// return SQLITE_BUSY if the deferred transaction cannot upgrade to a writer
+// lock, and can also return a UNIQUE-constraint error when a concurrent
+// inserter beat us between our SELECT and INSERT. Both cases are handled
+// with a bounded retry loop modelled on ClaimNextTask.
 func (s *Store) AcquireIssueClaim(repo string, issueNum int, workerID string, lease time.Duration) (AcquireIssueClaimResult, error) {
 	if strings.TrimSpace(workerID) == "" {
 		return AcquireIssueClaimResult{}, errors.New("store: acquire issue claim: worker_id is required")
@@ -1742,6 +1761,17 @@ func (s *Store) AcquireIssueClaim(repo string, issueNum int, workerID string, le
 	if lease <= 0 {
 		lease = 30 * time.Minute
 	}
+	for attempt := 0; attempt < 5; attempt++ {
+		res, err := s.acquireIssueClaimOnce(repo, issueNum, workerID, lease)
+		if err == nil || !isSQLiteBusyError(err) {
+			return res, err
+		}
+		time.Sleep(time.Duration(attempt+1) * 10 * time.Millisecond)
+	}
+	return s.acquireIssueClaimOnce(repo, issueNum, workerID, lease)
+}
+
+func (s *Store) acquireIssueClaimOnce(repo string, issueNum int, workerID string, lease time.Duration) (AcquireIssueClaimResult, error) {
 	now := time.Now().UTC()
 	expiresAt := now.Add(lease)
 
@@ -1769,17 +1799,41 @@ func (s *Store) AcquireIssueClaim(repo string, issueNum int, workerID string, le
 		if tokErr != nil {
 			return AcquireIssueClaimResult{}, tokErr
 		}
-		if _, insErr := tx.Exec(
+		_, insErr := tx.Exec(
 			`INSERT INTO issue_claim (repo, issue_num, worker_id, claim_token, acquired_at, expires_at)
 			 VALUES (?, ?, ?, ?, ?, ?)`,
 			repo, issueNum, workerID, token, now.Format("2006-01-02 15:04:05"), expiresAt.Format("2006-01-02 15:04:05"),
-		); insErr != nil {
+		)
+		if insErr == nil {
+			if commitErr := tx.Commit(); commitErr != nil {
+				return AcquireIssueClaimResult{}, fmt.Errorf("store: commit acquire issue claim: %w", commitErr)
+			}
+			return AcquireIssueClaimResult{ClaimToken: token}, nil
+		}
+		// A concurrent acquirer may have inserted between our SELECT and our
+		// INSERT. Re-read to find the winner; if its lease is still live the
+		// contract says we return ErrIssueClaimHeldByOther. If the winner's
+		// lease is already expired (very short leases), fall through to the
+		// normal expired-holder path by overwriting below.
+		if !isSQLiteUniqueConstraint(insErr) {
 			return AcquireIssueClaimResult{}, fmt.Errorf("store: insert issue claim: %w", insErr)
 		}
-		if commitErr := tx.Commit(); commitErr != nil {
-			return AcquireIssueClaimResult{}, fmt.Errorf("store: commit acquire issue claim: %w", commitErr)
+		if scanErr := tx.QueryRow(
+			`SELECT worker_id, claim_token, expires_at
+			 FROM issue_claim
+			 WHERE repo = ? AND issue_num = ?`,
+			repo, issueNum,
+		).Scan(&holderWorker, &holderToken, &holderExpRaw); scanErr != nil {
+			if errors.Is(scanErr, sql.ErrNoRows) {
+				// Extremely unlikely — row disappeared between the PK conflict
+				// and our re-read. Surface the original insert error so the
+				// caller can retry if desired.
+				return AcquireIssueClaimResult{}, fmt.Errorf("store: insert issue claim: %w", insErr)
+			}
+			return AcquireIssueClaimResult{}, fmt.Errorf("store: query issue claim after insert conflict: %w", scanErr)
 		}
-		return AcquireIssueClaimResult{ClaimToken: token}, nil
+		// Fall through to the holder-classification branch below with the
+		// re-read values populated.
 	case err != nil:
 		return AcquireIssueClaimResult{}, fmt.Errorf("store: query issue claim: %w", err)
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -863,3 +863,231 @@ func TestWorkerHasRunningTask(t *testing.T) {
 		t.Fatal("expected running task to be detected")
 	}
 }
+
+// TestAcquireIssueClaimFresh verifies a first-time acquisition returns a
+// non-empty token and persists an issue_claim row (AC-2, AC-8).
+func TestAcquireIssueClaimFresh(t *testing.T) {
+	s := newTestStore(t)
+
+	res, err := s.AcquireIssueClaim("org/repo", 42, "worker-a", time.Minute)
+	if err != nil {
+		t.Fatalf("AcquireIssueClaim fresh: %v", err)
+	}
+	if res.ClaimToken == "" {
+		t.Fatal("expected non-empty claim token")
+	}
+	if res.Extended || res.OverwrotePrior {
+		t.Fatalf("unexpected flags on fresh acquire: %+v", res)
+	}
+
+	got, err := s.QueryIssueClaim("org/repo", 42)
+	if err != nil {
+		t.Fatalf("QueryIssueClaim: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected persisted claim")
+	}
+	if got.WorkerID != "worker-a" || got.ClaimToken != res.ClaimToken {
+		t.Fatalf("unexpected claim: %+v", got)
+	}
+	if !got.ExpiresAt.After(time.Now().UTC().Add(30 * time.Second)) {
+		t.Fatalf("expected expires_at well into the future, got %v", got.ExpiresAt)
+	}
+}
+
+// TestAcquireIssueClaimSelfExtend verifies that the same worker acquiring an
+// already-held claim extends the existing lease in place (AC-2, AC-8).
+func TestAcquireIssueClaimSelfExtend(t *testing.T) {
+	s := newTestStore(t)
+
+	first, err := s.AcquireIssueClaim("org/repo", 7, "worker-a", 30*time.Second)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+
+	// Wait a tick so the expires_at comparison is meaningful.
+	time.Sleep(10 * time.Millisecond)
+
+	second, err := s.AcquireIssueClaim("org/repo", 7, "worker-a", 5*time.Minute)
+	if err != nil {
+		t.Fatalf("self re-acquire: %v", err)
+	}
+	if !second.Extended {
+		t.Fatalf("expected Extended=true, got %+v", second)
+	}
+	if second.ClaimToken != first.ClaimToken {
+		t.Fatalf("self-extend should reuse the token: first=%q second=%q", first.ClaimToken, second.ClaimToken)
+	}
+	got, err := s.QueryIssueClaim("org/repo", 7)
+	if err != nil {
+		t.Fatalf("QueryIssueClaim: %v", err)
+	}
+	if got == nil {
+		t.Fatal("claim disappeared after extend")
+	}
+	if !got.ExpiresAt.After(time.Now().UTC().Add(4 * time.Minute)) {
+		t.Fatalf("expected extended expires_at >4m ahead, got %v", got.ExpiresAt)
+	}
+}
+
+// TestAcquireIssueClaimHeldByOther verifies contention returns the sentinel
+// error and does not modify the persisted claim (AC-2, AC-8).
+func TestAcquireIssueClaimHeldByOther(t *testing.T) {
+	s := newTestStore(t)
+
+	first, err := s.AcquireIssueClaim("org/repo", 9, "worker-a", 5*time.Minute)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+
+	_, err = s.AcquireIssueClaim("org/repo", 9, "worker-b", 5*time.Minute)
+	if !errors.Is(err, ErrIssueClaimHeldByOther) {
+		t.Fatalf("expected ErrIssueClaimHeldByOther, got %v", err)
+	}
+
+	got, err := s.QueryIssueClaim("org/repo", 9)
+	if err != nil {
+		t.Fatalf("QueryIssueClaim: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected existing claim row")
+	}
+	if got.WorkerID != "worker-a" || got.ClaimToken != first.ClaimToken {
+		t.Fatalf("claim should still belong to worker-a with original token, got %+v", got)
+	}
+}
+
+// TestAcquireIssueClaimOverwritesExpired verifies an expired claim is
+// transparently overwritten by a new acquirer (AC-6, AC-8).
+func TestAcquireIssueClaimOverwritesExpired(t *testing.T) {
+	s := newTestStore(t)
+
+	// Acquire with a sub-second lease so we can wait it out.
+	if _, err := s.AcquireIssueClaim("org/repo", 11, "worker-a", time.Millisecond); err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	// SQLite datetime('now') has second resolution, so wait long enough for
+	// the lease to definitively expire.
+	time.Sleep(1100 * time.Millisecond)
+
+	res, err := s.AcquireIssueClaim("org/repo", 11, "worker-b", 5*time.Minute)
+	if err != nil {
+		t.Fatalf("expired re-acquire: %v", err)
+	}
+	if !res.OverwrotePrior {
+		t.Fatalf("expected OverwrotePrior=true, got %+v", res)
+	}
+	if res.PriorWorkerID != "worker-a" {
+		t.Fatalf("expected PriorWorkerID=worker-a, got %q", res.PriorWorkerID)
+	}
+	if res.ClaimToken == "" {
+		t.Fatal("expected non-empty replacement token")
+	}
+	got, err := s.QueryIssueClaim("org/repo", 11)
+	if err != nil {
+		t.Fatalf("QueryIssueClaim: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected current claim row")
+	}
+	if got.WorkerID != "worker-b" || got.ClaimToken != res.ClaimToken {
+		t.Fatalf("claim should now belong to worker-b with new token, got %+v", got)
+	}
+}
+
+// TestReleaseIssueClaim verifies release only succeeds for the holder (AC-3).
+func TestReleaseIssueClaim(t *testing.T) {
+	s := newTestStore(t)
+
+	if _, err := s.AcquireIssueClaim("org/repo", 5, "worker-a", 5*time.Minute); err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+
+	// Non-holder release is a no-op.
+	ok, err := s.ReleaseIssueClaim("org/repo", 5, "worker-b")
+	if err != nil {
+		t.Fatalf("non-holder release: %v", err)
+	}
+	if ok {
+		t.Fatal("expected non-holder release to return false")
+	}
+
+	// Holder release succeeds.
+	ok, err = s.ReleaseIssueClaim("org/repo", 5, "worker-a")
+	if err != nil {
+		t.Fatalf("holder release: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected holder release to return true")
+	}
+
+	got, err := s.QueryIssueClaim("org/repo", 5)
+	if err != nil {
+		t.Fatalf("QueryIssueClaim: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected claim to be deleted, got %+v", got)
+	}
+
+	// Releasing a missing claim returns false, not an error.
+	ok, err = s.ReleaseIssueClaim("org/repo", 5, "worker-a")
+	if err != nil {
+		t.Fatalf("release after delete: %v", err)
+	}
+	if ok {
+		t.Fatal("expected release of missing claim to return false")
+	}
+}
+
+// TestRefreshIssueClaim verifies refresh extends the holder's lease and is a
+// no-op for other workers or expired claims (AC-4).
+func TestRefreshIssueClaim(t *testing.T) {
+	s := newTestStore(t)
+
+	if _, err := s.AcquireIssueClaim("org/repo", 14, "worker-a", 30*time.Second); err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	before, err := s.QueryIssueClaim("org/repo", 14)
+	if err != nil {
+		t.Fatalf("QueryIssueClaim before: %v", err)
+	}
+
+	time.Sleep(1100 * time.Millisecond) // SQLite datetime() second resolution
+
+	ok, err := s.RefreshIssueClaim("org/repo", 14, "worker-a", 10*time.Minute)
+	if err != nil {
+		t.Fatalf("RefreshIssueClaim: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected refresh to succeed for holder")
+	}
+	after, err := s.QueryIssueClaim("org/repo", 14)
+	if err != nil {
+		t.Fatalf("QueryIssueClaim after: %v", err)
+	}
+	if !after.ExpiresAt.After(before.ExpiresAt) {
+		t.Fatalf("expected extended expires_at; before=%v after=%v", before.ExpiresAt, after.ExpiresAt)
+	}
+
+	// Non-holder refresh is a no-op.
+	ok, err = s.RefreshIssueClaim("org/repo", 14, "worker-b", 10*time.Minute)
+	if err != nil {
+		t.Fatalf("non-holder refresh: %v", err)
+	}
+	if ok {
+		t.Fatal("expected non-holder refresh to return false")
+	}
+
+	// Expired self-claim cannot be refreshed (the claim must be re-acquired).
+	if _, err := s.AcquireIssueClaim("org/repo", 15, "worker-a", time.Millisecond); err != nil {
+		t.Fatalf("acquire short: %v", err)
+	}
+	time.Sleep(1100 * time.Millisecond)
+	ok, err = s.RefreshIssueClaim("org/repo", 15, "worker-a", 10*time.Minute)
+	if err != nil {
+		t.Fatalf("refresh expired: %v", err)
+	}
+	if ok {
+		t.Fatal("expected refresh of expired self-claim to return false")
+	}
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"errors"
+	"fmt"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -1089,5 +1090,57 @@ func TestRefreshIssueClaim(t *testing.T) {
 	}
 	if ok {
 		t.Fatal("expected refresh of expired self-claim to return false")
+	}
+}
+
+// TestAcquireIssueClaimConcurrent exercises the primary-key conflict path
+// in AcquireIssueClaim: N goroutines racing on the same (repo, issueNum)
+// with distinct worker IDs must produce exactly one ClaimToken winner and
+// N-1 ErrIssueClaimHeldByOther results. Without the PK-conflict handler the
+// losers surface a raw "UNIQUE constraint failed" error.
+func TestAcquireIssueClaimConcurrent(t *testing.T) {
+	s := newTestStore(t)
+
+	const goroutines = 8
+	var (
+		wg       sync.WaitGroup
+		mu       sync.Mutex
+		wins     int
+		conflict int
+		other    []error
+	)
+	start := make(chan struct{})
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		worker := fmt.Sprintf("worker-%d", i)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := s.AcquireIssueClaim("org/repo", 77, worker, 5*time.Minute)
+			mu.Lock()
+			defer mu.Unlock()
+			switch {
+			case err == nil:
+				wins++
+			case errors.Is(err, ErrIssueClaimHeldByOther):
+				conflict++
+			default:
+				other = append(other, err)
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	if wins != 1 {
+		t.Fatalf("expected exactly one winner, got %d (conflicts=%d other=%v)", wins, conflict, other)
+	}
+	if len(other) > 0 {
+		t.Fatalf("unexpected errors from racing acquirers (conflicts=%d wins=%d): %v", conflict, wins, other)
+	}
+	if conflict != goroutines-1 {
+		t.Fatalf("expected %d conflicts, got %d", goroutines-1, conflict)
 	}
 }

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -1797,3 +1797,40 @@ requirements:
       - internal/statemachine/statemachine_test.go
       - internal/store/store_test.go
     deps: [REQ-001, REQ-017, REQ-030]
+
+  - id: REQ-057
+    title: Per-issue worker claim with TTL to prevent worker races
+    description: >
+      On issue #120 two workers (fedora and machine-ddq) were observed taking
+      turns dispatching on the same issue within seconds of each other because
+      the state machine's in-memory inflight map is cleared on every task
+      completion — letting a just-finished-then-immediately-redispatched issue
+      race between workers on each cycle. REQ-057 adds a SQLite-backed
+      issue_claim table so that only one coordinator can hold a dispatch lease
+      on a given (repo, issue) pair at a time. The claim is acquired by the
+      StateMachine before dispatchSingleAgent and released when the inflight
+      group for that issue finishes. Expired claims are transparently
+      overwritten (with a logged claim_expired event) so a crashed coordinator
+      cannot wedge an issue indefinitely.
+    priority: P0
+    version: v0.2.0
+    status: tested
+    acceptance_criteria:
+      - "AC-057-1: New issue_claim(repo, issue_num, worker_id, claim_token, acquired_at, expires_at) table with primary key (repo, issue_num), created by store.createTables"
+      - "AC-057-2: Store.AcquireIssueClaim atomically inserts or extends a claim, returning a claim_token on success or ErrIssueClaimHeldByOther when another worker holds an unexpired lease"
+      - "AC-057-3: Store.ReleaseIssueClaim deletes the claim only when it belongs to the given worker and reports whether a row was removed"
+      - "AC-057-4: Store.RefreshIssueClaim extends expires_at for the current holder, returning false when not held by the worker or already expired"
+      - "AC-057-5: StateMachine.DispatchAgent acquires the claim before dispatchSingleAgent; on contention it logs eventlog.TypeDispatchSkippedClaim and returns cleanly, and MarkAgentCompleted releases the claim when the group advances"
+      - "AC-057-6: An expired claim does not block; the new acquirer overwrites it and emits eventlog.TypeIssueClaimExpired"
+      - "AC-057-7: Default lease is statemachine.DefaultIssueClaimLease (30 minutes); wired through SetIssueClaim from serve.go and repo_runtime.go"
+      - "AC-057-8: Unit tests cover acquire-fresh, self-extend, conflict, expired-overwrite, release, and refresh"
+    code:
+      - internal/store/store.go
+      - internal/statemachine/statemachine.go
+      - internal/eventlog/eventlog.go
+      - cmd/serve.go
+      - cmd/repo_runtime.go
+    tests:
+      - internal/store/store_test.go
+      - internal/statemachine/statemachine_test.go
+    deps: [REQ-017, REQ-027, REQ-030]


### PR DESCRIPTION
Fixes #132.

## Summary

- New `issue_claim(repo, issue_num, worker_id, claim_token, acquired_at, expires_at)` SQLite table with PK `(repo, issue_num)`, wired into `(*Store).createTables`.
- `(*Store).AcquireIssueClaim` / `ReleaseIssueClaim` / `RefreshIssueClaim` / `QueryIssueClaim` — atomic lease primitives. Acquisition returns the sentinel `ErrIssueClaimHeldByOther` when another worker holds an unexpired claim; expired claims are transparently overwritten.
- `StateMachine.SetIssueClaim(claimerID, lease)` enables persistent claim acquisition. `DispatchAgent` now acquires before `dispatchSingleAgent`; `MarkAgentCompleted` (and the context-cancel rollback) releases when the group advances.
- New event types `eventlog.TypeDispatchSkippedClaim` and `TypeIssueClaimExpired` (added to `AllEventTypes`).
- Default lease of 30 minutes (`statemachine.DefaultIssueClaimLease`). `serve.go` wires the claimer to the embedded worker ID; `repo_runtime.go` (distributed coordinator) uses `coordinator-<hostname>`.

## Rationale for AC-5 design choice

Coordinator-side acquisition (Option A) was chosen because `DispatchAgent` is a single choke point every dispatch flows through — the lease protects the full issue cycle rather than a single task-queue row, release lives in exactly one place, and worker-side acquisition would have required matching changes in `serve.go`, `worker.go`, and every redispatch-after-failure path for marginal benefit.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1` (all packages green)
- [x] `python3 ~/.autoharness/scripts/validate_index.py project-index.yaml`
- [x] New store tests: `TestAcquireIssueClaimFresh`, `TestAcquireIssueClaimSelfExtend`, `TestAcquireIssueClaimHeldByOther`, `TestAcquireIssueClaimOverwritesExpired`, `TestReleaseIssueClaim`, `TestRefreshIssueClaim`
- [x] New statemachine integration tests: `TestDispatchAgentRespectsIssueClaim` (two coordinators sharing one Store, second one blocked + logs `dispatch_skipped_claim`, unblocks after the holder's `MarkAgentCompleted`), `TestDispatchAgentReleasesOnContextCancel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)