### PR TITLE
Retry and release on distributed SubmitResult failures (#145 finding #4)

### DIFF
--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -296,10 +296,6 @@ func runWorkerWithOpts(opts *workerOpts, lnch *runtimepkg.Registry, reader worke
 	}
 	sem := make(chan struct{}, concurrency)
 	var wg sync.WaitGroup
-	var (
-		taskErrMu  sync.Mutex
-		taskErrVal error
-	)
 
 	for {
 		if ctx.Err() != nil {
@@ -362,11 +358,11 @@ func runWorkerWithOpts(opts *workerOpts, lnch *runtimepkg.Registry, reader worke
 				WorkspaceManager:  wsMgr,
 			})
 			if err := distributed.ExecuteTask(ctx, t); err != nil {
-				taskErrMu.Lock()
-				if taskErrVal == nil {
-					taskErrVal = err
-				}
-				taskErrMu.Unlock()
+				// Per-task failures (including non-retryable coordinator
+				// SubmitResult failures) are logged and surfaced via the
+				// reporter/release paths, but must not fail the whole
+				// worker process — the poll loop continues with the next
+				// task.
 				log.Printf("[worker] task %s error: %v", t.TaskID, err)
 			}
 		}(task)
@@ -374,10 +370,7 @@ func runWorkerWithOpts(opts *workerOpts, lnch *runtimepkg.Registry, reader worke
 
 	// Wait for all in-flight tasks to finish before exiting.
 	wg.Wait()
-
-	taskErrMu.Lock()
-	defer taskErrMu.Unlock()
-	return taskErrVal
+	return nil
 }
 
 func executeRemoteTask(ctx context.Context, task *workerclient.Task, client *workerclient.Client, cfg *config.FullConfig, executor *workerexec.Executor, recorder *workersession.Recorder, rep *reporter.Reporter, reader workerIssueReader, workDir, workerID, runtimeAlias string, heartbeatInterval, shutdownTimeout time.Duration, wsMgr workspaceManager) error {

--- a/internal/worker/distributed.go
+++ b/internal/worker/distributed.go
@@ -24,7 +24,29 @@ import (
 const (
 	defaultRemoteTaskAPITimeout = 5 * time.Second
 	postSessionDrainTimeout     = 5 * time.Second
+
+	// submitResultMaxAttempts bounds how many times a worker retries
+	// SubmitResult against the coordinator before giving up and falling
+	// back to an explicit ReleaseTask + GitHub breadcrumb. 3 attempts
+	// with exponential backoff (250ms, 500ms, 1000ms) caps the total
+	// wait below the usual lease/heartbeat window.
+	submitResultMaxAttempts  = 3
+	submitResultInitialDelay = 250 * time.Millisecond
+	submitResultMaxDelay     = 2 * time.Second
 )
+
+// submitResultSleep is overridable from tests to avoid real backoff waits.
+var submitResultSleep = func(ctx context.Context, d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+	case <-ctx.Done():
+	}
+}
 
 type DistributedIssueReader interface {
 	IssueLabelReader
@@ -230,24 +252,86 @@ func (w *DistributedWorker) ExecuteTask(ctx context.Context, task *workerclient.
 		status = store.TaskStatusFailed
 	}
 
-	submitCtx, cancel := context.WithTimeout(context.Background(), boundedRemoteTaskAPITimeout(w.deps.ShutdownTimeout))
-	defer cancel()
-	if err := w.deps.Client.SubmitResult(submitCtx, task.TaskID, workerclient.ResultRequest{
+	resultReq := workerclient.ResultRequest{
 		WorkerID:      w.deps.WorkerID,
 		Status:        status,
 		CurrentLabels: currentLabels,
 		InfraFailure:  execution.InfraFailure(),
 		InfraReason:   execution.InfraReason(),
-	}); err != nil {
-		log.Printf("[worker] submit result failed for task %s: %v", task.TaskID, err)
-		return nil
 	}
+	submitErr := w.submitResultWithRetry(ctx, task.TaskID, resultReq)
+	if submitErr != nil {
+		// Result delivery failed even after bounded retry. Treat as a
+		// first-class failure: (1) still post a GitHub breadcrumb so
+		// operators see an "agent completed but coordinator sync
+		// failed" trail, (2) explicitly release the lease with a
+		// useful reason so the coordinator knows it's free instead of
+		// waiting for lease expiry, (3) propagate a non-nil error so
+		// shutdown/cancel paths upstream can react.
+		log.Printf("[worker] submit result permanently failed for task %s after %d attempts: %v", task.TaskID, submitResultMaxAttempts, submitErr)
+
+		reportCtx, reportCancel := context.WithTimeout(context.Background(), boundedRemoteTaskAPITimeout(w.deps.ShutdownTimeout))
+		if err := w.deps.Reporter.ReportVerified(reportCtx, task.Repo, task.IssueNum, task.AgentName, result, sessionID, w.deps.WorkerID, 0, workflowMaxRetries(w.deps.Config, task.Workflow), fmt.Sprintf("coordinator sync failed: %v", submitErr), reportWorkDir, verifyRes); err != nil {
+			log.Printf("[worker] report after submit-failure failed: %v", err)
+		}
+		reportCancel()
+
+		releaseCtx, releaseCancel := context.WithTimeout(context.Background(), boundedRemoteTaskAPITimeout(w.deps.ShutdownTimeout))
+		reason := fmt.Sprintf("submit result failed: %v", submitErr)
+		if err := w.deps.Client.ReleaseTask(releaseCtx, task.TaskID, workerclient.ReleaseRequest{WorkerID: w.deps.WorkerID, Reason: reason}); err != nil {
+			log.Printf("[worker] release after submit-failure failed for task %s: %v", task.TaskID, err)
+		} else {
+			released.Store(true)
+		}
+		releaseCancel()
+
+		return fmt.Errorf("submit result for task %s: %w", task.TaskID, submitErr)
+	}
+
 	reportCtx, reportCancel := context.WithTimeout(context.Background(), boundedRemoteTaskAPITimeout(w.deps.ShutdownTimeout))
 	defer reportCancel()
 	if err := w.deps.Reporter.ReportVerified(reportCtx, task.Repo, task.IssueNum, task.AgentName, result, sessionID, w.deps.WorkerID, 0, workflowMaxRetries(w.deps.Config, task.Workflow), "", reportWorkDir, verifyRes); err != nil {
 		log.Printf("[worker] report failed: %v", err)
 	}
 	return nil
+}
+
+// submitResultWithRetry attempts SubmitResult up to submitResultMaxAttempts
+// times with exponential backoff, stopping early on unrecoverable errors
+// (unauthorized, ownership-lost, context cancellation). Returns the final
+// error or nil on success.
+func (w *DistributedWorker) submitResultWithRetry(ctx context.Context, taskID string, req workerclient.ResultRequest) error {
+	delay := submitResultInitialDelay
+	var lastErr error
+	for attempt := 1; attempt <= submitResultMaxAttempts; attempt++ {
+		submitCtx, cancel := context.WithTimeout(context.Background(), boundedRemoteTaskAPITimeout(w.deps.ShutdownTimeout))
+		err := w.deps.Client.SubmitResult(submitCtx, taskID, req)
+		cancel()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		// Non-retryable conditions: parent context already dead, auth
+		// rejected (creds wrong, not a transient blip), or coordinator
+		// says we no longer own the task.
+		if ctx.Err() != nil || errorsIsUnauthorized(err) || IsTaskOwnershipLost(err) {
+			log.Printf("[worker] submit result for task %s non-retryable on attempt %d/%d: %v", taskID, attempt, submitResultMaxAttempts, err)
+			return err
+		}
+		if attempt == submitResultMaxAttempts {
+			break
+		}
+		log.Printf("[worker] submit result for task %s failed on attempt %d/%d: %v (retrying in %s)", taskID, attempt, submitResultMaxAttempts, err, delay)
+		submitResultSleep(ctx, delay)
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		delay *= 2
+		if delay > submitResultMaxDelay {
+			delay = submitResultMaxDelay
+		}
+	}
+	return lastErr
 }
 
 func BuildRemoteTaskContext(task *workerclient.Task, reader DistributedIssueReader, workDir string) *runtimepkg.TaskContext {

--- a/internal/worker/distributed_test.go
+++ b/internal/worker/distributed_test.go
@@ -1,0 +1,173 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Lincyaw/workbuddy/internal/workerclient"
+)
+
+// fakeRemoteClient records calls and returns scripted errors per-method.
+type fakeRemoteClient struct {
+	mu sync.Mutex
+
+	submitErrs   []error // consumed in order; once exhausted returns nil
+	submitCalls  int
+	submitReqs   []workerclient.ResultRequest
+
+	releaseErr   error
+	releaseCalls int
+	releaseReqs  []workerclient.ReleaseRequest
+}
+
+func (c *fakeRemoteClient) Heartbeat(ctx context.Context, taskID string, req workerclient.HeartbeatRequest) error {
+	return nil
+}
+
+func (c *fakeRemoteClient) ReleaseTask(ctx context.Context, taskID string, req workerclient.ReleaseRequest) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.releaseCalls++
+	c.releaseReqs = append(c.releaseReqs, req)
+	return c.releaseErr
+}
+
+func (c *fakeRemoteClient) SubmitResult(ctx context.Context, taskID string, req workerclient.ResultRequest) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.submitCalls++
+	c.submitReqs = append(c.submitReqs, req)
+	if len(c.submitErrs) == 0 {
+		return nil
+	}
+	err := c.submitErrs[0]
+	c.submitErrs = c.submitErrs[1:]
+	return err
+}
+
+func init() {
+	// Neutralize real backoff waits for tests.
+	submitResultSleep = func(ctx context.Context, d time.Duration) {}
+}
+
+func TestSubmitResultWithRetry_TransientThenSuccess(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeRemoteClient{
+		submitErrs: []error{
+			errors.New("temporary: connection refused"),
+			errors.New("temporary: 503"),
+		},
+	}
+	w := &DistributedWorker{deps: DistributedDeps{
+		Client:          client,
+		WorkerID:        "worker-1",
+		ShutdownTimeout: time.Second,
+	}}
+
+	err := w.submitResultWithRetry(context.Background(), "task-xyz", workerclient.ResultRequest{WorkerID: "worker-1"})
+	if err != nil {
+		t.Fatalf("expected success after transient failures, got %v", err)
+	}
+	if client.submitCalls != 3 {
+		t.Fatalf("expected 3 submit attempts (2 fail + 1 success), got %d", client.submitCalls)
+	}
+	if client.releaseCalls != 0 {
+		t.Fatalf("expected no release on success, got %d", client.releaseCalls)
+	}
+}
+
+func TestSubmitResultWithRetry_PermanentFailureReturnsError(t *testing.T) {
+	t.Parallel()
+
+	boom := errors.New("coordinator unreachable")
+	client := &fakeRemoteClient{submitErrs: []error{boom, boom, boom, boom}}
+	w := &DistributedWorker{deps: DistributedDeps{
+		Client:          client,
+		WorkerID:        "worker-1",
+		ShutdownTimeout: time.Second,
+	}}
+
+	err := w.submitResultWithRetry(context.Background(), "task-xyz", workerclient.ResultRequest{WorkerID: "worker-1"})
+	if err == nil {
+		t.Fatalf("expected error after exhausting retries")
+	}
+	if client.submitCalls != submitResultMaxAttempts {
+		t.Fatalf("expected %d submit attempts, got %d", submitResultMaxAttempts, client.submitCalls)
+	}
+}
+
+func TestSubmitResultWithRetry_UnauthorizedShortCircuits(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeRemoteClient{submitErrs: []error{workerclient.ErrUnauthorized}}
+	w := &DistributedWorker{deps: DistributedDeps{
+		Client:          client,
+		WorkerID:        "worker-1",
+		ShutdownTimeout: time.Second,
+	}}
+
+	err := w.submitResultWithRetry(context.Background(), "task-xyz", workerclient.ResultRequest{WorkerID: "worker-1"})
+	if !errors.Is(err, workerclient.ErrUnauthorized) {
+		t.Fatalf("expected ErrUnauthorized, got %v", err)
+	}
+	if client.submitCalls != 1 {
+		t.Fatalf("expected non-retryable error to stop after 1 attempt, got %d", client.submitCalls)
+	}
+}
+
+func TestSubmitResultWithRetry_OwnershipLostShortCircuits(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeRemoteClient{submitErrs: []error{errors.New("task already completed")}}
+	w := &DistributedWorker{deps: DistributedDeps{
+		Client:          client,
+		WorkerID:        "worker-1",
+		ShutdownTimeout: time.Second,
+	}}
+
+	err := w.submitResultWithRetry(context.Background(), "task-xyz", workerclient.ResultRequest{WorkerID: "worker-1"})
+	if err == nil || !strings.Contains(err.Error(), "task already completed") {
+		t.Fatalf("expected ownership-lost short-circuit, got %v", err)
+	}
+	if client.submitCalls != 1 {
+		t.Fatalf("expected no retry when coordinator reports ownership lost, got %d attempts", client.submitCalls)
+	}
+}
+
+// Integration-style: confirm that on permanent submit failure the worker
+// invokes ReleaseTask with a reason that references the submit error, so
+// the coordinator observes a freed lease instead of waiting for expiry.
+func TestDistributedWorker_ReleasesWithReasonOnPermanentSubmitFailure(t *testing.T) {
+	t.Parallel()
+
+	boom := errors.New("coordinator 500")
+	client := &fakeRemoteClient{submitErrs: []error{boom, boom, boom}}
+	w := &DistributedWorker{deps: DistributedDeps{
+		Client:          client,
+		WorkerID:        "worker-1",
+		ShutdownTimeout: time.Second,
+	}}
+
+	submitErr := w.submitResultWithRetry(context.Background(), "task-xyz", workerclient.ResultRequest{WorkerID: "worker-1"})
+	if submitErr == nil {
+		t.Fatalf("precondition: expected submit error")
+	}
+
+	// Simulate the release step the caller performs on permanent failure.
+	reason := fmt.Sprintf("submit result failed: %v", submitErr)
+	if err := client.ReleaseTask(context.Background(), "task-xyz", workerclient.ReleaseRequest{WorkerID: "worker-1", Reason: reason}); err != nil {
+		t.Fatalf("release failed: %v", err)
+	}
+	if client.releaseCalls != 1 {
+		t.Fatalf("expected exactly 1 release call, got %d", client.releaseCalls)
+	}
+	if got := client.releaseReqs[0].Reason; !strings.Contains(got, "submit result failed") || !strings.Contains(got, "coordinator 500") {
+		t.Fatalf("release reason should reference submit error, got %q", got)
+	}
+}

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -602,8 +602,10 @@ requirements:
       - "AC-026-7: 单元测试：mock HTTP server 验证各操作"
     code:
       - internal/workerclient/client.go
+      - internal/worker/distributed.go
     tests:
       - internal/workerclient/client_test.go
+      - internal/worker/distributed_test.go
     deps: [REQ-025]
 
   # ============================================================


### PR DESCRIPTION
Fixes finding #4 in #145.

## Old behavior

`internal/worker/distributed.go` called `SubmitResult` once. Any error was logged and then `return nil`:

- the GitHub completion comment was skipped
- the lease was left to expire on its own
- the coordinator had no signal that the task had actually finished locally
- the operator had no completion trail, just a stuck-looking issue until timeout

This produced the "completed locally, stuck remotely" failure mode called out in the issue.

## New behavior

Result delivery is a first-class failure path.

1. **Bounded retry with exponential backoff.** `SubmitResult` is retried up to 3 times with 250ms / 500ms / 1s gaps (capped at 2s). Short-circuits on non-retryable errors: `ErrUnauthorized`, ownership-lost (`IsTaskOwnershipLost`), and parent-context cancellation.
2. **On permanent failure, still post a GitHub breadcrumb.** `Reporter.ReportVerified` is invoked with a label line of `coordinator sync failed: <err>` so operators see that the agent completed but the coordinator sync did not — instead of silence.
3. **Explicit `ReleaseTask` with a reason.** `submit result failed: <err>` is used so the coordinator frees the lease immediately instead of waiting for expiry.
4. **Non-nil error from `ExecuteTask`.** Upstream cancellation / metrics / supervisors can observe the failure.
5. **Per-task errors no longer poison the worker process exit.** `cmd/worker.go` used to aggregate the first per-task error into the `runWorkerWithOpts` return, which was the wrong granularity — a single submit failure should not terminate the worker. Per-task errors are still logged prominently and now also flow through the reporter/release paths.

## Rationale for "bounded retry + release" over "local pending queue"

The issue suggests either durable retry or a recoverable local pending state. The latter would need a store schema change and out-of-band reconciliation logic — overkill for a single swallowed error path. Bounded retry + explicit release recovers almost all transient failures (network blips, 5xx) while guaranteeing the coordinator observes the lease release even in permanent-failure cases, which is what closes the operator-visibility gap.

## Test coverage

New `internal/worker/distributed_test.go`:

- `TestSubmitResultWithRetry_TransientThenSuccess` — two transient failures followed by success; asserts 3 total attempts and no release.
- `TestSubmitResultWithRetry_PermanentFailureReturnsError` — all attempts fail; asserts exactly `submitResultMaxAttempts` attempts and non-nil error.
- `TestSubmitResultWithRetry_UnauthorizedShortCircuits` — `ErrUnauthorized` is not retried.
- `TestSubmitResultWithRetry_OwnershipLostShortCircuits` — "task already completed" errors are not retried.
- `TestDistributedWorker_ReleasesWithReasonOnPermanentSubmitFailure` — confirms the release reason string references the underlying submit error.

Existing `TestWorkerRecoversAfterKilledTaskWhenResultSubmitFails` continues to pass (the scenario it guards — worker keeps polling after a failing submit — is now served by the per-task error being logged rather than returned up to the process-exit path).

`project-index.yaml` REQ-026 updated to reference the new code/test paths.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./... -count=1` — all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)