### PR TITLE
refactor(store): narrow repository methods, retire Store.DB() on hot path (#145)

### DIFF
--- a/internal/audit/http.go
+++ b/internal/audit/http.go
@@ -178,23 +178,7 @@ func (h *HTTPHandler) queryIssueState(repo string, issueNum int) (IssueStateResp
 }
 
 func (h *HTTPHandler) latestIssueEvent(repo string, issueNum int) (*time.Time, error) {
-	var raw string
-	err := h.store.DB().QueryRow(
-		`SELECT ts FROM events WHERE repo = ? AND issue_num = ? ORDER BY ts DESC, id DESC LIMIT 1`,
-		repo, issueNum,
-	).Scan(&raw)
-	if err == sql.ErrNoRows {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("latest issue event: %w", err)
-	}
-	ts, ok := parseAuditTimestamp(raw)
-	if !ok {
-		return nil, nil
-	}
-	ts = ts.UTC()
-	return &ts, nil
+	return h.store.LatestEventAt(repo, issueNum)
 }
 
 func parseEventFilter(values url.Values) (eventlog.EventFilter, error) {

--- a/internal/auditapi/handler.go
+++ b/internal/auditapi/handler.go
@@ -560,62 +560,38 @@ func (h *Handler) queryAlerts(r *http.Request) ([]operator.Alert, error) {
 
 func (h *Handler) queryStatus() (statusResponse, error) {
 	var resp statusResponse
-	if err := h.store.DB().QueryRow(
-		`SELECT COUNT(*)
-		 FROM sessions s
-		 LEFT JOIN task_queue t ON t.id = s.task_id
-		 WHERE COALESCE(t.status, s.status) IN (?, ?)`,
-		store.TaskStatusPending, store.TaskStatusRunning,
-	).Scan(&resp.ActiveSessions); err != nil {
+	active, err := h.store.CountActiveSessions()
+	if err != nil {
 		return resp, fmt.Errorf("count active sessions: %w", err)
 	}
-	if err := h.store.DB().QueryRow(`SELECT COUNT(*) FROM workers`).Scan(&resp.Workers); err != nil {
+	resp.ActiveSessions = active
+	workers, err := h.store.CountWorkers()
+	if err != nil {
 		return resp, fmt.Errorf("count workers: %w", err)
 	}
-	var raw sql.NullString
-	if err := h.store.DB().QueryRow(
-		`SELECT ts FROM events WHERE type = ? ORDER BY id DESC LIMIT 1`,
-		poller.EventPollCycleDone,
-	).Scan(&raw); err != nil && err != sql.ErrNoRows {
+	resp.Workers = workers
+	lastPoll, err := h.store.LastEventTimestampByType(poller.EventPollCycleDone)
+	if err != nil {
 		return resp, fmt.Errorf("query last poll: %w", err)
 	}
-	if raw.Valid {
-		if ts, ok := parseSQLiteTimestamp(raw.String); ok {
-			ts = ts.UTC()
-			resp.LastPoll = &ts
-		}
-	}
+	resp.LastPoll = lastPoll
 	return resp, nil
 }
 
 func (h *Handler) listSessions(repo string, limit, offset int) ([]sessionListResponse, error) {
-	query := `SELECT s.id, s.session_id, s.task_id, s.repo, s.issue_num, s.agent_name, s.runtime, s.worker_id, s.attempt,
-	                 COALESCE(t.status, s.status),
-	                 s.dir, s.stdout_path, s.stderr_path, s.tool_calls_path, s.metadata_path, s.summary, s.raw_path, s.created_at, s.closed_at
-	          FROM sessions s
-	          LEFT JOIN task_queue t ON t.id = s.task_id
-	          WHERE 1=1`
-	args := make([]any, 0, 3)
-	if strings.TrimSpace(repo) != "" {
-		query += ` AND s.repo = ?`
-		args = append(args, strings.TrimSpace(repo))
-	}
-	query += ` ORDER BY s.id DESC LIMIT ? OFFSET ?`
-	args = append(args, limit, offset)
-
-	rows, err := h.store.DB().Query(query, args...)
+	records, err := h.store.ListSessionsForAPI(store.SessionListFilter{
+		Repo:   repo,
+		Limit:  limit,
+		Offset: offset,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("list sessions: %w", err)
 	}
-	defer func() { _ = rows.Close() }()
 
-	var out []sessionListResponse
-	for rows.Next() {
-		record, err := scanSessionRecord(rows.Scan)
-		if err != nil {
-			return nil, fmt.Errorf("scan session: %w", err)
-		}
-		exitCode, _, finishedAt, err := h.sessionTaskStats(*record)
+	out := make([]sessionListResponse, 0, len(records))
+	for i := range records {
+		record := records[i]
+		exitCode, _, finishedAt, err := h.sessionTaskStats(record)
 		if err != nil {
 			return nil, err
 		}
@@ -636,7 +612,7 @@ func (h *Handler) listSessions(repo string, limit, offset int) ([]sessionListRes
 			Summary:    record.Summary,
 		})
 	}
-	return out, rows.Err()
+	return out, nil
 }
 
 func (h *Handler) buildSessionDetail(record store.SessionRecord) (sessionDetailResponse, error) {
@@ -707,47 +683,26 @@ func (h *Handler) sessionTaskStats(record store.SessionRecord) (int, string, *ti
 
 func (h *Handler) queryMetrics() (metricsResponse, error) {
 	resp := metricsResponse{AgentExecutions: map[string]int{}}
-	var total, successful, retried int
-	var avg sql.NullFloat64
-	if err := h.store.DB().QueryRow(
-		`SELECT
-			 COUNT(*),
-			 SUM(CASE WHEN COALESCE(t.status, s.status) = ? THEN 1 ELSE 0 END),
-			 AVG(CASE
-				 WHEN s.closed_at IS NOT NULL THEN (julianday(s.closed_at) - julianday(s.created_at)) * 86400.0
-				 ELSE NULL
-			 END),
-			 SUM(CASE WHEN s.attempt > 1 THEN 1 ELSE 0 END)
-		 FROM sessions s
-		 LEFT JOIN task_queue t ON t.id = s.task_id
-		 WHERE COALESCE(t.status, s.status) IN (?, ?, ?)`,
-		store.TaskStatusCompleted,
-		store.TaskStatusCompleted, store.TaskStatusFailed, store.TaskStatusTimeout,
-	).Scan(&total, &successful, &avg, &retried); err != nil {
+	agg, err := h.store.AggregateSessionMetrics()
+	if err != nil {
 		return resp, fmt.Errorf("aggregate metrics: %w", err)
 	}
-	if total > 0 {
-		resp.SuccessRate = float64(successful) / float64(total)
-		resp.RetryRate = float64(retried) / float64(total)
+	if agg.Total > 0 {
+		resp.SuccessRate = float64(agg.Successful) / float64(agg.Total)
+		resp.RetryRate = float64(agg.Retried) / float64(agg.Total)
 	}
-	if avg.Valid {
-		resp.AvgDuration = avg.Float64
+	if agg.AvgDuration.Valid {
+		resp.AvgDuration = agg.AvgDuration.Float64
 	}
 
-	rows, err := h.store.DB().Query(`SELECT agent_name, COUNT(*) FROM sessions GROUP BY agent_name ORDER BY agent_name`)
+	perAgent, err := h.store.CountSessionsByAgent()
 	if err != nil {
 		return resp, fmt.Errorf("aggregate per-agent counts: %w", err)
 	}
-	defer func() { _ = rows.Close() }()
-	for rows.Next() {
-		var agentName string
-		var count int
-		if err := rows.Scan(&agentName, &count); err != nil {
-			return resp, fmt.Errorf("scan per-agent counts: %w", err)
-		}
-		resp.AgentExecutions[agentName] = count
+	for _, row := range perAgent {
+		resp.AgentExecutions[row.AgentName] = row.Count
 	}
-	return resp, rows.Err()
+	return resp, nil
 }
 
 func scanSessionRecord(scan func(dest ...any) error) (*store.SessionRecord, error) {

--- a/internal/eventlog/eventlog.go
+++ b/internal/eventlog/eventlog.go
@@ -187,49 +187,11 @@ func (l *EventLogger) Health() Health {
 // Query returns events matching the filter criteria.
 // All filter fields are optional; zero-value fields are ignored.
 func (l *EventLogger) Query(filter EventFilter) ([]store.Event, error) {
-	db := l.store.DB()
-
-	query := `SELECT id, ts, type, repo, issue_num, payload FROM events WHERE 1=1`
-	var args []interface{}
-
-	if filter.Repo != "" {
-		query += ` AND repo = ?`
-		args = append(args, filter.Repo)
-	}
-	if filter.Type != "" {
-		query += ` AND type = ?`
-		args = append(args, filter.Type)
-	}
-	if filter.IssueNum != 0 {
-		query += ` AND issue_num = ?`
-		args = append(args, filter.IssueNum)
-	}
-	if filter.Since != nil {
-		query += ` AND ts >= ?`
-		args = append(args, filter.Since.UTC().Format("2006-01-02 15:04:05"))
-	}
-	if filter.Until != nil {
-		query += ` AND ts <= ?`
-		args = append(args, filter.Until.UTC().Format("2006-01-02 15:04:05"))
-	}
-
-	query += ` ORDER BY id`
-
-	rows, err := db.Query(query, args...)
-	if err != nil {
-		return nil, fmt.Errorf("eventlog: query: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	var out []store.Event
-	for rows.Next() {
-		var ev store.Event
-		var ts string
-		if err := rows.Scan(&ev.ID, &ts, &ev.Type, &ev.Repo, &ev.IssueNum, &ev.Payload); err != nil {
-			return nil, fmt.Errorf("eventlog: scan: %w", err)
-		}
-		ev.TS, _ = time.Parse("2006-01-02 15:04:05", ts)
-		out = append(out, ev)
-	}
-	return out, rows.Err()
+	return l.store.QueryEventsFiltered(store.EventQueryFilter{
+		Since:    filter.Since,
+		Until:    filter.Until,
+		Type:     filter.Type,
+		Repo:     filter.Repo,
+		IssueNum: filter.IssueNum,
+	})
 }

--- a/internal/metrics/handler.go
+++ b/internal/metrics/handler.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -15,18 +14,32 @@ import (
 
 const stuckThreshold = time.Hour
 
+// Source is the narrow, read-only view of persistence required by the metrics
+// handler. It is satisfied by *store.Store and exists so this package never
+// touches a raw *sql.DB. Keeping the surface small (only aggregates, not
+// arbitrary SQL) is the point of issue #145 finding #9.
+type Source interface {
+	CountEventsByRepoType() ([]store.EventCountByRepoType, error)
+	TokenUsageEvents(eventType string) ([]store.TokenUsagePayload, error)
+	CountTasksByRepoStatus() ([]store.TaskCountByRepoStatus, error)
+	CountWorkersByRepo() ([]store.WorkerCountByRepo, error)
+	MaxTransitionCounts() ([]store.TransitionMaxCount, error)
+	ListOpenIssueActivity(pendingStatus, runningStatus string) ([]store.IssueActivityRow, error)
+}
+
 // Handler serves Prometheus metrics from SQLite state.
 type Handler struct {
-	store *store.Store
+	src   Source
 	evlog *eventlog.EventLogger
 	now   func() time.Time
 }
 
-// NewHandler returns a handler bound to the provided store.
-func NewHandler(st *store.Store) *Handler {
+// NewHandler returns a handler bound to the provided metrics source. Any type
+// satisfying Source can be passed; in production this is *store.Store.
+func NewHandler(src Source) *Handler {
 	return &Handler{
-		store: st,
-		now:   time.Now,
+		src: src,
+		now: time.Now,
 	}
 }
 
@@ -60,21 +73,20 @@ func (h *Handler) handleMetrics(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) writeMetrics(b *strings.Builder, now time.Time) error {
-	db := h.store.DB()
-	if err := h.writeEventCounters(b, db); err != nil {
+	if err := h.writeEventCounters(b); err != nil {
 		return err
 	}
-	if err := h.writeTaskCounters(b, db); err != nil {
+	if err := h.writeTaskCounters(b); err != nil {
 		return err
 	}
-	if err := h.writeWorkerCounters(b, db); err != nil {
+	if err := h.writeWorkerCounters(b); err != nil {
 		return err
 	}
-	if err := h.writeTransitionMaxCounters(b, db); err != nil {
+	if err := h.writeTransitionMaxCounters(b); err != nil {
 		return err
 	}
 	h.writeEventlogHealth(b)
-	return h.writeIssueCounters(b, db, now)
+	return h.writeIssueCounters(b, now)
 }
 
 func (h *Handler) writeEventlogHealth(b *strings.Builder) {
@@ -94,90 +106,66 @@ func (h *Handler) writeEventlogHealth(b *strings.Builder) {
 	_, _ = b.WriteString(fmt.Sprintf("workbuddy_eventlog_degraded %d\n", degraded))
 }
 
-func (h *Handler) writeEventCounters(b *strings.Builder, db *sql.DB) error {
-	rows, err := db.Query(`SELECT COALESCE(repo, ''), COALESCE(type, ''), COUNT(1) FROM events GROUP BY repo, type`)
+func (h *Handler) writeEventCounters(b *strings.Builder) error {
+	agg, err := h.src.CountEventsByRepoType()
 	if err != nil {
 		return fmt.Errorf("events query: %w", err)
 	}
-	defer func() { _ = rows.Close() }()
-
-	type eventMetric struct {
-		repo string
-		typ  string
-		cnt  int64
-	}
-	metrics := make([]eventMetric, 0)
+	metrics := append([]store.EventCountByRepoType(nil), agg...)
 	eventCounts := make(map[string]map[string]int64)
-	for rows.Next() {
-		var m eventMetric
-		if err := rows.Scan(&m.repo, &m.typ, &m.cnt); err != nil {
-			return fmt.Errorf("scan events: %w", err)
-		}
-		metrics = append(metrics, m)
-		byType, ok := eventCounts[m.typ]
+	for _, m := range metrics {
+		byType, ok := eventCounts[m.Type]
 		if !ok {
 			byType = make(map[string]int64)
-			eventCounts[m.typ] = byType
+			eventCounts[m.Type] = byType
 		}
-		byType[m.repo] = m.cnt
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("scan events rows: %w", err)
+		byType[m.Repo] = m.Count
 	}
 
 	sort.Slice(metrics, func(i, j int) bool {
-		if metrics[i].repo == metrics[j].repo {
-			return metrics[i].typ < metrics[j].typ
+		if metrics[i].Repo == metrics[j].Repo {
+			return metrics[i].Type < metrics[j].Type
 		}
-		return metrics[i].repo < metrics[j].repo
+		return metrics[i].Repo < metrics[j].Repo
 	})
 
 	_, _ = b.WriteString("# HELP workbuddy_events_total Total count of lifecycle events by type and repository.\n")
 	_, _ = b.WriteString("# TYPE workbuddy_events_total counter\n")
 	for _, m := range metrics {
 		_, _ = b.WriteString(fmt.Sprintf(`workbuddy_events_total{repo=%s,type=%s} %d`+"\n",
-			promLabel(m.repo, "repo"), promLabel(m.typ, "type"), m.cnt))
+			promLabel(m.Repo, "repo"), promLabel(m.Type, "type"), m.Count))
 	}
 	h.writeDerivedEventCounter(b, "workbuddy_tasks_dispatched_total", "Total workflow dispatch events.", eventCounts[eventlog.TypeDispatch])
 	h.writeDerivedEventCounter(b, "workbuddy_retry_limit_reached_total", "Total retry limit reached events.", eventCounts[eventlog.TypeRetryLimit])
 	h.writeDerivedEventCounter(b, "workbuddy_cycle_limit_reached_total", "Total cycle limit reached events.", eventCounts[eventlog.TypeCycleLimitReached])
 	h.writeDerivedEventCounter(b, "workbuddy_dependency_blocked_total", "Total events for dispatches blocked by dependency verdict.", eventCounts[eventlog.TypeDispatchBlockedByDependency])
 
-	tokenTotals := map[string]map[string]int64{}
-	var tokenParseErrors int64
-	tokenRows, err := db.Query(`SELECT COALESCE(repo, ''), COALESCE(payload, '') FROM events WHERE type = ?`, eventlog.TypeTokenUsage)
+	tokenEvents, err := h.src.TokenUsageEvents(eventlog.TypeTokenUsage)
 	if err != nil {
 		return fmt.Errorf("token usage query: %w", err)
 	}
-	defer func() { _ = tokenRows.Close() }()
-	for tokenRows.Next() {
-		var repo, rawPayload string
-		if err := tokenRows.Scan(&repo, &rawPayload); err != nil {
-			return fmt.Errorf("scan token usage: %w", err)
-		}
+	tokenTotals := map[string]map[string]int64{}
+	var tokenParseErrors int64
+	for _, ev := range tokenEvents {
 		var usage struct {
 			Input  int64 `json:"input"`
 			Output int64 `json:"output"`
 			Cached int64 `json:"cached"`
 			Total  int64 `json:"total"`
 		}
-		if err := json.Unmarshal([]byte(rawPayload), &usage); err != nil {
+		if err := json.Unmarshal([]byte(ev.Payload), &usage); err != nil {
 			tokenParseErrors++
 			continue
 		}
-
-		agg, ok := tokenTotals[repo]
+		agg, ok := tokenTotals[ev.Repo]
 		if !ok {
 			agg = map[string]int64{}
-			tokenTotals[repo] = agg
+			tokenTotals[ev.Repo] = agg
 		}
 		agg["input"] += usage.Input
 		agg["output"] += usage.Output
 		agg["cached"] += usage.Cached
 		agg["total"] += usage.Total
-	}
-	if err := tokenRows.Err(); err != nil {
-		return fmt.Errorf("scan token usage rows: %w", err)
 	}
 
 	_, _ = b.WriteString("# HELP workbuddy_token_parse_errors_total Number of malformed token usage payloads.\n")
@@ -218,190 +206,98 @@ func (h *Handler) writeDerivedEventCounter(b *strings.Builder, metricName, helpT
 	}
 }
 
-func (h *Handler) writeTaskCounters(b *strings.Builder, db *sql.DB) error {
-	rows, err := db.Query(`SELECT COALESCE(repo, ''), COALESCE(status, ''), COUNT(1) FROM task_queue GROUP BY repo, status`)
+func (h *Handler) writeTaskCounters(b *strings.Builder) error {
+	metrics, err := h.src.CountTasksByRepoStatus()
 	if err != nil {
 		return fmt.Errorf("tasks query: %w", err)
 	}
-	defer func() { _ = rows.Close() }()
-
-	type metric struct {
-		repo   string
-		status string
-		count  int64
-	}
-	metrics := make([]metric, 0)
-	for rows.Next() {
-		var m metric
-		if err := rows.Scan(&m.repo, &m.status, &m.count); err != nil {
-			return fmt.Errorf("scan tasks: %w", err)
-		}
-		metrics = append(metrics, m)
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("scan task rows: %w", err)
-	}
-
 	sort.Slice(metrics, func(i, j int) bool {
-		if metrics[i].repo == metrics[j].repo {
-			return metrics[i].status < metrics[j].status
+		if metrics[i].Repo == metrics[j].Repo {
+			return metrics[i].Status < metrics[j].Status
 		}
-		return metrics[i].repo < metrics[j].repo
+		return metrics[i].Repo < metrics[j].Repo
 	})
 
 	_, _ = b.WriteString("# HELP workbuddy_tasks_active Active task count by repo and status.\n")
 	_, _ = b.WriteString("# TYPE workbuddy_tasks_active gauge\n")
 	for _, m := range metrics {
 		_, _ = b.WriteString(fmt.Sprintf(`workbuddy_tasks_active{repo=%s,status=%s} %d`+"\n",
-			promLabel(m.repo, "repo"), promLabel(m.status, "status"), m.count))
+			promLabel(m.Repo, "repo"), promLabel(m.Status, "status"), m.Count))
 	}
 	return nil
 }
 
-func (h *Handler) writeWorkerCounters(b *strings.Builder, db *sql.DB) error {
-	rows, err := db.Query(`
-		SELECT COALESCE(repo, ''), COUNT(1),
-		       SUM(CASE WHEN status = 'online' THEN 1 ELSE 0 END)
-		FROM workers
-		GROUP BY repo`)
+func (h *Handler) writeWorkerCounters(b *strings.Builder) error {
+	metrics, err := h.src.CountWorkersByRepo()
 	if err != nil {
 		return fmt.Errorf("workers query: %w", err)
 	}
-	defer func() { _ = rows.Close() }()
-
-	type metric struct {
-		repo   string
-		total  int64
-		online int64
-	}
-	metrics := make([]metric, 0)
-	for rows.Next() {
-		var m metric
-		if err := rows.Scan(&m.repo, &m.total, &m.online); err != nil {
-			return fmt.Errorf("scan workers: %w", err)
-		}
-		metrics = append(metrics, m)
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("scan worker rows: %w", err)
-	}
-
-	sort.Slice(metrics, func(i, j int) bool { return metrics[i].repo < metrics[j].repo })
+	sort.Slice(metrics, func(i, j int) bool { return metrics[i].Repo < metrics[j].Repo })
 	_, _ = b.WriteString("# HELP workbuddy_workers_total Total registered workers by repo.\n")
 	_, _ = b.WriteString("# TYPE workbuddy_workers_total gauge\n")
 	_, _ = b.WriteString("# HELP workbuddy_workers_online Online workers by repo.\n")
 	_, _ = b.WriteString("# TYPE workbuddy_workers_online gauge\n")
 	for _, m := range metrics {
-		repoLabel := promLabel(m.repo, "repo")
-		_, _ = b.WriteString(fmt.Sprintf("workbuddy_workers_total{repo=%s} %d\n", repoLabel, m.total))
-		_, _ = b.WriteString(fmt.Sprintf("workbuddy_workers_online{repo=%s} %d\n", repoLabel, m.online))
+		repoLabel := promLabel(m.Repo, "repo")
+		_, _ = b.WriteString(fmt.Sprintf("workbuddy_workers_total{repo=%s} %d\n", repoLabel, m.Total))
+		_, _ = b.WriteString(fmt.Sprintf("workbuddy_workers_online{repo=%s} %d\n", repoLabel, m.Online))
 	}
 	return nil
 }
 
-func (h *Handler) writeTransitionMaxCounters(b *strings.Builder, db *sql.DB) error {
-	rows, err := db.Query(`SELECT COALESCE(repo, ''), COALESCE(from_state, ''), COALESCE(to_state, ''), MAX(count) FROM transition_counts GROUP BY repo, from_state, to_state`)
+func (h *Handler) writeTransitionMaxCounters(b *strings.Builder) error {
+	metrics, err := h.src.MaxTransitionCounts()
 	if err != nil {
 		return fmt.Errorf("transition max query: %w", err)
 	}
-	defer func() { _ = rows.Close() }()
-
-	type metric struct {
-		repo      string
-		fromState string
-		toState   string
-		maxCount  int64
-	}
-	metrics := make([]metric, 0)
-	for rows.Next() {
-		var m metric
-		if err := rows.Scan(&m.repo, &m.fromState, &m.toState, &m.maxCount); err != nil {
-			return fmt.Errorf("scan transition max: %w", err)
-		}
-		metrics = append(metrics, m)
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("scan transition max rows: %w", err)
-	}
-
 	sort.Slice(metrics, func(i, j int) bool {
 		a, b := metrics[i], metrics[j]
-		if a.repo == b.repo {
-			if a.fromState == b.fromState {
-				return a.toState < b.toState
+		if a.Repo == b.Repo {
+			if a.FromState == b.FromState {
+				return a.ToState < b.ToState
 			}
-			return a.fromState < b.fromState
+			return a.FromState < b.FromState
 		}
-		return a.repo < b.repo
+		return a.Repo < b.Repo
 	})
 
 	_, _ = b.WriteString("# HELP workbuddy_transition_max_count Maximum retry count observed for each workflow transition.\n")
 	_, _ = b.WriteString("# TYPE workbuddy_transition_max_count gauge\n")
 	for _, m := range metrics {
 		_, _ = b.WriteString(fmt.Sprintf(`workbuddy_transition_max_count{repo=%s,from=%s,to=%s} %d`+"\n",
-			promLabel(m.repo, "repo"), promLabel(m.fromState, "from"), promLabel(m.toState, "to"), m.maxCount))
+			promLabel(m.Repo, "repo"), promLabel(m.FromState, "from"), promLabel(m.ToState, "to"), m.MaxCount))
 	}
 	return nil
 }
 
-func (h *Handler) writeIssueCounters(b *strings.Builder, db *sql.DB, now time.Time) error {
-	rows, err := db.Query(`
-		SELECT
-			ic.repo,
-			ic.issue_num,
-			ic.labels,
-			COALESCE(ic.state, ''),
-			(
-				SELECT MAX(e.ts) FROM events e
-				WHERE e.repo = ic.repo AND e.issue_num = ic.issue_num
-			),
-			(
-				SELECT COUNT(1) FROM task_queue tq
-				WHERE tq.repo = ic.repo AND tq.issue_num = ic.issue_num
-					AND tq.status IN (?, ?)
-			)
-		FROM issue_cache ic
-		WHERE (ic.state = 'open' OR ic.state IS NULL)
-			AND (ic.state IS NULL OR ic.state NOT LIKE 'pr:%')`,
-		store.TaskStatusPending, store.TaskStatusRunning)
+func (h *Handler) writeIssueCounters(b *strings.Builder, now time.Time) error {
+	rows, err := h.src.ListOpenIssueActivity(store.TaskStatusPending, store.TaskStatusRunning)
 	if err != nil {
 		return fmt.Errorf("open issue query: %w", err)
 	}
-	defer func() { _ = rows.Close() }()
 
 	openIssues := map[string]int64{}
 	stuckIssues := map[string]int64{}
-	for rows.Next() {
-		var repo, labelsJSON, issueState string
-		var issueNum int
-		var rawLastEvent sql.NullString
-		var activeTaskCount int
-		if err := rows.Scan(&repo, &issueNum, &labelsJSON, &issueState, &rawLastEvent, &activeTaskCount); err != nil {
-			return fmt.Errorf("scan issue row: %w", err)
-		}
-		openIssues[repo]++
+	for _, row := range rows {
+		openIssues[row.Repo]++
 
-		_ = issueNum
-		state := inferCurrentState(labelsJSON, issueState)
+		state := inferCurrentState(row.LabelsJSON, row.State)
 		if !isIntermediateState(state) {
 			continue
 		}
-		if activeTaskCount > 0 {
+		if row.ActiveTaskCount > 0 {
 			continue
 		}
-		if !rawLastEvent.Valid {
+		if !row.LastEventAt.Valid {
 			continue
 		}
-		lastEventAt, ok := parseEventTimestamp(rawLastEvent.String)
+		lastEventAt, ok := parseEventTimestamp(row.LastEventAt.String)
 		if !ok {
 			continue
 		}
 		if now.Sub(lastEventAt) > stuckThreshold {
-			stuckIssues[repo]++
+			stuckIssues[row.Repo]++
 		}
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("scan issue rows: %w", err)
 	}
 
 	repos := make([]string, 0, len(openIssues))

--- a/internal/statemachine/statemachine.go
+++ b/internal/statemachine/statemachine.go
@@ -150,7 +150,7 @@ func NewStateMachine(
 ) *StateMachine {
 	var workflowManager *workflow.Manager
 	if st != nil {
-		workflowManager = workflow.NewManager(st.DB())
+		workflowManager = workflow.NewManager(st)
 	}
 	return &StateMachine{
 		workflows:       workflows,

--- a/internal/statemachine/statemachine_test.go
+++ b/internal/statemachine/statemachine_test.go
@@ -202,7 +202,7 @@ func TestNormalTransition(t *testing.T) {
 		t.Error("expected dispatch request, got none")
 	}
 
-	instances, err := workflow.NewManager(sm.store.DB()).QueryByRepoIssue("test/repo", 1)
+	instances, err := workflow.NewManager(sm.store).QueryByRepoIssue("test/repo", 1)
 	if err != nil {
 		t.Fatalf("workflow query: %v", err)
 	}

--- a/internal/store/queries.go
+++ b/internal/store/queries.go
@@ -1,0 +1,614 @@
+package store
+
+// This file contains narrow, purpose-built query methods used by higher-level
+// packages (eventlog, metrics, auditapi, audit, workflow) so those consumers
+// no longer need to reach through Store.DB() and issue raw SQL against storage
+// internals. See issue #145 finding #9.
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Event query (eventlog)
+// ---------------------------------------------------------------------------
+
+// EventQueryFilter specifies optional criteria for QueryEventsFiltered.
+// All fields are optional; zero values are ignored.
+type EventQueryFilter struct {
+	Since    *time.Time
+	Until    *time.Time
+	Type     string
+	Repo     string
+	IssueNum int
+}
+
+// QueryEventsFiltered returns events matching the provided filter. It exists
+// so eventlog.EventLogger can run filtered queries without needing a raw
+// *sql.DB handle.
+func (s *Store) QueryEventsFiltered(filter EventQueryFilter) ([]Event, error) {
+	query := `SELECT id, ts, type, repo, issue_num, payload FROM events WHERE 1=1`
+	var args []interface{}
+
+	if filter.Repo != "" {
+		query += ` AND repo = ?`
+		args = append(args, filter.Repo)
+	}
+	if filter.Type != "" {
+		query += ` AND type = ?`
+		args = append(args, filter.Type)
+	}
+	if filter.IssueNum != 0 {
+		query += ` AND issue_num = ?`
+		args = append(args, filter.IssueNum)
+	}
+	if filter.Since != nil {
+		query += ` AND ts >= ?`
+		args = append(args, filter.Since.UTC().Format("2006-01-02 15:04:05"))
+	}
+	if filter.Until != nil {
+		query += ` AND ts <= ?`
+		args = append(args, filter.Until.UTC().Format("2006-01-02 15:04:05"))
+	}
+
+	query += ` ORDER BY id`
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("store: query events filtered: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []Event
+	for rows.Next() {
+		var ev Event
+		var ts string
+		if err := rows.Scan(&ev.ID, &ts, &ev.Type, &ev.Repo, &ev.IssueNum, &ev.Payload); err != nil {
+			return nil, fmt.Errorf("store: scan event: %w", err)
+		}
+		ev.TS, _ = time.Parse("2006-01-02 15:04:05", ts)
+		out = append(out, ev)
+	}
+	return out, rows.Err()
+}
+
+// LatestEventAt returns the timestamp of the most recent event for the given
+// repo/issue pair, or nil if there are no events. Used by audit handlers to
+// compute "last activity" surfaces.
+func (s *Store) LatestEventAt(repo string, issueNum int) (*time.Time, error) {
+	var raw string
+	err := s.db.QueryRow(
+		`SELECT ts FROM events WHERE repo = ? AND issue_num = ? ORDER BY ts DESC, id DESC LIMIT 1`,
+		repo, issueNum,
+	).Scan(&raw)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("store: latest event at: %w", err)
+	}
+	ts, ok := ParseTimestamp(raw, "event.ts")
+	if !ok {
+		return nil, nil
+	}
+	ts = ts.UTC()
+	return &ts, nil
+}
+
+// ---------------------------------------------------------------------------
+// Metrics aggregates
+// ---------------------------------------------------------------------------
+
+// EventCountByRepoType is one row of the (repo,type,count) aggregation used by
+// the Prometheus metrics handler.
+type EventCountByRepoType struct {
+	Repo  string
+	Type  string
+	Count int64
+}
+
+// TokenUsagePayload is a single token_usage event payload surfaced to metrics.
+type TokenUsagePayload struct {
+	Repo    string
+	Payload string
+}
+
+// TaskCountByRepoStatus aggregates task_queue rows by (repo,status).
+type TaskCountByRepoStatus struct {
+	Repo   string
+	Status string
+	Count  int64
+}
+
+// WorkerCountByRepo aggregates workers by repo including online totals.
+type WorkerCountByRepo struct {
+	Repo   string
+	Total  int64
+	Online int64
+}
+
+// TransitionMaxCount is the MAX(count) per (repo,from_state,to_state).
+type TransitionMaxCount struct {
+	Repo      string
+	FromState string
+	ToState   string
+	MaxCount  int64
+}
+
+// IssueActivityRow is one issue_cache row joined with its last event time and
+// active-task count, used to compute open/stuck issue gauges.
+type IssueActivityRow struct {
+	Repo            string
+	IssueNum        int
+	LabelsJSON      string
+	State           string
+	LastEventAt     sql.NullString
+	ActiveTaskCount int
+}
+
+// CountEventsByRepoType returns the (repo,type,count) aggregation for all
+// lifecycle events. Used by the metrics handler.
+func (s *Store) CountEventsByRepoType() ([]EventCountByRepoType, error) {
+	rows, err := s.db.Query(`SELECT COALESCE(repo, ''), COALESCE(type, ''), COUNT(1) FROM events GROUP BY repo, type`)
+	if err != nil {
+		return nil, fmt.Errorf("store: events by repo/type: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []EventCountByRepoType
+	for rows.Next() {
+		var m EventCountByRepoType
+		if err := rows.Scan(&m.Repo, &m.Type, &m.Count); err != nil {
+			return nil, fmt.Errorf("store: scan events agg: %w", err)
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}
+
+// TokenUsageEvents returns the raw payload of every token_usage event along
+// with its repo. Parsing is left to the caller.
+func (s *Store) TokenUsageEvents(eventType string) ([]TokenUsagePayload, error) {
+	rows, err := s.db.Query(`SELECT COALESCE(repo, ''), COALESCE(payload, '') FROM events WHERE type = ?`, eventType)
+	if err != nil {
+		return nil, fmt.Errorf("store: token usage events: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []TokenUsagePayload
+	for rows.Next() {
+		var t TokenUsagePayload
+		if err := rows.Scan(&t.Repo, &t.Payload); err != nil {
+			return nil, fmt.Errorf("store: scan token usage: %w", err)
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+// CountTasksByRepoStatus returns task_queue counts grouped by (repo,status).
+func (s *Store) CountTasksByRepoStatus() ([]TaskCountByRepoStatus, error) {
+	rows, err := s.db.Query(`SELECT COALESCE(repo, ''), COALESCE(status, ''), COUNT(1) FROM task_queue GROUP BY repo, status`)
+	if err != nil {
+		return nil, fmt.Errorf("store: task counts: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []TaskCountByRepoStatus
+	for rows.Next() {
+		var m TaskCountByRepoStatus
+		if err := rows.Scan(&m.Repo, &m.Status, &m.Count); err != nil {
+			return nil, fmt.Errorf("store: scan task count: %w", err)
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}
+
+// CountWorkersByRepo returns total and online worker counts grouped by repo.
+func (s *Store) CountWorkersByRepo() ([]WorkerCountByRepo, error) {
+	rows, err := s.db.Query(`
+		SELECT COALESCE(repo, ''), COUNT(1),
+		       SUM(CASE WHEN status = 'online' THEN 1 ELSE 0 END)
+		FROM workers
+		GROUP BY repo`)
+	if err != nil {
+		return nil, fmt.Errorf("store: worker counts: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []WorkerCountByRepo
+	for rows.Next() {
+		var m WorkerCountByRepo
+		if err := rows.Scan(&m.Repo, &m.Total, &m.Online); err != nil {
+			return nil, fmt.Errorf("store: scan worker count: %w", err)
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}
+
+// MaxTransitionCounts returns the MAX(count) per transition.
+func (s *Store) MaxTransitionCounts() ([]TransitionMaxCount, error) {
+	rows, err := s.db.Query(`SELECT COALESCE(repo, ''), COALESCE(from_state, ''), COALESCE(to_state, ''), MAX(count) FROM transition_counts GROUP BY repo, from_state, to_state`)
+	if err != nil {
+		return nil, fmt.Errorf("store: transition max: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []TransitionMaxCount
+	for rows.Next() {
+		var m TransitionMaxCount
+		if err := rows.Scan(&m.Repo, &m.FromState, &m.ToState, &m.MaxCount); err != nil {
+			return nil, fmt.Errorf("store: scan transition max: %w", err)
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}
+
+// ListOpenIssueActivity returns, for every open issue, the activity row needed
+// to compute open/stuck issue gauges. pendingStatus and runningStatus bound
+// the "active task" count used to determine whether the issue is idle.
+func (s *Store) ListOpenIssueActivity(pendingStatus, runningStatus string) ([]IssueActivityRow, error) {
+	rows, err := s.db.Query(`
+		SELECT
+			ic.repo,
+			ic.issue_num,
+			ic.labels,
+			COALESCE(ic.state, ''),
+			(
+				SELECT MAX(e.ts) FROM events e
+				WHERE e.repo = ic.repo AND e.issue_num = ic.issue_num
+			),
+			(
+				SELECT COUNT(1) FROM task_queue tq
+				WHERE tq.repo = ic.repo AND tq.issue_num = ic.issue_num
+					AND tq.status IN (?, ?)
+			)
+		FROM issue_cache ic
+		WHERE (ic.state = 'open' OR ic.state IS NULL)
+			AND (ic.state IS NULL OR ic.state NOT LIKE 'pr:%')`,
+		pendingStatus, runningStatus)
+	if err != nil {
+		return nil, fmt.Errorf("store: open issue activity: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []IssueActivityRow
+	for rows.Next() {
+		var r IssueActivityRow
+		if err := rows.Scan(&r.Repo, &r.IssueNum, &r.LabelsJSON, &r.State, &r.LastEventAt, &r.ActiveTaskCount); err != nil {
+			return nil, fmt.Errorf("store: scan open issue: %w", err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// ---------------------------------------------------------------------------
+// Audit API (auditapi + audit/http)
+// ---------------------------------------------------------------------------
+
+// CountActiveSessions returns the number of sessions whose joined task status
+// (falling back to session status) is pending or running.
+func (s *Store) CountActiveSessions() (int, error) {
+	var n int
+	err := s.db.QueryRow(
+		`SELECT COUNT(*)
+		 FROM sessions s
+		 LEFT JOIN task_queue t ON t.id = s.task_id
+		 WHERE COALESCE(t.status, s.status) IN (?, ?)`,
+		TaskStatusPending, TaskStatusRunning,
+	).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("store: count active sessions: %w", err)
+	}
+	return n, nil
+}
+
+// CountWorkers returns the total number of rows in the workers table.
+func (s *Store) CountWorkers() (int, error) {
+	var n int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM workers`).Scan(&n); err != nil {
+		return 0, fmt.Errorf("store: count workers: %w", err)
+	}
+	return n, nil
+}
+
+// LastEventTimestampByType returns the timestamp of the most recent event of
+// the given type, or nil if none exists.
+func (s *Store) LastEventTimestampByType(eventType string) (*time.Time, error) {
+	var raw sql.NullString
+	err := s.db.QueryRow(
+		`SELECT ts FROM events WHERE type = ? ORDER BY id DESC LIMIT 1`,
+		eventType,
+	).Scan(&raw)
+	if err != nil && err != sql.ErrNoRows {
+		return nil, fmt.Errorf("store: last event by type: %w", err)
+	}
+	if !raw.Valid {
+		return nil, nil
+	}
+	ts, ok := ParseTimestamp(raw.String, "event.ts")
+	if !ok {
+		return nil, nil
+	}
+	ts = ts.UTC()
+	return &ts, nil
+}
+
+// SessionListFilter narrows ListSessionsForAPI.
+type SessionListFilter struct {
+	Repo   string
+	Limit  int
+	Offset int
+}
+
+// ListSessionsForAPI returns session rows with joined task status, ordered
+// newest first, for the audit API. This preserves the exact JOIN semantics
+// previously inlined in auditapi.
+func (s *Store) ListSessionsForAPI(filter SessionListFilter) ([]SessionRecord, error) {
+	query := `SELECT s.id, s.session_id, s.task_id, s.repo, s.issue_num, s.agent_name, s.runtime, s.worker_id, s.attempt,
+	                 COALESCE(t.status, s.status),
+	                 s.dir, s.stdout_path, s.stderr_path, s.tool_calls_path, s.metadata_path, s.summary, s.raw_path, s.created_at, s.closed_at
+	          FROM sessions s
+	          LEFT JOIN task_queue t ON t.id = s.task_id
+	          WHERE 1=1`
+	args := make([]any, 0, 3)
+	if trimmed := strings.TrimSpace(filter.Repo); trimmed != "" {
+		query += ` AND s.repo = ?`
+		args = append(args, trimmed)
+	}
+	query += ` ORDER BY s.id DESC LIMIT ? OFFSET ?`
+	args = append(args, filter.Limit, filter.Offset)
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("store: list sessions for api: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []SessionRecord
+	for rows.Next() {
+		record, err := scanSessionRecordForAPI(rows.Scan)
+		if err != nil {
+			return nil, fmt.Errorf("store: scan session for api: %w", err)
+		}
+		out = append(out, *record)
+	}
+	return out, rows.Err()
+}
+
+func scanSessionRecordForAPI(scan func(dest ...any) error) (*SessionRecord, error) {
+	var record SessionRecord
+	var createdAt string
+	var closedAt sql.NullString
+	if err := scan(
+		&record.ID, &record.SessionID, &record.TaskID, &record.Repo, &record.IssueNum, &record.AgentName,
+		&record.Runtime, &record.WorkerID, &record.Attempt, &record.Status, &record.Dir, &record.StdoutPath,
+		&record.StderrPath, &record.ToolCallsPath, &record.MetadataPath, &record.Summary, &record.RawPath,
+		&createdAt, &closedAt,
+	); err != nil {
+		return nil, err
+	}
+	record.CreatedAt, _ = ParseTimestamp(createdAt, "session.created_at")
+	if closedAt.Valid {
+		record.ClosedAt, _ = ParseTimestamp(closedAt.String, "session.closed_at")
+	}
+	return &record, nil
+}
+
+// SessionAggregateMetrics captures the aggregate session metrics returned to
+// the audit API.
+type SessionAggregateMetrics struct {
+	Total       int
+	Successful  int
+	Retried     int
+	AvgDuration sql.NullFloat64
+}
+
+// AggregateSessionMetrics returns the counts/averages used by the audit API's
+// /api/v1/metrics endpoint.
+func (s *Store) AggregateSessionMetrics() (SessionAggregateMetrics, error) {
+	var m SessionAggregateMetrics
+	var successful, retried sql.NullInt64
+	err := s.db.QueryRow(
+		`SELECT
+			 COUNT(*),
+			 SUM(CASE WHEN COALESCE(t.status, s.status) = ? THEN 1 ELSE 0 END),
+			 AVG(CASE
+				 WHEN s.closed_at IS NOT NULL THEN (julianday(s.closed_at) - julianday(s.created_at)) * 86400.0
+				 ELSE NULL
+			 END),
+			 SUM(CASE WHEN s.attempt > 1 THEN 1 ELSE 0 END)
+		 FROM sessions s
+		 LEFT JOIN task_queue t ON t.id = s.task_id
+		 WHERE COALESCE(t.status, s.status) IN (?, ?, ?)`,
+		TaskStatusCompleted,
+		TaskStatusCompleted, TaskStatusFailed, TaskStatusTimeout,
+	).Scan(&m.Total, &successful, &m.AvgDuration, &retried)
+	if err != nil {
+		return m, fmt.Errorf("store: aggregate session metrics: %w", err)
+	}
+	if successful.Valid {
+		m.Successful = int(successful.Int64)
+	}
+	if retried.Valid {
+		m.Retried = int(retried.Int64)
+	}
+	return m, nil
+}
+
+// SessionCountByAgent is one row of the per-agent session count aggregation.
+type SessionCountByAgent struct {
+	AgentName string
+	Count     int
+}
+
+// CountSessionsByAgent returns per-agent session counts ordered by agent name.
+func (s *Store) CountSessionsByAgent() ([]SessionCountByAgent, error) {
+	rows, err := s.db.Query(`SELECT agent_name, COUNT(*) FROM sessions GROUP BY agent_name ORDER BY agent_name`)
+	if err != nil {
+		return nil, fmt.Errorf("store: sessions by agent: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []SessionCountByAgent
+	for rows.Next() {
+		var r SessionCountByAgent
+		if err := rows.Scan(&r.AgentName, &r.Count); err != nil {
+			return nil, fmt.Errorf("store: scan session by agent: %w", err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// ---------------------------------------------------------------------------
+// Workflow (workflow.Manager)
+// ---------------------------------------------------------------------------
+
+// WorkflowInstanceRow is the raw workflow_instances row returned to the
+// workflow package. Keeping it string-typed for timestamps lets workflow
+// parse them with its own helpers and keeps store.go time-format agnostic.
+type WorkflowInstanceRow struct {
+	ID           string
+	WorkflowName string
+	Repo         string
+	IssueNum     int
+	CurrentState string
+	CreatedAt    string
+	UpdatedAt    string
+}
+
+// WorkflowTransitionRow is the raw workflow_transitions row.
+type WorkflowTransitionRow struct {
+	FromState    string
+	ToState      string
+	TriggerAgent string
+	CreatedAt    string
+}
+
+// ErrWorkflowInstanceNotFound is returned when UpdateWorkflowInstanceState
+// fails to match an existing instance.
+var ErrWorkflowInstanceNotFound = fmt.Errorf("workflow instance not found")
+
+// CreateWorkflowInstanceIfMissing inserts a new workflow_instances row if it
+// does not already exist.
+func (s *Store) CreateWorkflowInstanceIfMissing(id, workflowName, repo string, issueNum int, currentState string) error {
+	_, err := s.db.Exec(
+		`INSERT INTO workflow_instances (id, workflow_name, repo, issue_num, current_state)
+		 VALUES (?, ?, ?, ?, ?) ON CONFLICT (repo, issue_num, workflow_name) DO NOTHING`,
+		id, workflowName, repo, issueNum, currentState,
+	)
+	if err != nil {
+		return fmt.Errorf("store: create workflow instance: %w", err)
+	}
+	return nil
+}
+
+// AdvanceWorkflowInstance writes a new transition and updates CurrentState in
+// a single transaction. Returns ErrWorkflowInstanceNotFound if no row matched.
+func (s *Store) AdvanceWorkflowInstance(id, fromState, toState, triggerAgent string, at time.Time) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("store: begin advance workflow: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	ts := at.UTC().Format(time.RFC3339)
+	if _, err := tx.Exec(
+		`INSERT INTO workflow_transitions (workflow_instance_id, from_state, to_state, trigger_agent, created_at)
+		 VALUES (?, ?, ?, ?, ?)`,
+		id, fromState, toState, triggerAgent, ts,
+	); err != nil {
+		return fmt.Errorf("store: insert workflow transition: %w", err)
+	}
+
+	result, err := tx.Exec(
+		`UPDATE workflow_instances SET current_state = ?, updated_at = ? WHERE id = ?`,
+		toState, ts, id,
+	)
+	if err != nil {
+		return fmt.Errorf("store: update workflow instance: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("store: workflow rows affected: %w", err)
+	}
+	if rows == 0 {
+		return ErrWorkflowInstanceNotFound
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("store: commit advance workflow: %w", err)
+	}
+	return nil
+}
+
+// QueryWorkflowInstancesByRepoIssue returns all workflow_instances rows for
+// one issue ordered by creation time.
+func (s *Store) QueryWorkflowInstancesByRepoIssue(repo string, issueNum int) ([]WorkflowInstanceRow, error) {
+	rows, err := s.db.Query(
+		`SELECT id, workflow_name, repo, issue_num, current_state, created_at, updated_at
+		 FROM workflow_instances
+		 WHERE repo = ? AND issue_num = ?
+		 ORDER BY created_at, id`,
+		repo, issueNum,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("store: query workflow instances: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []WorkflowInstanceRow
+	for rows.Next() {
+		var r WorkflowInstanceRow
+		if err := rows.Scan(&r.ID, &r.WorkflowName, &r.Repo, &r.IssueNum, &r.CurrentState, &r.CreatedAt, &r.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("store: scan workflow instance: %w", err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// GetWorkflowInstanceByID loads a single workflow_instances row.
+func (s *Store) GetWorkflowInstanceByID(id string) (*WorkflowInstanceRow, error) {
+	row := s.db.QueryRow(
+		`SELECT id, workflow_name, repo, issue_num, current_state, created_at, updated_at
+		 FROM workflow_instances
+		 WHERE id = ?`,
+		id,
+	)
+	var r WorkflowInstanceRow
+	err := row.Scan(&r.ID, &r.WorkflowName, &r.Repo, &r.IssueNum, &r.CurrentState, &r.CreatedAt, &r.UpdatedAt)
+	if err == sql.ErrNoRows {
+		return nil, ErrWorkflowInstanceNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("store: get workflow instance: %w", err)
+	}
+	return &r, nil
+}
+
+// QueryWorkflowTransitions returns the ordered transition history for an
+// instance.
+func (s *Store) QueryWorkflowTransitions(instanceID string) ([]WorkflowTransitionRow, error) {
+	rows, err := s.db.Query(
+		`SELECT from_state, to_state, trigger_agent, created_at
+		 FROM workflow_transitions
+		 WHERE workflow_instance_id = ?
+		 ORDER BY created_at ASC, id ASC`,
+		instanceID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("store: query workflow transitions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make([]WorkflowTransitionRow, 0)
+	for rows.Next() {
+		var r WorkflowTransitionRow
+		if err := rows.Scan(&r.FromState, &r.ToState, &r.TriggerAgent, &r.CreatedAt); err != nil {
+			return nil, fmt.Errorf("store: scan workflow transition: %w", err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}

--- a/internal/store/queries_test.go
+++ b/internal/store/queries_test.go
@@ -1,0 +1,234 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+// TestQueryEventsFiltered exercises the new narrow event query used by
+// eventlog.EventLogger.Query.
+func TestQueryEventsFiltered(t *testing.T) {
+	s := newTestStore(t)
+
+	mustInsertEvent(t, s, Event{Type: "poll", Repo: "org/a", IssueNum: 1, Payload: `{}`})
+	mustInsertEvent(t, s, Event{Type: "dispatch", Repo: "org/a", IssueNum: 1, Payload: `{}`})
+	mustInsertEvent(t, s, Event{Type: "poll", Repo: "org/b", IssueNum: 2, Payload: `{}`})
+
+	all, err := s.QueryEventsFiltered(EventQueryFilter{})
+	if err != nil {
+		t.Fatalf("QueryEventsFiltered all: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(all))
+	}
+
+	repoA, err := s.QueryEventsFiltered(EventQueryFilter{Repo: "org/a"})
+	if err != nil {
+		t.Fatalf("QueryEventsFiltered repoA: %v", err)
+	}
+	if len(repoA) != 2 {
+		t.Fatalf("expected 2 events for org/a, got %d", len(repoA))
+	}
+
+	poll, err := s.QueryEventsFiltered(EventQueryFilter{Type: "poll"})
+	if err != nil {
+		t.Fatalf("QueryEventsFiltered type: %v", err)
+	}
+	if len(poll) != 2 {
+		t.Fatalf("expected 2 poll events, got %d", len(poll))
+	}
+
+	issue1, err := s.QueryEventsFiltered(EventQueryFilter{IssueNum: 1})
+	if err != nil {
+		t.Fatalf("QueryEventsFiltered issue: %v", err)
+	}
+	if len(issue1) != 2 {
+		t.Fatalf("expected 2 events for issue 1, got %d", len(issue1))
+	}
+}
+
+// TestLatestEventAt exercises the helper used by audit.HTTPHandler.
+func TestLatestEventAt(t *testing.T) {
+	s := newTestStore(t)
+
+	ts, err := s.LatestEventAt("org/a", 1)
+	if err != nil {
+		t.Fatalf("LatestEventAt missing: %v", err)
+	}
+	if ts != nil {
+		t.Fatalf("expected nil timestamp, got %v", ts)
+	}
+
+	mustInsertEvent(t, s, Event{Type: "poll", Repo: "org/a", IssueNum: 1, Payload: `{}`})
+	ts, err = s.LatestEventAt("org/a", 1)
+	if err != nil {
+		t.Fatalf("LatestEventAt present: %v", err)
+	}
+	if ts == nil {
+		t.Fatal("expected non-nil timestamp")
+	}
+}
+
+// TestMetricsAggregates exercises the aggregate query methods consumed by
+// internal/metrics.
+func TestMetricsAggregates(t *testing.T) {
+	s := newTestStore(t)
+	mustInsertEvent(t, s, Event{Type: "poll", Repo: "org/a", IssueNum: 1, Payload: `{}`})
+	mustInsertEvent(t, s, Event{Type: "poll", Repo: "org/a", IssueNum: 2, Payload: `{}`})
+	mustInsertEvent(t, s, Event{Type: "dispatch", Repo: "org/b", IssueNum: 3, Payload: `{}`})
+	mustInsertEvent(t, s, Event{Type: "token_usage", Repo: "org/a", IssueNum: 1, Payload: `{"input":10,"output":5,"total":15}`})
+
+	events, err := s.CountEventsByRepoType()
+	if err != nil {
+		t.Fatalf("CountEventsByRepoType: %v", err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("expected 3 (repo,type) groups, got %d", len(events))
+	}
+
+	tokens, err := s.TokenUsageEvents("token_usage")
+	if err != nil {
+		t.Fatalf("TokenUsageEvents: %v", err)
+	}
+	if len(tokens) != 1 || tokens[0].Repo != "org/a" {
+		t.Fatalf("unexpected token events: %+v", tokens)
+	}
+
+	tasks, err := s.CountTasksByRepoStatus()
+	if err != nil {
+		t.Fatalf("CountTasksByRepoStatus: %v", err)
+	}
+	// No tasks inserted: empty aggregate is fine.
+	_ = tasks
+
+	workers, err := s.CountWorkersByRepo()
+	if err != nil {
+		t.Fatalf("CountWorkersByRepo: %v", err)
+	}
+	_ = workers
+
+	maxCounts, err := s.MaxTransitionCounts()
+	if err != nil {
+		t.Fatalf("MaxTransitionCounts: %v", err)
+	}
+	_ = maxCounts
+
+	open, err := s.ListOpenIssueActivity(TaskStatusPending, TaskStatusRunning)
+	if err != nil {
+		t.Fatalf("ListOpenIssueActivity: %v", err)
+	}
+	_ = open
+}
+
+// TestAuditAPIQueries exercises the auditapi-oriented query methods.
+func TestAuditAPIQueries(t *testing.T) {
+	s := newTestStore(t)
+
+	active, err := s.CountActiveSessions()
+	if err != nil {
+		t.Fatalf("CountActiveSessions: %v", err)
+	}
+	if active != 0 {
+		t.Fatalf("expected 0 active sessions, got %d", active)
+	}
+
+	workers, err := s.CountWorkers()
+	if err != nil {
+		t.Fatalf("CountWorkers: %v", err)
+	}
+	if workers != 0 {
+		t.Fatalf("expected 0 workers, got %d", workers)
+	}
+
+	ts, err := s.LastEventTimestampByType("poll")
+	if err != nil {
+		t.Fatalf("LastEventTimestampByType missing: %v", err)
+	}
+	if ts != nil {
+		t.Fatalf("expected nil ts, got %v", ts)
+	}
+	mustInsertEvent(t, s, Event{Type: "poll", Repo: "org/a", IssueNum: 1, Payload: `{}`})
+	ts, err = s.LastEventTimestampByType("poll")
+	if err != nil {
+		t.Fatalf("LastEventTimestampByType present: %v", err)
+	}
+	if ts == nil {
+		t.Fatal("expected non-nil ts")
+	}
+
+	sessions, err := s.ListSessionsForAPI(SessionListFilter{Limit: 10, Offset: 0})
+	if err != nil {
+		t.Fatalf("ListSessionsForAPI: %v", err)
+	}
+	_ = sessions
+
+	agg, err := s.AggregateSessionMetrics()
+	if err != nil {
+		t.Fatalf("AggregateSessionMetrics: %v", err)
+	}
+	if agg.Total != 0 {
+		t.Fatalf("expected 0 sessions, got %d", agg.Total)
+	}
+
+	perAgent, err := s.CountSessionsByAgent()
+	if err != nil {
+		t.Fatalf("CountSessionsByAgent: %v", err)
+	}
+	if len(perAgent) != 0 {
+		t.Fatalf("expected 0 agents, got %d", len(perAgent))
+	}
+}
+
+// TestWorkflowRepositoryMethods exercises the workflow-oriented methods used
+// by workflow.Manager.
+func TestWorkflowRepositoryMethods(t *testing.T) {
+	s := newTestStore(t)
+	id := "org/a#7#default"
+	if err := s.CreateWorkflowInstanceIfMissing(id, "default", "org/a", 7, "triage"); err != nil {
+		t.Fatalf("CreateWorkflowInstanceIfMissing: %v", err)
+	}
+	// Idempotent: second call should not error.
+	if err := s.CreateWorkflowInstanceIfMissing(id, "default", "org/a", 7, "triage"); err != nil {
+		t.Fatalf("CreateWorkflowInstanceIfMissing (repeat): %v", err)
+	}
+
+	if err := s.AdvanceWorkflowInstance(id, "triage", "developing", "dev", time.Now()); err != nil {
+		t.Fatalf("AdvanceWorkflowInstance: %v", err)
+	}
+
+	row, err := s.GetWorkflowInstanceByID(id)
+	if err != nil {
+		t.Fatalf("GetWorkflowInstanceByID: %v", err)
+	}
+	if row.CurrentState != "developing" {
+		t.Fatalf("expected developing, got %q", row.CurrentState)
+	}
+
+	instances, err := s.QueryWorkflowInstancesByRepoIssue("org/a", 7)
+	if err != nil {
+		t.Fatalf("QueryWorkflowInstancesByRepoIssue: %v", err)
+	}
+	if len(instances) != 1 {
+		t.Fatalf("expected 1 instance, got %d", len(instances))
+	}
+
+	transitions, err := s.QueryWorkflowTransitions(id)
+	if err != nil {
+		t.Fatalf("QueryWorkflowTransitions: %v", err)
+	}
+	if len(transitions) != 1 || transitions[0].ToState != "developing" {
+		t.Fatalf("unexpected transitions: %+v", transitions)
+	}
+
+	err = s.AdvanceWorkflowInstance("does/not#1#exist", "a", "b", "agent", time.Now())
+	if err == nil {
+		t.Fatal("expected ErrWorkflowInstanceNotFound, got nil")
+	}
+}
+
+func mustInsertEvent(t *testing.T, s *Store, e Event) {
+	t.Helper()
+	if _, err := s.InsertEvent(e); err != nil {
+		t.Fatalf("InsertEvent: %v", err)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -104,6 +104,11 @@ func (s *Store) Close() error {
 }
 
 // DB returns the underlying *sql.DB for advanced use cases.
+//
+// Deprecated: Prefer the typed methods on Store (or define a new narrow
+// repository method here) instead of issuing raw SQL through this handle.
+// Direct access couples callers to storage internals and was the cause of
+// issue #145 finding #9. Remaining callers are tracked by TODO(#145-9).
 func (s *Store) DB() *sql.DB {
 	return s.db
 }

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -2,7 +2,6 @@
 package workflow
 
 import (
-	"database/sql"
 	"errors"
 	"fmt"
 	"time"
@@ -33,14 +32,27 @@ type WorkflowInstance struct {
 // ErrWorkflowInstanceNotFound is returned when requested instance rows do not exist.
 var ErrWorkflowInstanceNotFound = errors.New("workflow instance not found")
 
-// Manager provides CRUD operations for workflow instances and transitions.
-type Manager struct {
-	db *sql.DB
+// Repository is the narrow persistence surface required by Manager. It is
+// satisfied by *store.Store and is defined here so workflow.Manager does not
+// have to reach through to a raw *sql.DB.
+type Repository interface {
+	CreateWorkflowInstanceIfMissing(id, workflowName, repo string, issueNum int, currentState string) error
+	AdvanceWorkflowInstance(id, fromState, toState, triggerAgent string, at time.Time) error
+	QueryWorkflowInstancesByRepoIssue(repo string, issueNum int) ([]store.WorkflowInstanceRow, error)
+	GetWorkflowInstanceByID(id string) (*store.WorkflowInstanceRow, error)
+	QueryWorkflowTransitions(instanceID string) ([]store.WorkflowTransitionRow, error)
 }
 
-// NewManager creates a workflow manager using an existing SQLite connection.
-func NewManager(db *sql.DB) *Manager {
-	return &Manager{db: db}
+// Manager provides CRUD operations for workflow instances and transitions.
+type Manager struct {
+	repo Repository
+}
+
+// NewManager creates a workflow manager bound to the given store-backed
+// repository. Passing nil is permitted but every subsequent call will return
+// "workflow manager not initialized".
+func NewManager(repo Repository) *Manager {
+	return &Manager{repo: repo}
 }
 
 // CreateIfMissing creates a WorkflowInstance if one does not exist.
@@ -48,17 +60,11 @@ func NewManager(db *sql.DB) *Manager {
 func (m *Manager) CreateIfMissing(
 	repo string, issueNum int, workflowName, currentState string,
 ) error {
-	if m == nil || m.db == nil {
+	if m == nil || m.repo == nil {
 		return errors.New("workflow manager not initialized")
 	}
 	id := makeInstanceID(repo, issueNum, workflowName)
-
-	_, err := m.db.Exec(
-		`INSERT INTO workflow_instances (id, workflow_name, repo, issue_num, current_state)
-		 VALUES (?, ?, ?, ?, ?) ON CONFLICT (repo, issue_num, workflow_name) DO NOTHING`,
-		id, workflowName, repo, issueNum, currentState,
-	)
-	if err != nil {
+	if err := m.repo.CreateWorkflowInstanceIfMissing(id, workflowName, repo, issueNum, currentState); err != nil {
 		return fmt.Errorf("create workflow instance: %w", err)
 	}
 	return nil
@@ -66,158 +72,90 @@ func (m *Manager) CreateIfMissing(
 
 // Advance writes a new transition and updates CurrentState atomically.
 func (m *Manager) Advance(repo string, issueNum int, workflowName, fromState, toState, triggerAgent string) error {
-	if m == nil || m.db == nil {
+	if m == nil || m.repo == nil {
 		return errors.New("workflow manager not initialized")
 	}
 	id := makeInstanceID(repo, issueNum, workflowName)
-
-	tx, err := m.db.Begin()
-	if err != nil {
-		return fmt.Errorf("begin advance tx: %w", err)
-	}
-	defer func() {
-		_ = tx.Rollback()
-	}()
-
-	now := time.Now().UTC()
-	if _, err := tx.Exec(
-		`INSERT INTO workflow_transitions (workflow_instance_id, from_state, to_state, trigger_agent, created_at)
-		 VALUES (?, ?, ?, ?, ?)`,
-		id, fromState, toState, triggerAgent, now.Format(time.RFC3339),
-	); err != nil {
-		return fmt.Errorf("insert transition: %w", err)
-	}
-
-	result, err := tx.Exec(
-		`UPDATE workflow_instances
-			SET current_state = ?, updated_at = ?
-			WHERE id = ?`,
-		toState, now.Format(time.RFC3339), id,
-	)
-	if err != nil {
-		return fmt.Errorf("update workflow instance state: %w", err)
-	}
-	rows, err := result.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("rows affected: %w", err)
-	}
-	if rows == 0 {
+	err := m.repo.AdvanceWorkflowInstance(id, fromState, toState, triggerAgent, time.Now().UTC())
+	if errors.Is(err, store.ErrWorkflowInstanceNotFound) {
 		return ErrWorkflowInstanceNotFound
 	}
-
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit advance tx: %w", err)
+	if err != nil {
+		return fmt.Errorf("advance workflow instance: %w", err)
 	}
 	return nil
 }
 
 // QueryByRepoIssue returns all workflow instances for one issue with history.
 func (m *Manager) QueryByRepoIssue(repo string, issueNum int) ([]WorkflowInstance, error) {
-	if m == nil || m.db == nil {
+	if m == nil || m.repo == nil {
 		return nil, errors.New("workflow manager not initialized")
 	}
-	rows, err := m.db.Query(
-		`SELECT id, workflow_name, repo, issue_num, current_state, created_at, updated_at
-		 FROM workflow_instances
-		 WHERE repo = ? AND issue_num = ?
-		 ORDER BY created_at, id`,
-		repo, issueNum,
-	)
+	rows, err := m.repo.QueryWorkflowInstancesByRepoIssue(repo, issueNum)
 	if err != nil {
 		return nil, fmt.Errorf("query workflow instances: %w", err)
 	}
-	defer func() { _ = rows.Close() }()
-
-	var out []WorkflowInstance
-	for rows.Next() {
-		inst := WorkflowInstance{}
-		var createdAtStr, updatedAtStr string
-		if err := rows.Scan(
-			&inst.ID, &inst.WorkflowName, &inst.Repo, &inst.IssueNum, &inst.CurrentState,
-			&createdAtStr, &updatedAtStr,
-		); err != nil {
-			return nil, fmt.Errorf("scan workflow instance: %w", err)
-		}
-		inst.CreatedAt, _ = store.ParseTimestamp(createdAtStr, "workflow.created_at")
-		inst.UpdatedAt, _ = store.ParseTimestamp(updatedAtStr, "workflow.updated_at")
-		inst.History, err = m.queryHistory(inst.ID)
+	out := make([]WorkflowInstance, 0, len(rows))
+	for _, r := range rows {
+		inst := instanceFromRow(r)
+		inst.History, err = m.loadHistory(inst.ID)
 		if err != nil {
 			return nil, err
 		}
 		out = append(out, inst)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate workflow instances: %w", err)
 	}
 	return out, nil
 }
 
 // GetByID loads one WorkflowInstance and its transitions by ID.
 func (m *Manager) GetByID(id string) (*WorkflowInstance, error) {
-	if m == nil || m.db == nil {
+	if m == nil || m.repo == nil {
 		return nil, errors.New("workflow manager not initialized")
 	}
-	row := m.db.QueryRow(
-		`SELECT id, workflow_name, repo, issue_num, current_state, created_at, updated_at
-		 FROM workflow_instances
-		 WHERE id = ?`,
-		id,
-	)
-	record, err := scanInstance(row.Scan)
-	if err == sql.ErrNoRows {
+	row, err := m.repo.GetWorkflowInstanceByID(id)
+	if errors.Is(err, store.ErrWorkflowInstanceNotFound) {
 		return nil, ErrWorkflowInstanceNotFound
 	}
 	if err != nil {
 		return nil, fmt.Errorf("query workflow instance by id: %w", err)
 	}
-	record.History, err = m.queryHistory(record.ID)
+	inst := instanceFromRow(*row)
+	inst.History, err = m.loadHistory(inst.ID)
 	if err != nil {
 		return nil, err
 	}
-	return record, nil
+	return &inst, nil
 }
 
-func (m *Manager) queryHistory(instanceID string) ([]StateTransition, error) {
-	rows, err := m.db.Query(
-		`SELECT from_state, to_state, trigger_agent, created_at
-		 FROM workflow_transitions
-		 WHERE workflow_instance_id = ?
-		 ORDER BY created_at ASC, id ASC`,
-		instanceID,
-	)
+func (m *Manager) loadHistory(instanceID string) ([]StateTransition, error) {
+	rows, err := m.repo.QueryWorkflowTransitions(instanceID)
 	if err != nil {
 		return nil, fmt.Errorf("query workflow transitions: %w", err)
 	}
-	defer func() { _ = rows.Close() }()
-
-	history := make([]StateTransition, 0)
-	for rows.Next() {
-		var tr StateTransition
-		var ts string
-		if err := rows.Scan(&tr.From, &tr.To, &tr.TriggerAgent, &ts); err != nil {
-			return nil, fmt.Errorf("scan workflow transition: %w", err)
-		}
-		tr.Timestamp, _ = store.ParseTimestamp(ts, "workflow_transition.created_at")
-		history = append(history, tr)
+	out := make([]StateTransition, 0, len(rows))
+	for _, r := range rows {
+		ts, _ := store.ParseTimestamp(r.CreatedAt, "workflow_transition.created_at")
+		out = append(out, StateTransition{
+			From:         r.FromState,
+			To:           r.ToState,
+			Timestamp:    ts,
+			TriggerAgent: r.TriggerAgent,
+		})
 	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate workflow transitions: %w", err)
-	}
-	return history, nil
+	return out, nil
 }
 
-func scanInstance(scan func(dest ...any) error) (*WorkflowInstance, error) {
-	record := &WorkflowInstance{}
-	var createdAtStr, updatedAtStr string
-	if err := scan(
-		&record.ID, &record.WorkflowName, &record.Repo, &record.IssueNum,
-		&record.CurrentState, &createdAtStr, &updatedAtStr,
-	); err != nil {
-		return nil, err
+func instanceFromRow(r store.WorkflowInstanceRow) WorkflowInstance {
+	inst := WorkflowInstance{
+		ID:           r.ID,
+		WorkflowName: r.WorkflowName,
+		Repo:         r.Repo,
+		IssueNum:     r.IssueNum,
+		CurrentState: r.CurrentState,
 	}
-	record.CreatedAt, _ = store.ParseTimestamp(createdAtStr, "workflow.created_at")
-	record.UpdatedAt, _ = store.ParseTimestamp(updatedAtStr, "workflow.updated_at")
-	return record, nil
+	inst.CreatedAt, _ = store.ParseTimestamp(r.CreatedAt, "workflow.created_at")
+	inst.UpdatedAt, _ = store.ParseTimestamp(r.UpdatedAt, "workflow.updated_at")
+	return inst
 }
 
 func makeInstanceID(repo string, issueNum int, workflowName string) string {

--- a/internal/workflow/workflow_test.go
+++ b/internal/workflow/workflow_test.go
@@ -15,7 +15,7 @@ func newTestManager(t *testing.T) *Manager {
 		t.Fatalf("NewStore: %v", err)
 	}
 	t.Cleanup(func() { _ = st.Close() })
-	return NewManager(st.DB())
+	return NewManager(st)
 }
 
 func TestCreateWorkflowInstance(t *testing.T) {

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -632,8 +632,10 @@ requirements:
     code:
       - internal/eventlog/eventlog.go
       - internal/metrics/handler.go
+      - internal/store/queries.go
     tests:
       - internal/eventlog/eventlog_test.go
+      - internal/store/queries_test.go
     deps: [REQ-024]
 
   - id: REQ-010


### PR DESCRIPTION
## Summary

Fixes issue #145 finding #9: `internal/store.Store` was a god-package that
exposed `DB() *sql.DB`, forcing orchestration/metrics/audit/workflow layers
to reach through and issue raw SQL against storage internals.

Each consumer now gets a small, role-named surface. Raw `*sql.DB` never
leaves the `store` package on the production path.

### Consumer → new surface

| Old call (`st.DB()` usage)                                      | Replacement                                       |
|-----------------------------------------------------------------|---------------------------------------------------|
| `internal/statemachine/statemachine.go` → `workflow.NewManager(st.DB())` | `workflow.NewManager(st)` via `workflow.Repository` interface |
| `internal/workflow/workflow.go` (all internal SQL)              | `store.{Create,Advance,Query...}WorkflowInstance*` typed methods |
| `internal/metrics/handler.go` (6 raw aggregates)                | `metrics.Source` interface → `store.{CountEventsByRepoType, TokenUsageEvents, CountTasksByRepoStatus, CountWorkersByRepo, MaxTransitionCounts, ListOpenIssueActivity}` |
| `internal/eventlog/eventlog.go` Query (dynamic filter)          | `store.QueryEventsFiltered(EventQueryFilter)` |
| `internal/auditapi/handler.go` queryStatus (3 raw queries)      | `store.{CountActiveSessions, CountWorkers, LastEventTimestampByType}` |
| `internal/auditapi/handler.go` listSessions                     | `store.ListSessionsForAPI(SessionListFilter)` |
| `internal/auditapi/handler.go` queryMetrics (2 raw queries)     | `store.{AggregateSessionMetrics, CountSessionsByAgent}` |
| `internal/audit/http.go` latestIssueEvent                       | `store.LatestEventAt(repo, issueNum)` |

All new store methods are purpose-built; there is no "one big StorageInterface"
that would just relocate the god-package.

### TODO(#145-9) — scope-cut

`Store.DB()` is retained and marked `// Deprecated:`. The following call
sites still touch it, all in **test-only fixture code** — migrating them
requires adding 6-8 narrow test helpers that only exist to let tests forge
stale timestamps. Left for a follow-up to keep this PR focused on the
production coupling:

- `internal/metrics/handler_test.go` (2 uses — UPDATE events.ts for stale tests)
- `internal/auditapi/handler_test.go` (1 use — UPDATE task_queue.completed_at)
- `internal/statemachine/statemachine_test.go` (1 use — UPDATE issue_claim)
- `internal/operator/detector.go`/`_test.go` (non-listed package, 2 prod + 6 test)
- `internal/registry/registry.go`/`_test.go` (non-listed package, 2)
- `cmd/status_test.go`, `cmd/coordinator_audit_test.go`, `internal/recover/recover_test.go`,
  `internal/diagnose/diagnose_test.go`, `internal/workflow/workflow_test.go` (test fixtures)
- `internal/store/store_test.go` (own-package, legitimate)

Line drawn at: remove `DB()` from the production code path of every
consumer listed in the issue audit. Test fixtures and non-listed packages
(`operator`, `registry`) are a separate follow-up because each one needs
its own small typed helper and extending this PR another 200+ lines would
stop being a focused fix.

### Tests

Added `internal/store/queries_test.go` with happy-path coverage for every
new method. Pre-existing consumer tests (metrics, auditapi, audit, workflow,
statemachine, eventlog) exercise the integration. `go build`, `go vet`, and
`go test ./... -count=1` all green.

One latent bug surfaced by the new empty-DB test and fixed inline:
`AggregateSessionMetrics` had to use `sql.NullInt64` for `SUM(...)` columns
because SQLite returns NULL over an empty result set (the old raw-SQL path
was only ever hit in tests that pre-populated sessions).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1`
- [x] `python3 ~/.autoharness/scripts/validate_index.py project-index.yaml`
- [x] Grep `st.DB()` in the listed consumer production files returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)