### PR TITLE
Surface eventlog write failures as a first-class health signal (#145)

### DIFF
--- a/cmd/coordinator.go
+++ b/cmd/coordinator.go
@@ -505,7 +505,7 @@ func runCoordinatorWithOpts(opts *coordinatorOpts, ghReader poller.GHReader, par
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", api.handleHealth)
-	metrics.NewHandler(st).Register(mux)
+	metrics.NewHandler(st).WithEventLogger(evlog).Register(mux)
 	readOnlyAudit := audit.NewHTTPHandler(st)
 	readOnlyAuditMux := http.NewServeMux()
 	readOnlyAudit.Register(readOnlyAuditMux)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -413,7 +413,7 @@ func runServeWithOpts(opts *serveOpts, ghReader poller.GHReader, launcherOverrid
 	})
 
 	audit.NewHTTPHandler(st).Register(mux)
-	metrics.NewHandler(st).Register(mux)
+	metrics.NewHandler(st).WithEventLogger(evlog).Register(mux)
 	dashboardAPI := auditapi.NewHandler(st)
 	dashboardAPI.SetSessionsDir(sessionsDir)
 	dashboardAPI.RegisterDashboard(mux)

--- a/internal/eventlog/eventlog.go
+++ b/internal/eventlog/eventlog.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Lincyaw/workbuddy/internal/store"
@@ -91,10 +93,36 @@ type EventFilter struct {
 	IssueNum int
 }
 
+// Health reports the observability state of an EventLogger.
+//
+// Event-log writes are best-effort telemetry: a single failed INSERT must not
+// block the orchestration pipeline. But silently swallowing failures hides
+// degraded audit trails from operators. Health exposes the degraded condition
+// so it can be surfaced via /metrics, `workbuddy status`, or log scraping
+// without changing the best-effort Log() contract.
+type Health struct {
+	// Degraded is true once any write has failed since process start.
+	Degraded bool `json:"degraded"`
+	// WriteFailures counts the number of failed InsertEvent calls.
+	WriteFailures int64 `json:"write_failures"`
+	// LastError is the string form of the most recent write error, if any.
+	LastError string `json:"last_error,omitempty"`
+	// LastFailureAt is the UTC timestamp of the most recent write error.
+	LastFailureAt time.Time `json:"last_failure_at,omitempty"`
+}
+
 // EventLogger provides a higher-level API over store.Store for event logging.
-// It marshals payloads to JSON and swallows write errors (printing to stderr).
+// It marshals payloads to JSON and swallows write errors (printing to stderr),
+// while tracking failures on a per-instance health counter so operators can
+// detect degraded observability via Health().
 type EventLogger struct {
 	store *store.Store
+
+	writeFailures atomic.Int64
+
+	healthMu      sync.RWMutex
+	lastErr       string
+	lastFailureAt time.Time
 }
 
 // NewEventLogger creates an EventLogger backed by the given Store.
@@ -103,7 +131,8 @@ func NewEventLogger(s *store.Store) *EventLogger {
 }
 
 // Log records an event. The payload is marshalled to JSON automatically.
-// On failure the error is printed to stderr; the caller is never blocked.
+// On failure the error is printed to stderr and the logger's health is
+// marked degraded; the caller is never blocked.
 func (l *EventLogger) Log(eventType, repo string, issueNum int, payload interface{}) {
 	var payloadStr string
 	if payload != nil {
@@ -124,6 +153,34 @@ func (l *EventLogger) Log(eventType, repo string, issueNum int, payload interfac
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "eventlog: write failed: %v\n", err)
+		l.recordFailure(err)
+	}
+}
+
+func (l *EventLogger) recordFailure(err error) {
+	l.writeFailures.Add(1)
+	l.healthMu.Lock()
+	l.lastErr = err.Error()
+	l.lastFailureAt = time.Now().UTC()
+	l.healthMu.Unlock()
+}
+
+// Health returns a snapshot of the logger's observability state. It is safe
+// to call from any goroutine. Callers that treat event-log writes as
+// best-effort can ignore this; operator surfaces (metrics, status, healthz)
+// should surface Degraded as a first-class condition so a lost audit trail
+// is visible instead of silent.
+func (l *EventLogger) Health() Health {
+	failures := l.writeFailures.Load()
+	l.healthMu.RLock()
+	lastErr := l.lastErr
+	lastAt := l.lastFailureAt
+	l.healthMu.RUnlock()
+	return Health{
+		Degraded:      failures > 0,
+		WriteFailures: failures,
+		LastError:     lastErr,
+		LastFailureAt: lastAt,
 	}
 }
 

--- a/internal/eventlog/eventlog_test.go
+++ b/internal/eventlog/eventlog_test.go
@@ -183,6 +183,127 @@ func TestWriteRateLimitEvent(t *testing.T) {
 	}
 }
 
+// TestHealthHappyPath verifies successful writes never mark the logger
+// degraded.
+func TestHealthHappyPath(t *testing.T) {
+	logger := newTestLogger(t)
+
+	logger.Log(TypePoll, "owner/repo", 1, nil)
+	logger.Log(TypeDispatch, "owner/repo", 1, map[string]string{"agent": "dev"})
+
+	h := logger.Health()
+	if h.Degraded {
+		t.Fatalf("expected Degraded=false after successful writes, got %+v", h)
+	}
+	if h.WriteFailures != 0 {
+		t.Fatalf("expected WriteFailures=0, got %d", h.WriteFailures)
+	}
+	if h.LastError != "" {
+		t.Fatalf("expected empty LastError, got %q", h.LastError)
+	}
+	if !h.LastFailureAt.IsZero() {
+		t.Fatalf("expected zero LastFailureAt, got %v", h.LastFailureAt)
+	}
+}
+
+// TestHealthDegradedOnWriteFailure verifies that a failed write marks the
+// logger degraded, increments the counter, and captures the last error — but
+// Log() itself still returns cleanly (best-effort contract preserved).
+func TestHealthDegradedOnWriteFailure(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	s, err := store.NewStore(dbPath)
+	if err != nil {
+		t.Fatalf("store.NewStore: %v", err)
+	}
+	logger := NewEventLogger(s)
+
+	// Healthy baseline.
+	logger.Log(TypePoll, "owner/repo", 1, nil)
+	if h := logger.Health(); h.Degraded {
+		t.Fatalf("expected healthy baseline, got %+v", h)
+	}
+
+	// Close the store so subsequent InsertEvent calls fail.
+	if err := s.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	before := time.Now().UTC()
+	// These must not panic or block despite the closed store.
+	logger.Log(TypePoll, "owner/repo", 2, nil)
+	logger.Log(TypeDispatch, "owner/repo", 3, nil)
+
+	h := logger.Health()
+	if !h.Degraded {
+		t.Fatalf("expected Degraded=true after failed writes, got %+v", h)
+	}
+	if h.WriteFailures != 2 {
+		t.Fatalf("expected WriteFailures=2, got %d", h.WriteFailures)
+	}
+	if h.LastError == "" {
+		t.Fatalf("expected non-empty LastError")
+	}
+	if h.LastFailureAt.Before(before) {
+		t.Fatalf("expected LastFailureAt >= %v, got %v", before, h.LastFailureAt)
+	}
+}
+
+// TestHealthConcurrentSafe verifies Health() is safe to call while Log()
+// runs from multiple goroutines. Run under `go test -race`.
+func TestHealthConcurrentSafe(t *testing.T) {
+	logger := newTestLogger(t)
+
+	const writers = 4
+	const readers = 4
+	const iterations = 20
+
+	stop := make(chan struct{})
+
+	var readerWG sync.WaitGroup
+	readerWG.Add(readers)
+	for i := 0; i < readers; i++ {
+		go func() {
+			defer readerWG.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = logger.Health()
+				}
+			}
+		}()
+	}
+
+	var writerWG sync.WaitGroup
+	writerWG.Add(writers)
+	for i := 0; i < writers; i++ {
+		go func(g int) {
+			defer writerWG.Done()
+			for j := 0; j < iterations; j++ {
+				logger.Log(TypePoll, "owner/repo", g, map[string]int{"iter": j})
+			}
+		}(i)
+	}
+
+	writerWG.Wait()
+	close(stop)
+	readerWG.Wait()
+
+	// The primary invariant is that Health() and Log() race cleanly under
+	// `-race`. The SQLite backend can occasionally return SQLITE_BUSY under
+	// heavy concurrent writes; if that happens the logger correctly marks
+	// itself degraded. Either outcome is acceptable for this test — we only
+	// assert the numbers are self-consistent.
+	h := logger.Health()
+	if h.Degraded && h.WriteFailures == 0 {
+		t.Fatalf("Degraded=true but WriteFailures=0: %+v", h)
+	}
+	if !h.Degraded && h.WriteFailures != 0 {
+		t.Fatalf("Degraded=false but WriteFailures=%d: %+v", h.WriteFailures, h)
+	}
+}
+
 func TestWriteReportOverflowEvent(t *testing.T) {
 	logger := newTestLogger(t)
 	logger.Log(TypeReportOverflow, "owner/repo", 17, map[string]any{

--- a/internal/metrics/handler.go
+++ b/internal/metrics/handler.go
@@ -18,6 +18,7 @@ const stuckThreshold = time.Hour
 // Handler serves Prometheus metrics from SQLite state.
 type Handler struct {
 	store *store.Store
+	evlog *eventlog.EventLogger
 	now   func() time.Time
 }
 
@@ -27,6 +28,14 @@ func NewHandler(st *store.Store) *Handler {
 		store: st,
 		now:   time.Now,
 	}
+}
+
+// WithEventLogger attaches an EventLogger whose health is exposed as the
+// `workbuddy_eventlog_write_failures_total` and `workbuddy_eventlog_degraded`
+// metrics. Passing nil is a no-op. Returns the receiver for chaining.
+func (h *Handler) WithEventLogger(ev *eventlog.EventLogger) *Handler {
+	h.evlog = ev
+	return h
 }
 
 // Register registers GET /metrics.
@@ -64,7 +73,25 @@ func (h *Handler) writeMetrics(b *strings.Builder, now time.Time) error {
 	if err := h.writeTransitionMaxCounters(b, db); err != nil {
 		return err
 	}
+	h.writeEventlogHealth(b)
 	return h.writeIssueCounters(b, db, now)
+}
+
+func (h *Handler) writeEventlogHealth(b *strings.Builder) {
+	if h.evlog == nil {
+		return
+	}
+	hs := h.evlog.Health()
+	_, _ = b.WriteString("# HELP workbuddy_eventlog_write_failures_total Number of event-log writes that failed since process start.\n")
+	_, _ = b.WriteString("# TYPE workbuddy_eventlog_write_failures_total counter\n")
+	_, _ = b.WriteString(fmt.Sprintf("workbuddy_eventlog_write_failures_total %d\n", hs.WriteFailures))
+	_, _ = b.WriteString("# HELP workbuddy_eventlog_degraded 1 if any event-log write has failed since process start, else 0.\n")
+	_, _ = b.WriteString("# TYPE workbuddy_eventlog_degraded gauge\n")
+	degraded := 0
+	if hs.Degraded {
+		degraded = 1
+	}
+	_, _ = b.WriteString(fmt.Sprintf("workbuddy_eventlog_degraded %d\n", degraded))
 }
 
 func (h *Handler) writeEventCounters(b *strings.Builder, db *sql.DB) error {

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -628,8 +628,10 @@ requirements:
       - "AC-009-5: 并发安全（SQLite WAL 模式）"
       - "AC-009-6: 支持按时间范围 + 事件类型 + repo + issue 查询"
       - "AC-009-7: 单元测试：写入/查询/并发写入 3 种场景"
+      - "AC-009-8: EventLogger.Health() 暴露降级计数与最近错误，通过 /metrics 导出 workbuddy_eventlog_degraded / workbuddy_eventlog_write_failures_total (issue #145)"
     code:
       - internal/eventlog/eventlog.go
+      - internal/metrics/handler.go
     tests:
       - internal/eventlog/eventlog_test.go
     deps: [REQ-024]


### PR DESCRIPTION
Fixes finding #14 in #145.

## Problem

`internal/eventlog/eventlog.go` treated every write failure the same way: `log.Printf` to stderr and return nil. That is correct *behaviourally* (orchestration must not block on best-effort telemetry), but it silently degrades the audit trail — once a write fails, operators have no way to know breadcrumbs are being lost.

## Fix

Distinguish best-effort telemetry from the signal operators need:

**Before**
```go
_, err := l.store.InsertEvent(...)
if err != nil {
    fmt.Fprintf(os.Stderr, "eventlog: write failed: %v\n", err)
}
```
No state anywhere; failures vanish.

**After**
- `EventLogger` gains an `atomic.Int64 writeFailures` and a mutex-guarded `lastErr` / `lastFailureAt`.
- A new `Health()` method returns a `Health{Degraded, WriteFailures, LastError, LastFailureAt}` snapshot, safe to call from any goroutine.
- `Log()` still returns nothing and still logs to stderr — existing callers are untouched — but now also updates the health counter on failure.

## Where it surfaces

`internal/metrics/handler.go` gains an optional `WithEventLogger(...)` setter. When wired, `/metrics` emits:
- `workbuddy_eventlog_write_failures_total` (counter)
- `workbuddy_eventlog_degraded` (gauge, 0 or 1)

Wired in `cmd/serve.go` and `cmd/coordinator.go`. The `internal/coordinator.Server` type doesn't currently hold an EventLogger; leaving it unwired is safe (the handler no-ops without a logger) and left as a follow-up once that server grows real event-logging.

## Test coverage

- `TestHealthHappyPath` — successful writes never mark the logger degraded.
- `TestHealthDegradedOnWriteFailure` — closes the store so `InsertEvent` fails, then asserts `Degraded=true`, `WriteFailures=2`, non-empty `LastError`, fresh `LastFailureAt`.
- `TestHealthConcurrentSafe` — Health() and Log() race cleanly under `-race` from multiple goroutines; asserts the counter/degraded flag stay self-consistent.

`go build ./... && go vet ./... && go test ./... -count=1` all green. `validate_index.py` passes with REQ-009 updated.

## Test plan
- [ ] Review the stderr+counter behaviour preserves the best-effort contract
- [ ] Confirm `/metrics` exposes both series after serve startup
- [ ] Optional follow-up: wire EventLogger into `internal/coordinator.Server` and into a `workbuddy status` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)