### PR TITLE
fix(gha): mark GitHub Actions runtime failures as infra failures (#145)

### DIFF
--- a/internal/launcher/runners/gha/gha.go
+++ b/internal/launcher/runners/gha/gha.go
@@ -20,6 +20,67 @@ type CommandRunner interface {
 	Run(ctx context.Context, stdin []byte, args ...string) ([]byte, error)
 }
 
+// FailureStage classifies where a GitHub Actions run failed. Callers use it to
+// distinguish runtime/infrastructure problems (dispatch, poll, artifact IO/parse)
+// from the agent itself reporting a non-zero exit inside a workflow that ran
+// to completion.
+type FailureStage string
+
+const (
+	// StageDispatch covers errors dispatching the workflow (HTTP, auth, missing
+	// workflow, or a dispatch response that cannot be parsed).
+	StageDispatch FailureStage = "dispatch"
+	// StagePoll covers errors polling the workflow run status (context cancel,
+	// HTTP, parse, or unexpected empty metadata).
+	StagePoll FailureStage = "poll"
+	// StageLogs covers errors downloading or unpacking the run logs artifact.
+	StageLogs FailureStage = "logs"
+	// StageArtifacts covers errors listing/downloading/unzipping artifacts or
+	// missing required artifacts (e.g. events-v1.jsonl).
+	StageArtifacts FailureStage = "artifacts"
+)
+
+// StageError annotates a gha error with the failure stage so callers can map it
+// to the runtime infra-failure taxonomy without string matching.
+type StageError struct {
+	Stage FailureStage
+	Err   error
+}
+
+func (e *StageError) Error() string {
+	if e == nil || e.Err == nil {
+		return ""
+	}
+	return e.Err.Error()
+}
+
+func (e *StageError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func stageErr(stage FailureStage, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &StageError{Stage: stage, Err: err}
+}
+
+// StageOf returns the failure stage attached to err, or the empty string if
+// none is present.
+func StageOf(err error) FailureStage {
+	if err == nil {
+		return ""
+	}
+	var se *StageError
+	if errors.As(err, &se) {
+		return se.Stage
+	}
+	return ""
+}
+
 type GHCLI struct{}
 
 func (GHCLI) Run(ctx context.Context, stdin []byte, args ...string) ([]byte, error) {
@@ -120,20 +181,20 @@ func (c *Client) RunWorkflow(ctx context.Context, cfg Config) (*Outcome, error) 
 	dispatchedAt := c.now().UTC().Add(-2 * time.Second)
 	dispatchRun, err := c.dispatch(ctx, cfg)
 	if err != nil {
-		return nil, err
+		return nil, stageErr(StageDispatch, err)
 	}
 	run, err := c.waitForRun(ctx, cfg, dispatchedAt, dispatchRun)
 	if err != nil {
-		return nil, err
+		return nil, stageErr(StagePoll, err)
 	}
 
 	logPath, logs, err := c.downloadLogs(ctx, cfg, run.ID)
 	if err != nil {
-		return nil, err
+		return nil, stageErr(StageLogs, err)
 	}
 	files, resultPath, sessionPath, err := c.downloadArtifacts(ctx, cfg, run.ID)
 	if err != nil {
-		return nil, err
+		return nil, stageErr(StageArtifacts, err)
 	}
 
 	return &Outcome{

--- a/internal/runtime/gha_runner.go
+++ b/internal/runtime/gha_runner.go
@@ -80,6 +80,11 @@ func (s *GHASession) Run(ctx context.Context, events chan<- launcherevents.Event
 		if code == "timeout" {
 			result.Meta["timeout"] = "true"
 		}
+		// Classify every pre-completion failure (dispatch / poll / logs / artifact
+		// download) as an infrastructure failure: the agent never produced a
+		// verdict, so downstream retry/escalation must not treat this as an
+		// agent-reported failure.
+		MarkInfraFailure(result, ghaInfraReason(runErr, code))
 		EmitEvent(events, &seq, s.Task.Session.ID, s.Task.Session.ID, launcherevents.KindError, launcherevents.ErrorPayload{Code: code, Message: runErr.Error(), Recoverable: false}, nil)
 		EmitEvent(events, &seq, s.Task.Session.ID, s.Task.Session.ID, launcherevents.KindTurnCompleted, launcherevents.TurnCompletedPayload{TurnID: s.Task.Session.ID, Status: "error"}, nil)
 		return result, runErr
@@ -87,9 +92,28 @@ func (s *GHASession) Run(ctx context.Context, events chan<- launcherevents.Event
 
 	result, err := s.resultFromOutcome(outcome, duration)
 	if err != nil {
+		// Artifact parse failures mean the runner succeeded but we cannot read
+		// its verdict; treat as infra failure so retries do not count it as a
+		// legitimate agent failure.
+		parseResult := &Result{
+			ExitCode: -1,
+			Duration: duration,
+			Stderr:   err.Error(),
+			Meta: map[string]string{
+				"runner": config.RunnerGitHubActions,
+			},
+		}
+		if outcome != nil {
+			parseResult.Stdout = outcome.Logs
+			parseResult.SessionPath = outcome.CanonicalSessionPath
+			if parseResult.SessionPath == "" {
+				parseResult.SessionPath = outcome.LogPath
+			}
+		}
+		MarkInfraFailure(parseResult, "gha: artifact parse")
 		EmitEvent(events, &seq, s.Task.Session.ID, s.Task.Session.ID, launcherevents.KindError, launcherevents.ErrorPayload{Code: "artifact_parse", Message: err.Error(), Recoverable: false}, nil)
 		EmitEvent(events, &seq, s.Task.Session.ID, s.Task.Session.ID, launcherevents.KindTurnCompleted, launcherevents.TurnCompletedPayload{TurnID: s.Task.Session.ID, Status: "error"}, nil)
-		return nil, err
+		return parseResult, err
 	}
 	if err := ValidateOutputContract(s.Agent, result); err != nil {
 		EmitOutputContractFailure(events, &seq, s.Task.Session.ID, s.Task.Session.ID, err, EmitEvent)
@@ -228,6 +252,30 @@ func (s *GHASession) resolveRef(ctx context.Context) (string, error) {
 func (s *GHASession) SetApprover(Approver) error { return ErrNotSupported }
 
 func (s *GHASession) Close() error { return nil }
+
+// ghaInfraReason maps a RunWorkflow error to the infra-failure reason string.
+// It uses the typed FailureStage attached by the gha client; timeout/cancelled
+// contexts fall back to a generic reason so the caller's `code` still reflects
+// the context state.
+func ghaInfraReason(err error, code string) string {
+	switch code {
+	case "timeout":
+		return "gha: workflow timed out"
+	case "cancelled":
+		return "gha: run cancelled"
+	}
+	switch gha.StageOf(err) {
+	case gha.StageDispatch:
+		return "gha: workflow dispatch failed"
+	case gha.StagePoll:
+		return "gha: workflow poll failed"
+	case gha.StageLogs:
+		return "gha: logs download failed"
+	case gha.StageArtifacts:
+		return "gha: artifact download failed"
+	}
+	return "gha: runtime failure"
+}
 
 func SessionArtifactDir(task *TaskContext) string {
 	baseDir := task.RepoRoot

--- a/internal/runtime/gha_runner_test.go
+++ b/internal/runtime/gha_runner_test.go
@@ -1,0 +1,222 @@
+package runtime
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Lincyaw/workbuddy/internal/config"
+	launcherevents "github.com/Lincyaw/workbuddy/internal/launcher/events"
+	"github.com/Lincyaw/workbuddy/internal/launcher/runners/gha"
+)
+
+// fakeRunner lets a test script the response of each gh api call by
+// matching on a substring of the joined args.
+type fakeRunner struct {
+	rules []fakeRule
+}
+
+type fakeRule struct {
+	match string
+	body  []byte
+	err   error
+}
+
+func (f *fakeRunner) Run(_ context.Context, _ []byte, args ...string) ([]byte, error) {
+	joined := strings.Join(args, " ")
+	for _, r := range f.rules {
+		if strings.Contains(joined, r.match) {
+			return r.body, r.err
+		}
+	}
+	return nil, fmt.Errorf("fakeRunner: no rule matched: %s", joined)
+}
+
+func newSession(t *testing.T, runner gha.CommandRunner) (*GHASession, chan launcherevents.Event) {
+	t.Helper()
+	tmp := t.TempDir()
+	task := &TaskContext{
+		Repo:     "owner/repo",
+		RepoRoot: tmp,
+		WorkDir:  tmp,
+		Issue:    IssueContext{Number: 7},
+		Session:  SessionContext{ID: "sess-1"},
+	}
+	agent := &config.AgentConfig{
+		Name:    "dev-agent",
+		Runtime: config.RunnerGitHubActions,
+		GitHubActions: config.GitHubActionsRunnerConfig{
+			Workflow:     "workbuddy-remote-runner.yml",
+			Ref:          "main",
+			PollInterval: time.Millisecond,
+		},
+		Timeout: time.Minute,
+	}
+	s := &GHASession{Agent: agent, Task: task, Client: gha.NewClientWithRunner(runner)}
+	return s, make(chan launcherevents.Event, 64)
+}
+
+func drain(ch chan launcherevents.Event) {
+	go func() {
+		for range ch {
+		}
+	}()
+}
+
+func TestGHASession_DispatchFailureIsInfra(t *testing.T) {
+	runner := &fakeRunner{rules: []fakeRule{
+		{match: "workflows/workbuddy-remote-runner.yml/dispatches", err: errors.New("boom: 500")},
+	}}
+	s, ch := newSession(t, runner)
+	drain(ch)
+	result, err := s.Run(context.Background(), ch)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result with infra meta")
+	}
+	if !IsInfraFailure(result) {
+		t.Fatalf("expected infra failure meta, got %#v", result.Meta)
+	}
+	if got := result.Meta[MetaInfraFailureReason]; got != "gha: workflow dispatch failed" {
+		t.Fatalf("reason = %q, want gha: workflow dispatch failed", got)
+	}
+}
+
+func TestGHASession_PollFailureIsInfra(t *testing.T) {
+	runner := &fakeRunner{rules: []fakeRule{
+		{match: "workflows/workbuddy-remote-runner.yml/dispatches", body: []byte(`{"id":101,"html_url":"u","url":"u"}`)},
+		{match: "actions/runs/101", err: errors.New("transient 502")},
+	}}
+	s, ch := newSession(t, runner)
+	drain(ch)
+	result, err := s.Run(context.Background(), ch)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !IsInfraFailure(result) {
+		t.Fatalf("expected infra failure, got %#v", result.Meta)
+	}
+	if got := result.Meta[MetaInfraFailureReason]; got != "gha: workflow poll failed" {
+		t.Fatalf("reason = %q", got)
+	}
+}
+
+func TestGHASession_ArtifactDownloadFailureIsInfra(t *testing.T) {
+	runner := &fakeRunner{rules: []fakeRule{
+		{match: "workflows/workbuddy-remote-runner.yml/dispatches", body: []byte(`{"id":101,"html_url":"u","url":"u"}`)},
+		{match: "actions/runs/101/logs", body: zipBytes(t, map[string]string{"1.txt": "hi\n"})},
+		{match: "actions/runs/101/artifacts", err: errors.New("404: artifacts listing")},
+		{match: "actions/runs/101", body: []byte(`{"id":101,"html_url":"u","status":"completed","conclusion":"success","head_branch":"main","created_at":"2026-04-16T00:00:05Z"}`)},
+	}}
+	s, ch := newSession(t, runner)
+	drain(ch)
+	result, err := s.Run(context.Background(), ch)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !IsInfraFailure(result) {
+		t.Fatalf("expected infra failure, got %#v", result.Meta)
+	}
+	if got := result.Meta[MetaInfraFailureReason]; got != "gha: artifact download failed" {
+		t.Fatalf("reason = %q", got)
+	}
+}
+
+func TestGHASession_ArtifactParseFailureIsInfra(t *testing.T) {
+	// Happy path through dispatch/poll/logs/artifacts, but the
+	// workbuddy-result.json payload is malformed so resultFromOutcome fails.
+	artifact := zipBytes(t, map[string]string{
+		"events-v1.jsonl":       "{\"kind\":\"turn.completed\"}\n",
+		"workbuddy-result.json": `{not json`,
+	})
+	runner := &fakeRunner{rules: []fakeRule{
+		{match: "workflows/workbuddy-remote-runner.yml/dispatches", body: []byte(`{"id":101,"html_url":"u","url":"u"}`)},
+		{match: "actions/runs/101/logs", body: zipBytes(t, map[string]string{"1.txt": "hi\n"})},
+		{match: "actions/runs/101/artifacts", body: []byte(`{"artifacts":[{"id":1,"name":"workbuddy-session","archive_download_url":"repos/owner/repo/actions/artifacts/1/zip"}]}`)},
+		{match: "actions/artifacts/1/zip", body: artifact},
+		{match: "actions/runs/101", body: []byte(`{"id":101,"html_url":"u","status":"completed","conclusion":"success","head_branch":"main","created_at":"2026-04-16T00:00:05Z"}`)},
+	}}
+	s, ch := newSession(t, runner)
+	drain(ch)
+	result, err := s.Run(context.Background(), ch)
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	if result == nil || !IsInfraFailure(result) {
+		t.Fatalf("expected infra failure on artifact parse, got %#v", result)
+	}
+	if got := result.Meta[MetaInfraFailureReason]; got != "gha: artifact parse" {
+		t.Fatalf("reason = %q", got)
+	}
+}
+
+func TestGHASession_AgentNonZeroExitIsNotInfra(t *testing.T) {
+	// Workflow ran to completion; the remote agent itself reported
+	// exit_code=2. This must NOT be classified as infra failure.
+	artifact := zipBytes(t, map[string]string{
+		"events-v1.jsonl":       "{\"kind\":\"turn.completed\"}\n",
+		"workbuddy-result.json": `{"exit_code":2,"last_message":"agent failed","session_path":"events-v1.jsonl"}`,
+	})
+	runner := &fakeRunner{rules: []fakeRule{
+		{match: "workflows/workbuddy-remote-runner.yml/dispatches", body: []byte(`{"id":101,"html_url":"u","url":"u"}`)},
+		{match: "actions/runs/101/logs", body: zipBytes(t, map[string]string{"1.txt": "hi\n"})},
+		{match: "actions/runs/101/artifacts", body: []byte(`{"artifacts":[{"id":1,"name":"workbuddy-session","archive_download_url":"repos/owner/repo/actions/artifacts/1/zip"}]}`)},
+		{match: "actions/artifacts/1/zip", body: artifact},
+		{match: "actions/runs/101", body: []byte(`{"id":101,"html_url":"u","status":"completed","conclusion":"failure","head_branch":"main","created_at":"2026-04-16T00:00:05Z"}`)},
+	}}
+	s, ch := newSession(t, runner)
+	drain(ch)
+	result, err := s.Run(context.Background(), ch)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if result == nil {
+		t.Fatal("result nil")
+	}
+	if result.ExitCode != 2 {
+		t.Fatalf("exit code = %d, want 2", result.ExitCode)
+	}
+	if IsInfraFailure(result) {
+		t.Fatalf("agent-reported non-zero exit should not be infra failure: %#v", result.Meta)
+	}
+}
+
+func TestGHAInfraReason_TimeoutAndCancelled(t *testing.T) {
+	if got := ghaInfraReason(errors.New("ctx deadline"), "timeout"); got != "gha: workflow timed out" {
+		t.Fatalf("timeout reason = %q", got)
+	}
+	if got := ghaInfraReason(errors.New("ctx cancel"), "cancelled"); got != "gha: run cancelled" {
+		t.Fatalf("cancelled reason = %q", got)
+	}
+	if got := ghaInfraReason(errors.New("unknown"), "exec"); got != "gha: runtime failure" {
+		t.Fatalf("fallback reason = %q", got)
+	}
+}
+
+// zipBytes builds an in-memory zip archive with the given file map.
+func zipBytes(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, body := range files {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -1882,6 +1882,8 @@ requirements:
       - internal/launcher/process.go
       - internal/launcher/claude_stream.go
       - internal/launcher/agent_bridge.go
+      - internal/runtime/gha_runner.go
+      - internal/launcher/runners/gha/gha.go
       - internal/reporter/format.go
       - internal/reporter/reporter.go
       - internal/eventlog/eventlog.go
@@ -1893,6 +1895,7 @@ requirements:
       - cmd/worker.go
     tests:
       - internal/launcher/infra_failure_test.go
+      - internal/runtime/gha_runner_test.go
       - internal/reporter/reporter_test.go
       - cmd/serve_infra_failure_test.go
       - cmd/coordinator_infra_failure_test.go


### PR DESCRIPTION
Fixes finding #6 of issue #145: the GitHub Actions runner did not carry the infra-failure distinction that local runtimes (Claude, Codex) already honor. All pre-completion GHA errors returned bare `ExitCode=-1`, so downstream retry/escalation treated a failed `workflow_dispatch` the same as a legitimate agent failure verdict.

## Failure taxonomy (after this PR)

| Failure point                              | Classification       | `infra_failure_reason`          |
|--------------------------------------------|----------------------|---------------------------------|
| `workflow_dispatch` fails / malformed body | Infra failure        | `gha: workflow dispatch failed` |
| Run polling fails / empty metadata         | Infra failure        | `gha: workflow poll failed`     |
| Log artifact download/unzip fails          | Infra failure        | `gha: logs download failed`     |
| Artifact list/download/unzip fails         | Infra failure        | `gha: artifact download failed` |
| `workbuddy-result.json` parse fails        | Infra failure        | `gha: artifact parse`           |
| Context deadline exceeded                  | Infra failure        | `gha: workflow timed out`       |
| Context cancelled                          | Infra failure        | `gha: run cancelled`            |
| Workflow ran, remote agent exited non-zero | **Agent verdict**    | *(no infra meta)*               |

## Where infra meta is now emitted

- `internal/launcher/runners/gha/gha.go` - each stage wraps its error with `*StageError{Stage: ...}` (new `FailureStage` enum: `dispatch`, `poll`, `logs`, `artifacts`). New helper `gha.StageOf(err)` exposes the stage without string matching.
- `internal/runtime/gha_runner.go`
  - Pre-completion errors (dispatch / poll / logs / artifacts) now call `MarkInfraFailure(result, ghaInfraReason(err, code))` using the shared helper + constants from `internal/runtime/infra_failure.go`. No parallel taxonomy.
  - Artifact parse (`resultFromOutcome`) now returns a non-nil `*Result` with `infra_failure=true` and reason `gha: artifact parse`, so the worker/executor surfaces it through the same path as local runtime panics.
  - Timeout / cancelled paths keep their existing `code` but also get an infra_failure reason.

## Tests

New `internal/runtime/gha_runner_test.go` drives a `GHASession` with a scripted `gha.CommandRunner`:

- `TestGHASession_DispatchFailureIsInfra`
- `TestGHASession_PollFailureIsInfra`
- `TestGHASession_ArtifactDownloadFailureIsInfra`
- `TestGHASession_ArtifactParseFailureIsInfra`
- `TestGHASession_AgentNonZeroExitIsNotInfra` - explicit negative case
- `TestGHAInfraReason_TimeoutAndCancelled`

## Verification

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1`
- [x] `project-index.yaml` updated under REQ-056 (gha_runner.go + gha.go added to `code`; gha_runner_test.go added to `tests`); validator passes.

Refs #145.