### PR TITLE
Support codex v2 stream schema and stop raw output fallback

### DIFF
--- a/internal/launcher/codex.go
+++ b/internal/launcher/codex.go
@@ -282,6 +282,9 @@ func (s *codexSession) Run(ctx context.Context, events chan<- launcherevents.Eve
 	}
 
 	lastMessage := readOptionalFile(s.lastMsgPath)
+	if lastMessage == "" {
+		lastMessage = strings.TrimSpace(mapper.lastMessage)
+	}
 	result := &Result{
 		ExitCode:    exitCode,
 		Stdout:      stdoutBuf.String(),
@@ -381,6 +384,7 @@ type codexEventMapper struct {
 	sessionID        string
 	sessionRef       SessionRef
 	turnID           string
+	lastMessage      string
 	tokenUsage       *launcherevents.TokenUsagePayload
 	turnCompleteSaw  bool
 	turnCompleted    *launcherevents.TurnCompletedPayload
@@ -406,6 +410,45 @@ func (m *codexEventMapper) Map(line []byte, seq *uint64) []launcherevents.Event 
 
 	msgType := rawString(raw, "type")
 	switch msgType {
+	case "thread.started":
+		if threadID := rawString(raw, "thread_id"); threadID != "" {
+			m.sessionRef = SessionRef{ID: threadID, Kind: "codex-thread"}
+		}
+		return nil
+
+	case "turn.started":
+		turnID := firstNonEmpty(rawString(raw, "turn_id"), rawString(raw, "task_id"), m.effectiveTurnID())
+		m.turnID = turnID
+		if refID := firstNonEmpty(rawString(raw, "thread_id"), rawString(raw, "session_id")); refID != "" {
+			kind := "codex-session"
+			if rawString(raw, "thread_id") != "" {
+				kind = "codex-thread"
+			}
+			m.sessionRef = SessionRef{ID: refID, Kind: kind}
+		}
+		return []launcherevents.Event{m.makeEvent(seq, launcherevents.KindTurnStarted, launcherevents.TurnStartedPayload{TurnID: turnID}, line)}
+
+	case "item.started", "item.completed":
+		return m.mapItemEvent(raw, msgType == "item.completed", line, seq)
+
+	case "turn.completed":
+		status := firstNonEmpty(rawString(raw, "status"), "ok")
+		m.turnCompleteSaw = true
+		payload := launcherevents.TurnCompletedPayload{TurnID: m.effectiveTurnID(), Status: status}
+		m.turnCompleted = &payload
+		m.turnCompletedRaw = cloneRaw(line)
+
+		var out []launcherevents.Event
+		if usage := codexTurnUsage(rawObject(raw, "usage")); usage != nil {
+			m.tokenUsage = usage
+			out = append(out, m.makeEvent(seq, launcherevents.KindTokenUsage, *usage, line))
+		}
+		out = append(out, m.makeEvent(seq, launcherevents.KindTaskComplete, launcherevents.TaskCompletePayload{
+			TurnID: m.effectiveTurnID(),
+			Status: status,
+		}, line))
+		return out
+
 	case "task_started":
 		turnID := rawString(raw, "task_id")
 		if turnID == "" {
@@ -529,6 +572,82 @@ func (m *codexEventMapper) Map(line []byte, seq *uint64) []launcherevents.Event 
 	}
 }
 
+func (m *codexEventMapper) mapItemEvent(raw map[string]json.RawMessage, completed bool, line []byte, seq *uint64) []launcherevents.Event {
+	item := rawObject(raw, "item")
+	if item == nil {
+		return []launcherevents.Event{m.makeEvent(seq, launcherevents.KindLog, launcherevents.LogPayload{Stream: "stdout", Line: string(line)}, line)}
+	}
+
+	itemType := rawString(item, "type")
+	itemID := rawString(item, "id")
+	switch itemType {
+	case "agent_message":
+		text := strings.TrimSpace(rawString(item, "text"))
+		if text == "" {
+			return nil
+		}
+		if completed {
+			m.lastMessage = text
+		}
+		return []launcherevents.Event{m.makeEvent(seq, launcherevents.KindAgentMessage, launcherevents.AgentMessagePayload{Text: text, Delta: false, Final: completed}, line)}
+
+	case "reasoning", "agent_reasoning":
+		text := strings.TrimSpace(rawString(item, "text"))
+		if text == "" {
+			return nil
+		}
+		return []launcherevents.Event{m.makeEvent(seq, launcherevents.KindReasoning, launcherevents.ReasoningPayload{Text: text, Delta: false}, line)}
+
+	case "command_execution":
+		if !completed {
+			return []launcherevents.Event{m.makeEvent(seq, launcherevents.KindCommandExec, launcherevents.CommandExecPayload{
+				Cmd:    rawStringSlice(item, "command"),
+				CWD:    rawString(item, "cwd"),
+				CallID: itemID,
+			}, line)}
+		}
+		ok := true
+		if code, hasCode := rawInt(item, "exit_code"); hasCode {
+			ok = code == 0
+		}
+		var out []launcherevents.Event
+		if output := rawString(item, "aggregated_output"); output != "" {
+			out = append(out, m.makeEvent(seq, launcherevents.KindCommandOutput, launcherevents.CommandOutputPayload{
+				CallID: itemID,
+				Stream: "stdout",
+				Data:   output,
+			}, line))
+		}
+		out = append(out, m.makeEvent(seq, launcherevents.KindToolResult, launcherevents.ToolResultPayload{
+			CallID: itemID,
+			OK:     ok,
+			Result: append(json.RawMessage(nil), line...),
+		}, line))
+		return out
+
+	case "mcp_tool_call":
+		if !completed {
+			return []launcherevents.Event{m.makeEvent(seq, launcherevents.KindToolCall, launcherevents.ToolCallPayload{
+				Name:   rawString(item, "tool"),
+				CallID: itemID,
+				Args:   cloneRaw(item["arguments"]),
+			}, line)}
+		}
+		result := cloneRaw(item["result"])
+		if len(result) == 0 {
+			result = append(json.RawMessage(nil), line...)
+		}
+		return []launcherevents.Event{m.makeEvent(seq, launcherevents.KindToolResult, launcherevents.ToolResultPayload{
+			CallID: itemID,
+			OK:     rawString(item, "status") != "failed" && !rawBool(item, "is_error"),
+			Result: result,
+		}, line)}
+
+	default:
+		return []launcherevents.Event{m.makeEvent(seq, launcherevents.KindLog, launcherevents.LogPayload{Stream: "stdout", Line: string(line)}, line)}
+	}
+}
+
 func (m *codexEventMapper) taskCompleteObserved() bool {
 	return m.turnCompleteSaw
 }
@@ -608,6 +727,19 @@ func rawObject(raw map[string]json.RawMessage, key string) map[string]json.RawMe
 		return nil
 	}
 	return value
+}
+
+func codexTurnUsage(raw map[string]json.RawMessage) *launcherevents.TokenUsagePayload {
+	if len(raw) == 0 {
+		return nil
+	}
+	payload := &launcherevents.TokenUsagePayload{
+		Input:  rawIntValue(raw, "input_tokens"),
+		Output: rawIntValue(raw, "output_tokens"),
+		Cached: rawIntValue(raw, "cached_input_tokens"),
+	}
+	payload.Total = payload.Input + payload.Output
+	return payload
 }
 
 func cloneRaw(data []byte) json.RawMessage {

--- a/internal/launcher/codex_test.go
+++ b/internal/launcher/codex_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestCodexEventMapperFixture(t *testing.T) {
-	data, err := os.ReadFile(filepath.Join("testdata", "codex-exec-events.jsonl"))
+	data, err := os.ReadFile(filepath.Join("testdata", "codex-exec-events-v2.jsonl"))
 	if err != nil {
 		t.Fatalf("read fixture: %v", err)
 	}
@@ -30,21 +30,18 @@ func TestCodexEventMapperFixture(t *testing.T) {
 	if mapper.sessionRef.ID != "thread-abc" {
 		t.Fatalf("session ref = %+v", mapper.sessionRef)
 	}
-	if mapper.turnID != "task-123" {
+	if mapper.turnID != "turn-123" {
 		t.Fatalf("turn id = %q", mapper.turnID)
 	}
 
 	wantKinds := []launcherevents.EventKind{
 		launcherevents.KindTurnStarted,
 		launcherevents.KindAgentMessage,
-		launcherevents.KindAgentMessage,
-		launcherevents.KindReasoning,
 		launcherevents.KindCommandExec,
 		launcherevents.KindCommandOutput,
 		launcherevents.KindToolResult,
 		launcherevents.KindToolCall,
 		launcherevents.KindToolResult,
-		launcherevents.KindFileChange,
 		launcherevents.KindTokenUsage,
 		launcherevents.KindTaskComplete,
 	}
@@ -58,22 +55,17 @@ func TestCodexEventMapperFixture(t *testing.T) {
 	}
 
 	var usage launcherevents.TokenUsagePayload
-	if err := json.Unmarshal(got[10].Payload, &usage); err != nil {
+	if err := json.Unmarshal(got[7].Payload, &usage); err != nil {
 		t.Fatalf("usage payload: %v", err)
 	}
 	if usage.Total != 16 || usage.Cached != 2 {
 		t.Fatalf("unexpected usage: %+v", usage)
 	}
-
-	var change launcherevents.FileChangePayload
-	if err := json.Unmarshal(got[9].Payload, &change); err != nil {
-		t.Fatalf("file change payload: %v", err)
-	}
-	if change.Path != "file.txt" || change.ChangeKind != "modify" {
-		t.Fatalf("unexpected file change: %+v", change)
-	}
 	if mapper.turnCompleted == nil || mapper.turnCompleted.Status != "ok" {
 		t.Fatalf("pending turn completion = %+v", mapper.turnCompleted)
+	}
+	if mapper.lastMessage != "PONG" {
+		t.Fatalf("last message = %q", mapper.lastMessage)
 	}
 }
 
@@ -133,7 +125,9 @@ func TestLaunch_CodexRuntimeUsesPrompt(t *testing.T) {
 		t.Fatalf("read session path: %v", err)
 	}
 	if !strings.Contains(string(data), `"type":"task_complete"`) {
-		t.Fatalf("expected codex jsonl artifact, got: %s", string(data))
+		if !strings.Contains(string(data), `"type":"turn.completed"`) {
+			t.Fatalf("expected codex jsonl artifact, got: %s", string(data))
+		}
 	}
 }
 
@@ -204,6 +198,31 @@ func TestCodexSessionRunEmitsEventsAndArtifact(t *testing.T) {
 	lastMsgPath := filepath.Join(filepath.Dir(result.SessionPath), "codex-last-message.txt")
 	if _, err := os.Stat(lastMsgPath); err != nil {
 		t.Fatalf("expected last message file: %v", err)
+	}
+}
+
+func TestLaunch_CodexRuntimeRecoversLastMessageFromV2Stream(t *testing.T) {
+	restore := installFakeCodexNoLastMessage(t)
+	defer restore()
+
+	launcher := NewLauncher()
+	task := newTestTask(t)
+	agent := &config.AgentConfig{
+		Name:    "codex-agent",
+		Runtime: config.RuntimeCodexExec,
+		Prompt:  "Reply with exactly PONG",
+		Policy: config.PolicyConfig{
+			Sandbox:  "read-only",
+			Approval: "never",
+		},
+		Timeout: 10 * time.Second,
+	}
+	result, err := launcher.Launch(context.Background(), agent, task)
+	if err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	if result.LastMessage != "PONG" {
+		t.Fatalf("last message = %q", result.LastMessage)
 	}
 }
 
@@ -502,7 +521,7 @@ func installFakeCodex(t *testing.T) func() {
 	t.Helper()
 
 	fixturePath := filepath.Join(t.TempDir(), "codex-exec-events.jsonl")
-	data, err := os.ReadFile(filepath.Join("testdata", "codex-exec-events.jsonl"))
+	data, err := os.ReadFile(filepath.Join("testdata", "codex-exec-events-v2.jsonl"))
 	if err != nil {
 		t.Fatalf("read fixture: %v", err)
 	}
@@ -544,11 +563,40 @@ func installFakeCodex(t *testing.T) func() {
 	}
 }
 
+func installFakeCodexNoLastMessage(t *testing.T) func() {
+	t.Helper()
+
+	fixturePath := filepath.Join(t.TempDir(), "codex-exec-events.jsonl")
+	data, err := os.ReadFile(filepath.Join("testdata", "codex-exec-events-v2.jsonl"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	if err := os.WriteFile(fixturePath, data, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	binDir := t.TempDir()
+	scriptPath := filepath.Join(binDir, "codex")
+	script := "#!/bin/sh\n" +
+		"cat \"" + fixturePath + "\"\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake codex: %v", err)
+	}
+
+	oldPath := os.Getenv("PATH")
+	if err := os.Setenv("PATH", binDir+string(os.PathListSeparator)+oldPath); err != nil {
+		t.Fatalf("set PATH: %v", err)
+	}
+	return func() {
+		_ = os.Setenv("PATH", oldPath)
+	}
+}
+
 func installFakeCodexLastMessage(t *testing.T, lastMessage string) func() {
 	t.Helper()
 
 	fixturePath := filepath.Join(t.TempDir(), "codex-exec-events.jsonl")
-	data, err := os.ReadFile(filepath.Join("testdata", "codex-exec-events.jsonl"))
+	data, err := os.ReadFile(filepath.Join("testdata", "codex-exec-events-v2.jsonl"))
 	if err != nil {
 		t.Fatalf("read fixture: %v", err)
 	}

--- a/internal/launcher/testdata/codex-exec-events-v2.jsonl
+++ b/internal/launcher/testdata/codex-exec-events-v2.jsonl
@@ -1,0 +1,8 @@
+{"type":"thread.started","thread_id":"thread-abc"}
+{"type":"turn.started","turn_id":"turn-123"}
+{"type":"item.completed","item":{"id":"item-1","type":"agent_message","text":"PONG"}}
+{"type":"item.started","item":{"id":"item-2","type":"command_execution","command":["bash","-lc","echo PONG"],"cwd":"/tmp/repo","status":"in_progress"}}
+{"type":"item.completed","item":{"id":"item-2","type":"command_execution","command":["bash","-lc","echo PONG"],"aggregated_output":"PONG\n","exit_code":0,"status":"completed"}}
+{"type":"item.started","item":{"id":"item-3","type":"mcp_tool_call","tool":"github.search","arguments":{"q":"issue 8"},"status":"in_progress"}}
+{"type":"item.completed","item":{"id":"item-3","type":"mcp_tool_call","tool":"github.search","arguments":{"q":"issue 8"},"result":{"count":1},"status":"completed"}}
+{"type":"turn.completed","usage":{"input_tokens":11,"cached_input_tokens":2,"output_tokens":5}}

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -214,13 +214,9 @@ func (r *Reporter) Verify(ctx context.Context, repo string, issueNum int, result
 	if r.verifier == nil || result == nil || result.ExitCode != 0 {
 		return nil, nil
 	}
-	output := result.LastMessage
-	if output == "" {
-		output = result.Stdout
-	}
 	finishedAt := r.now()
 	return r.verifier.Verify(ctx, repo, issueNum, VerificationInput{
-		Output:    output,
+		Output:    reportOutput(result),
 		StartedAt: finishedAt.Add(-result.Duration),
 		EndedAt:   finishedAt,
 	})
@@ -336,13 +332,9 @@ func (r *Reporter) report(
 
 	// Run claim verification for successful runs
 	if status == "success" && verification == nil && r.verifier != nil {
-		output := result.LastMessage
-		if output == "" {
-			output = result.Stdout
-		}
 		finishedAt := r.now()
 		vRes, vErr := r.verifier.Verify(ctx, repo, issueNum, VerificationInput{
-			Output:    output,
+			Output:    reportOutput(result),
 			StartedAt: finishedAt.Add(-result.Duration),
 			EndedAt:   finishedAt,
 		})
@@ -378,10 +370,7 @@ func (r *Reporter) report(
 		prLink = result.Meta["pr_url"]
 	}
 
-	output := result.LastMessage
-	if output == "" {
-		output = result.Stdout
-	}
+	output := reportOutput(result)
 	if output == "" && result.Stderr != "" {
 		output = result.Stderr
 	}
@@ -414,6 +403,13 @@ func (r *Reporter) report(
 	return verification, r.writeWithRateLimitRetry(ctx, repo, issueNum, "report", func() error {
 		return r.gh.WriteComment(repo, issueNum, body)
 	})
+}
+
+func reportOutput(result *launcher.Result) string {
+	if result == nil {
+		return ""
+	}
+	return strings.TrimSpace(result.LastMessage)
 }
 
 func (r *Reporter) reportWithOverflow(ctx context.Context, repo string, issueNum int, agentName, body, workDir string) error {

--- a/internal/reporter/reporter_test.go
+++ b/internal/reporter/reporter_test.go
@@ -85,10 +85,10 @@ func TestReport_Success(t *testing.T) {
 	r := NewReporter(gh)
 
 	result := &launcher.Result{
-		ExitCode: 0,
-		Stdout:   "all good",
-		Duration: 5 * time.Second,
-		Meta:     map[string]string{"pr_url": "https://github.com/test/repo/pull/1"},
+		ExitCode:    0,
+		LastMessage: "all good",
+		Duration:    5 * time.Second,
+		Meta:        map[string]string{"pr_url": "https://github.com/test/repo/pull/1"},
 	}
 
 	err := r.Report(context.Background(), "test/repo", 42, "dev-agent", result, "sess-123", "worker-1", 1, 3, "Label transition: developing -> reviewing (OK)", "")
@@ -159,6 +159,25 @@ func TestReport_PrefersLastMessage(t *testing.T) {
 	}
 	if strings.Contains(body, "raw stdout") {
 		t.Fatalf("expected stdout fallback not to be used: %s", body)
+	}
+}
+
+func TestReport_DoesNotFallbackToStdout(t *testing.T) {
+	gh := &mockGHWriter{}
+	r := NewReporter(gh)
+
+	result := &launcher.Result{
+		ExitCode: 0,
+		Stdout:   "{\"type\":\"turn.started\"}\n{\"type\":\"item.completed\"}",
+		Duration: time.Second,
+	}
+
+	if err := r.Report(context.Background(), "test/repo", 42, "dev-agent", result, "sess-no-stdout", "worker-1", 0, 3, "", ""); err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+	body := gh.comments[0]
+	if strings.Contains(body, "{\"type\":\"turn.started\"}") {
+		t.Fatalf("expected raw stdout to be omitted from report: %s", body)
 	}
 }
 
@@ -271,6 +290,28 @@ func TestReporterVerify_UsesRunWindow(t *testing.T) {
 	}
 }
 
+func TestReporterVerify_DoesNotFallbackToStdout(t *testing.T) {
+	r := NewReporter(&mockGHWriter{})
+	v := &mockVerifier{result: &VerificationResult{}}
+	r.SetVerifier(v)
+
+	result := &launcher.Result{
+		ExitCode: 0,
+		Stdout:   "{\"type\":\"turn.started\"}",
+		Duration: time.Second,
+	}
+
+	if _, err := r.Verify(context.Background(), "test/repo", 42, result); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if v.calls != 1 {
+		t.Fatalf("expected verifier call, got %d", v.calls)
+	}
+	if got := v.inputs[0].Output; got != "" {
+		t.Fatalf("output = %q, want empty string", got)
+	}
+}
+
 func TestReport_RetryOnRateLimit(t *testing.T) {
 	gh := &mockGHWriter{failN: 2}
 	r := NewReporter(gh)
@@ -281,9 +322,9 @@ func TestReport_RetryOnRateLimit(t *testing.T) {
 	rateLimitRetryDelays = []time.Duration{1 * time.Millisecond}
 	defer func() { rateLimitRetryDelays = saved }()
 	result := &launcher.Result{
-		ExitCode: 0,
-		Stdout:   "ok",
-		Duration: 1 * time.Second,
+		ExitCode:    0,
+		LastMessage: "ok",
+		Duration:    1 * time.Second,
 	}
 	err := r.Report(context.Background(), "test/repo", 42, "dev-agent", result, "sess-789", "worker-1", 0, 3, "", "")
 	if err != nil {
@@ -311,9 +352,9 @@ func TestReport_RateLimitPayloadRedactsToken(t *testing.T) {
 	defer func() { rateLimitRetryDelays = saved }()
 
 	result := &launcher.Result{
-		ExitCode: 0,
-		Stdout:   "ok",
-		Duration: 1 * time.Second,
+		ExitCode:    0,
+		LastMessage: "ok",
+		Duration:    1 * time.Second,
 	}
 	err := r.Report(context.Background(), "test/repo", 42, "dev-agent", result, "sess-redact", "worker-1", 0, 3, "", "")
 	if err != nil {
@@ -350,9 +391,9 @@ func TestReport_RetryCancelsWithContext(t *testing.T) {
 	}()
 
 	result := &launcher.Result{
-		ExitCode: 0,
-		Stdout:   "ok",
-		Duration: 1 * time.Second,
+		ExitCode:    0,
+		LastMessage: "ok",
+		Duration:    1 * time.Second,
 	}
 	err := r.Report(ctx, "test/repo", 42, "dev-agent", result, "sess-cancel", "worker-1", 0, 3, "", "")
 	if err == nil {
@@ -452,9 +493,9 @@ func TestReport_UnderLimit(t *testing.T) {
 
 	// Body under the limit should be posted verbatim.
 	result := &launcher.Result{
-		ExitCode: 0,
-		Stdout:   "short output",
-		Duration: time.Second,
+		ExitCode:    0,
+		LastMessage: "short output",
+		Duration:    time.Second,
 	}
 	if err := r.Report(context.Background(), "test/repo", 42, "dev-agent", result, "sess-1", "worker-1", 0, 3, "", ""); err != nil {
 		t.Fatalf("Report: %v", err)
@@ -478,9 +519,9 @@ func TestReport_OverflowWithoutWorkDir(t *testing.T) {
 
 	longOutput := strings.Repeat("a", 70000)
 	result := &launcher.Result{
-		ExitCode: 0,
-		Stdout:   longOutput,
-		Duration: time.Second,
+		ExitCode:    0,
+		LastMessage: longOutput,
+		Duration:    time.Second,
 	}
 
 	if err := r.Report(context.Background(), "test/repo", 42, "dev-agent", result, "sess-2", "worker-1", 0, 3, "", ""); err != nil {
@@ -570,9 +611,9 @@ func TestReport_OverflowWithWorkDir(t *testing.T) {
 
 	longOutput := strings.Repeat("b", 70000)
 	result := &launcher.Result{
-		ExitCode: 0,
-		Stdout:   longOutput,
-		Duration: time.Second,
+		ExitCode:    0,
+		LastMessage: longOutput,
+		Duration:    time.Second,
 	}
 
 	if err := r.Report(context.Background(), "owner/repo", 42, "dev-agent", result, "sess-3", "worker-1", 0, 3, "", tmpDir); err != nil {
@@ -658,9 +699,9 @@ func TestReport_OverflowWithUnsafeAgentName(t *testing.T) {
 	r := NewReporter(gh)
 
 	result := &launcher.Result{
-		ExitCode: 0,
-		Stdout:   strings.Repeat("unsafe", 12000),
-		Duration: time.Second,
+		ExitCode:    0,
+		LastMessage: strings.Repeat("unsafe", 12000),
+		Duration:    time.Second,
 	}
 
 	if err := r.Report(context.Background(), "owner/repo", 42, "review/agent", result, "sess-unsafe", "worker-1", 0, 3, "", tmpDir); err != nil {
@@ -694,9 +735,9 @@ func TestReport_OverflowWithWorkDirButNotGitRepo(t *testing.T) {
 
 	longOutput := strings.Repeat("c", 70000)
 	result := &launcher.Result{
-		ExitCode: 0,
-		Stdout:   longOutput,
-		Duration: time.Second,
+		ExitCode:    0,
+		LastMessage: longOutput,
+		Duration:    time.Second,
 	}
 
 	tmpDir := t.TempDir()
@@ -738,9 +779,9 @@ func TestReport_OverflowUsesByteCountForUTF8(t *testing.T) {
 	// the character count is below the byte guard.
 	longOutput := strings.Repeat("你", 25000)
 	result := &launcher.Result{
-		ExitCode: 0,
-		Stdout:   longOutput,
-		Duration: time.Second,
+		ExitCode:    0,
+		LastMessage: longOutput,
+		Duration:    time.Second,
 	}
 
 	if err := r.Report(context.Background(), "test/repo", 42, "dev-agent", result, "sess-utf8", "worker-1", 0, 3, "", ""); err != nil {


### PR DESCRIPTION
Fixes the codex session parsing/reporting issue where workbuddy could dump raw JSONL into issue comments.

What changed:
- support the newer codex raw stream schema (`thread.started`, `turn.started`, `item.*`, `turn.completed`)
- recover the final agent message from the v2 stream when `codex-last-message.txt` is missing
- stop reporter/verifier fallback to raw stdout so issue comments no longer dump JSONL
- add/refresh tests for the new schema and the no-raw-fallback behavior

Validation:
- `go test ./internal/launcher ./internal/reporter`