### PR TITLE
Make poll cycle a two-phase snapshot (#145)

### DIFF
--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -178,13 +178,26 @@ func (p *Poller) Run(ctx context.Context) error {
 	}
 }
 
-// poll performs a single poll cycle: list issues + PRs, diff against cache, emit events.
-// Always emits EventPollCycleDone before returning so consumers can use it as a
-// per-cycle boundary signal (e.g. to reset dedup state).
+// poll performs a single poll cycle as a two-phase snapshot:
+//
+//  1. Collect phase — list issues + PRs and diff them against the cache
+//     purely in memory, producing a list of pending events and a list of
+//     pending cache mutations. No cache writes happen here.
+//  2. Commit phase — once every GitHub read has succeeded, apply all cache
+//     mutations and emit all pending events. Only at the end do we emit
+//     EventPollCycleDone.
+//
+// If any GitHub read fails partway through phase 1 (e.g. `gh pr list`
+// returns an error after `gh issue list` succeeded), we abort without
+// touching the cache and without emitting EventPollCycleDone, so the next
+// cycle will re-diff the same issues and no changes are silently lost. See
+// issue #145 finding #3.
 func (p *Poller) poll(ctx context.Context) {
-	defer p.emit(ctx, ChangeEvent{Type: EventPollCycleDone, Repo: p.repo})
+	// --- Phase 1: collect everything in memory ---
 	var pending []ChangeEvent
-	// --- Issues ---
+	var cacheOps []func() error
+
+	// Issues.
 	issues, err := p.gh.ListIssues(p.repo)
 	if err != nil {
 		if ghutil.IsRateLimit(err) {
@@ -200,10 +213,19 @@ func (p *Poller) poll(ctx context.Context) {
 		if ctx.Err() != nil {
 			return
 		}
-		pending = append(pending, p.diffIssue(iss)...)
+		evts, op, ok := p.planDiffIssue(iss)
+		if !ok {
+			// Cache query failed; treat as a phase-1 failure and abort
+			// before touching anything so the next cycle can retry.
+			return
+		}
+		pending = append(pending, evts...)
+		if op != nil {
+			cacheOps = append(cacheOps, op)
+		}
 	}
 
-	// --- PRs ---
+	// PRs.
 	prs, err := p.gh.ListPRs(p.repo)
 	if err != nil {
 		if ghutil.IsRateLimit(err) {
@@ -212,22 +234,30 @@ func (p *Poller) poll(ctx context.Context) {
 		} else {
 			log.Printf("[poller] error listing PRs for %s: %v", p.repo, err)
 		}
+		// Phase 1 failed: do NOT commit cache, do NOT emit events, do NOT
+		// emit EventPollCycleDone. The next cycle will re-observe the same
+		// issue changes and re-emit them.
 		return
 	}
-	p.ResetBackoff()
 
 	for _, pr := range prs {
 		if ctx.Err() != nil {
 			return
 		}
-		pending = append(pending, p.diffPR(pr)...)
+		evts, op, ok := p.planDiffPR(pr)
+		if !ok {
+			return
+		}
+		pending = append(pending, evts...)
+		if op != nil {
+			cacheOps = append(cacheOps, op)
+		}
 	}
 
-	// --- Detect closed/deleted issues ---
-	// Compare cached issue numbers against what we saw this poll.
-	// Issues in cache but not in current results have been closed/deleted.
-	// Skip this check if the result set may be truncated (gh --limit 100),
-	// since issues beyond the first page would be falsely classified as closed.
+	// Closed/deleted issue detection.
+	// Compare cached issue numbers against what we saw this poll. Issues in
+	// cache but not in current results have been closed or deleted. Skip
+	// when the result set may be truncated (gh --limit 100).
 	if len(issues) >= ghListLimit {
 		log.Printf("[poller] issue list may be truncated (%d results), skipping close detection", len(issues))
 	} else {
@@ -235,7 +265,6 @@ func (p *Poller) poll(ctx context.Context) {
 		for _, iss := range issues {
 			openIssueNums[iss.Number] = true
 		}
-		// Also include PR numbers so we don't treat them as closed issues.
 		openPRNums := make(map[int]bool, len(prs))
 		for _, pr := range prs {
 			openPRNums[pr.Number] = true
@@ -254,16 +283,32 @@ func (p *Poller) poll(ctx context.Context) {
 			if openIssueNums[num] || openPRNums[num] {
 				continue
 			}
+			closedNum := num
 			pending = append(pending, ChangeEvent{
 				Type:     EventIssueClosed,
 				Repo:     p.repo,
-				IssueNum: num,
+				IssueNum: closedNum,
 				Detail:   "issue no longer in open issues list",
 			})
-			if err := p.store.DeleteIssueCache(p.repo, num); err != nil {
-				log.Printf("[poller] error deleting cache for closed issue %s#%d: %v", p.repo, num, err)
-			}
+			cacheOps = append(cacheOps, func() error {
+				if err := p.store.DeleteIssueCache(p.repo, closedNum); err != nil {
+					log.Printf("[poller] error deleting cache for closed issue %s#%d: %v", p.repo, closedNum, err)
+					return err
+				}
+				return nil
+			})
 		}
+	}
+
+	// All GH reads succeeded. Safe to reset backoff now.
+	p.ResetBackoff()
+
+	// --- Phase 2: commit cache updates, then emit events + cycle-done. ---
+	for _, op := range cacheOps {
+		if ctx.Err() != nil {
+			return
+		}
+		_ = op()
 	}
 	for _, ev := range pending {
 		if ctx.Err() != nil {
@@ -271,17 +316,20 @@ func (p *Poller) poll(ctx context.Context) {
 		}
 		p.emit(ctx, ev)
 	}
+	p.emit(ctx, ChangeEvent{Type: EventPollCycleDone, Repo: p.repo})
 }
 
-// diffIssue compares a live issue against the cache and emits change events.
-func (p *Poller) diffIssue(iss Issue) []ChangeEvent {
+// planDiffIssue computes pending change events and a deferred cache-write op
+// for a live issue without mutating the cache. The ok return is false only
+// when querying the cache itself fails — which we treat as a phase-1 failure
+// so the whole cycle can be retried.
+func (p *Poller) planDiffIssue(iss Issue) (events []ChangeEvent, cacheOp func() error, ok bool) {
 	labelsJSON := labelsToJSON(iss.Labels)
-	var events []ChangeEvent
 
 	cached, err := p.store.QueryIssueCache(p.repo, iss.Number)
 	if err != nil {
 		log.Printf("[poller] error querying cache for %s#%d: %v", p.repo, iss.Number, err)
-		return nil
+		return nil, nil, false
 	}
 
 	if cached == nil {
@@ -294,7 +342,6 @@ func (p *Poller) diffIssue(iss Issue) []ChangeEvent {
 			Author:   iss.Author,
 		})
 	} else {
-		// Compare labels.
 		oldLabels := labelsFromJSON(cached.Labels)
 		added, removed := diffLabels(oldLabels, iss.Labels)
 		for _, l := range added {
@@ -319,32 +366,35 @@ func (p *Poller) diffIssue(iss Issue) []ChangeEvent {
 		}
 	}
 
-	// Update cache.
-	if err := p.store.UpsertIssueCache(store.IssueCache{
-		Repo:     p.repo,
-		IssueNum: iss.Number,
-		Labels:   labelsJSON,
-		Body:     iss.Body,
-		State:    strings.ToLower(iss.State),
-	}); err != nil {
-		log.Printf("[poller] error upserting cache for %s#%d: %v", p.repo, iss.Number, err)
+	issCopy := iss
+	cacheOp = func() error {
+		if err := p.store.UpsertIssueCache(store.IssueCache{
+			Repo:     p.repo,
+			IssueNum: issCopy.Number,
+			Labels:   labelsJSON,
+			Body:     issCopy.Body,
+			State:    strings.ToLower(issCopy.State),
+		}); err != nil {
+			log.Printf("[poller] error upserting cache for %s#%d: %v", p.repo, issCopy.Number, err)
+			return err
+		}
+		return nil
 	}
-	return events
+	return events, cacheOp, true
 }
 
-// diffPR compares a live PR against the cache and emits change events.
-func (p *Poller) diffPR(pr PR) []ChangeEvent {
-	// PRs are cached with negative number to avoid collision with issues.
-	// Actually, PR numbers are distinct from issue numbers on GitHub, but
-	// to be safe we use a "pr:" prefix in the state field.
+// planDiffPR computes pending change events and a deferred cache-write op
+// for a live PR without mutating the cache.
+func (p *Poller) planDiffPR(pr PR) (events []ChangeEvent, cacheOp func() error, ok bool) {
+	// PR numbers are distinct from issue numbers on GitHub, but to be safe
+	// we prefix the cached state with "pr:".
 	stateVal := "pr:" + strings.ToLower(pr.State)
 
 	cached, err := p.store.QueryIssueCache(p.repo, pr.Number)
 	if err != nil {
 		log.Printf("[poller] error querying cache for PR %s#%d: %v", p.repo, pr.Number, err)
-		return nil
+		return nil, nil, false
 	}
-	var events []ChangeEvent
 
 	if cached == nil {
 		events = append(events, ChangeEvent{
@@ -362,17 +412,21 @@ func (p *Poller) diffPR(pr PR) []ChangeEvent {
 		})
 	}
 
-	// Update cache.
-	if err := p.store.UpsertIssueCache(store.IssueCache{
-		Repo:     p.repo,
-		IssueNum: pr.Number,
-		Labels:   "",
-		Body:     "",
-		State:    stateVal,
-	}); err != nil {
-		log.Printf("[poller] error upserting cache for PR %s#%d: %v", p.repo, pr.Number, err)
+	prCopy := pr
+	cacheOp = func() error {
+		if err := p.store.UpsertIssueCache(store.IssueCache{
+			Repo:     p.repo,
+			IssueNum: prCopy.Number,
+			Labels:   "",
+			Body:     "",
+			State:    stateVal,
+		}); err != nil {
+			log.Printf("[poller] error upserting cache for PR %s#%d: %v", p.repo, prCopy.Number, err)
+			return err
+		}
+		return nil
 	}
-	return events
+	return events, cacheOp, true
 }
 
 // emit sends a ChangeEvent on the events channel, respecting context cancellation.

--- a/internal/poller/poller_test.go
+++ b/internal/poller/poller_test.go
@@ -641,6 +641,122 @@ func TestPollTruncatedIssueListStillEmitsBufferedEvents(t *testing.T) {
 	}
 }
 
+// TestPollPRListFailureDoesNotDropIssueChanges is a regression test for
+// issue #145 finding #3: before the two-phase snapshot fix, the poller
+// would (a) update the issue cache inline while diffing issues, (b) abort
+// on a subsequent `gh pr list` failure, and (c) still emit
+// EventPollCycleDone via defer. The net result was that buffered
+// issue-change events were thrown away while the cache had already been
+// advanced, so the next cycle saw "no change" and the label transition
+// was silently lost.
+//
+// With the fix, a PR-list failure mid-cycle must leave the cache
+// untouched and must not emit EventPollCycleDone, so the next successful
+// cycle re-diffs and re-emits the missed events.
+func TestPollPRListFailureDoesNotDropIssueChanges(t *testing.T) {
+	st := testStore(t)
+
+	// Seed an existing cached issue with label "bug".
+	if err := st.UpsertIssueCache(store.IssueCache{
+		Repo:     "owner/repo",
+		IssueNum: 1,
+		Labels:   `["bug"]`,
+		State:    "open",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Cycle 1: issue label has changed ("bug" -> "enhancement"), but the
+	// PR list fails. Nothing should be committed or flushed.
+	gh := &mockGHReader{
+		issues: []Issue{
+			{Number: 1, Title: "x", State: "open", Labels: []string{"enhancement"}, Author: "alice"},
+		},
+		prsErr: fmt.Errorf("gh pr list: network unreachable"),
+	}
+	p := NewPoller(gh, st, "owner/repo", time.Hour)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p.poll(ctx)
+
+	// Drain whatever was emitted (expected: nothing at all, including no
+	// EventPollCycleDone, because phase 1 failed).
+	events := collectAll(p.Events(), 200*time.Millisecond)
+	for _, ev := range events {
+		if ev.Type == EventPollCycleDone {
+			t.Fatalf("failed cycle should not emit EventPollCycleDone, got %+v", events)
+		}
+	}
+	if len(events) != 0 {
+		t.Fatalf("failed cycle should emit no change events, got %+v", events)
+	}
+
+	// Cache must NOT have been advanced: the cached labels should still
+	// be the seeded ["bug"], otherwise the next cycle would miss the
+	// transition.
+	cached, err := st.QueryIssueCache("owner/repo", 1)
+	if err != nil {
+		t.Fatalf("QueryIssueCache: %v", err)
+	}
+	if cached == nil {
+		t.Fatal("cache entry disappeared")
+	}
+	if cached.Labels != `["bug"]` {
+		t.Fatalf("cache was mutated during failed cycle: labels=%q (want [\"bug\"])", cached.Labels)
+	}
+
+	// Cycle 2: PR list now succeeds. The label transition we missed in
+	// cycle 1 must re-emerge as label_added/label_removed events.
+	gh.prsErr = nil
+	gh.prs = nil
+	p.poll(ctx)
+
+	events = collectAll(p.Events(), 200*time.Millisecond)
+	var sawAdded, sawRemoved, sawCycleDone bool
+	for _, ev := range events {
+		switch ev.Type {
+		case EventLabelAdded:
+			if ev.IssueNum == 1 && ev.Detail == "enhancement" {
+				sawAdded = true
+			}
+		case EventLabelRemoved:
+			if ev.IssueNum == 1 && ev.Detail == "bug" {
+				sawRemoved = true
+			}
+		case EventPollCycleDone:
+			sawCycleDone = true
+		}
+	}
+	if !sawAdded || !sawRemoved {
+		t.Fatalf("recovered cycle must re-emit missed label transition, got %+v", events)
+	}
+	if !sawCycleDone {
+		t.Fatalf("recovered cycle must emit EventPollCycleDone, got %+v", events)
+	}
+}
+
+// collectAll reads every event currently available on ch until the channel
+// is idle for the given quiescence window. Unlike drain, it does not skip
+// EventPollCycleDone — callers asserting on (or against) its presence need
+// to see it.
+func collectAll(ch <-chan ChangeEvent, quiet time.Duration) []ChangeEvent {
+	var out []ChangeEvent
+	for {
+		timer := time.NewTimer(quiet)
+		select {
+		case ev, ok := <-ch:
+			timer.Stop()
+			if !ok {
+				return out
+			}
+			out = append(out, ev)
+		case <-timer.C:
+			return out
+		}
+	}
+}
+
 func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
## Summary

Fixes finding #3 from issue #145: the poll cycle could silently drop events when an intermediate step failed.

### Old failure mode

`internal/poller/poller.go:poll()` previously:

1. Fetched issues and, inside `diffIssue`, **wrote each issue back to the cache inline** while computing buffered change events.
2. Then called `gh pr list`. If that failed, the function returned early.
3. A `defer` still emitted `EventPollCycleDone`.

Net effect: the in-memory `pending` events never got flushed, but the cache had already been advanced. On the next cycle the issue looked unchanged, so label transitions (e.g. `status:reviewing -> status:developing` after a review bounce-back) were silently lost. Consumers of `EventPollCycleDone` (state machine dedup reset in `cmd/serve.go` / `cmd/repo_runtime.go`, last-poll timestamp in `internal/auditapi`) were also told the cycle succeeded when it had not.

### Two-phase design

- **Phase 1 (collect)**: `planDiffIssue` / `planDiffPR` compute events and a deferred cache-write closure without mutating anything. Results accumulate in local `pending []ChangeEvent` and `cacheOps []func() error` slices. Any `gh` read failure or cache-query error aborts here.
- **Phase 2 (commit)**: only reached if every GH read succeeded. Backoff is reset, all cache ops are applied, all pending events emitted, and finally `EventPollCycleDone` is emitted. The `defer` that unconditionally emitted the sentinel is gone.

Consumers continue to observe the same event shapes; `EventPollCycleDone` is now a strict success sentinel instead of an always-fires boundary. A failed cycle emits nothing and the next successful cycle re-diffs the still-stale cache, re-emitting any missed changes.

### Test

`TestPollPRListFailureDoesNotDropIssueChanges` reproduces the bug:

- Seeds cache with issue#1 labeled `bug`.
- Cycle 1 returns issue#1 as labeled `enhancement` but errors on `ListPRs`.
- Asserts no events emitted (including no `EventPollCycleDone`) and that the cache is still `["bug"]`.
- Cycle 2 succeeds and must re-emit `label_added:enhancement` + `label_removed:bug` + `EventPollCycleDone`.

Verified the test fails on the pre-fix code (EventPollCycleDone leaks through, cache mutated) and passes with the fix.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1`
- [x] New regression test fails on old code, passes on new

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>