### PR TITLE
refactor(router): split scheduling from task materialization (#145)

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -349,7 +349,9 @@ func runServeWithOpts(opts *serveOpts, ghReader poller.GHReader, launcherOverrid
 	rep.SetBaseURL(fmt.Sprintf("http://localhost:%d", cfg.Global.Port))
 	rep.SetEventRecorder(recorder)
 	rep.SetVerifier(reporter.NewGHClaimVerifier())
-	rt.SetReporter(rep)
+	// Note: router no longer holds a Reporter — worktree-failure reporting
+	// now lives on the worker side (see internal/worker/executor.go). The
+	// reporter wired above is used by the poller/worker paths.
 
 	// Poller
 	p := poller.NewPoller(ghReader, st, cfg.Global.Repo, cfg.Global.PollInterval)

--- a/internal/dependency/gate.go
+++ b/internal/dependency/gate.go
@@ -1,0 +1,39 @@
+package dependency
+
+import (
+	"fmt"
+
+	"github.com/Lincyaw/workbuddy/internal/store"
+)
+
+// GateStore is the narrow store surface needed to evaluate a dispatch gate.
+type GateStore interface {
+	QueryIssueDependencyState(repo string, issueNum int) (*store.IssueDependencyState, error)
+}
+
+// IsBlocked reports whether dispatch for (repo, issueNum) is currently
+// blocked by its recorded dependency verdict. A verdict of "blocked" or
+// "needs_human" gates the dispatch; anything else (ready/override, or no
+// recorded state yet) permits it.
+//
+// This mirrors the policy previously inlined in internal/router/router.go so
+// the scheduling layer no longer reaches into store verdict semantics
+// directly.
+func IsBlocked(st GateStore, repo string, issueNum int) (bool, error) {
+	if st == nil {
+		return false, nil
+	}
+	depState, err := st.QueryIssueDependencyState(repo, issueNum)
+	if err != nil {
+		return false, fmt.Errorf("query dependency state for %s#%d: %w", repo, issueNum, err)
+	}
+	if depState == nil {
+		return false, nil
+	}
+	switch depState.Verdict {
+	case store.DependencyVerdictBlocked, store.DependencyVerdictNeedsHuman:
+		return true, nil
+	default:
+		return false, nil
+	}
+}

--- a/internal/dependency/gate_test.go
+++ b/internal/dependency/gate_test.go
@@ -1,0 +1,77 @@
+package dependency
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Lincyaw/workbuddy/internal/store"
+)
+
+type stubGateStore struct {
+	state *store.IssueDependencyState
+	err   error
+}
+
+func (s stubGateStore) QueryIssueDependencyState(_ string, _ int) (*store.IssueDependencyState, error) {
+	return s.state, s.err
+}
+
+func TestIsBlocked_TreatsBlockedAndNeedsHumanAsGated(t *testing.T) {
+	for _, verdict := range []string{store.DependencyVerdictBlocked, store.DependencyVerdictNeedsHuman} {
+		t.Run(verdict, func(t *testing.T) {
+			st := stubGateStore{state: &store.IssueDependencyState{Verdict: verdict}}
+			blocked, err := IsBlocked(st, "o/r", 1)
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if !blocked {
+				t.Fatalf("verdict %q should gate dispatch", verdict)
+			}
+		})
+	}
+}
+
+func TestIsBlocked_AllowsReadyAndOverride(t *testing.T) {
+	for _, verdict := range []string{store.DependencyVerdictReady, store.DependencyVerdictOverride} {
+		t.Run(verdict, func(t *testing.T) {
+			st := stubGateStore{state: &store.IssueDependencyState{Verdict: verdict}}
+			blocked, err := IsBlocked(st, "o/r", 1)
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if blocked {
+				t.Fatalf("verdict %q should permit dispatch", verdict)
+			}
+		})
+	}
+}
+
+func TestIsBlocked_NoStateIsNotBlocked(t *testing.T) {
+	st := stubGateStore{state: nil}
+	blocked, err := IsBlocked(st, "o/r", 1)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if blocked {
+		t.Fatal("missing dependency state should not gate dispatch")
+	}
+}
+
+func TestIsBlocked_NilStoreNotBlocked(t *testing.T) {
+	blocked, err := IsBlocked(nil, "o/r", 1)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if blocked {
+		t.Fatal("nil store should not gate dispatch")
+	}
+}
+
+func TestIsBlocked_WrapsStoreError(t *testing.T) {
+	sentinel := errors.New("boom")
+	st := stubGateStore{err: sentinel}
+	_, err := IsBlocked(st, "o/r", 1)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected wrapped sentinel, got %v", err)
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1,60 +1,78 @@
-// Package router dispatches agent tasks to available workers.
+// Package router makes the scheduling decision for an agent dispatch: given
+// a workflow state and the set of configured agents, which agent should run,
+// and should the task proceed at all (dependency gate)?
+//
+// It intentionally does NOT load GitHub context, persist the task row, or
+// provision worktrees — those responsibilities live in:
+//
+//   - internal/taskprep   — context loading, task persistence, embedded dispatch
+//   - internal/worker     — workspace/worktree provisioning at execute time
+//   - internal/dependency — dependency verdict computation + gating helper
+//
+// See issue #145 finding #8 for the motivation for this split.
 package router
 
 import (
 	"context"
-	"fmt"
 	"log"
-	"os"
-	"strings"
 
 	"github.com/Lincyaw/workbuddy/internal/config"
-	"github.com/Lincyaw/workbuddy/internal/ghadapter"
+	"github.com/Lincyaw/workbuddy/internal/dependency"
 	"github.com/Lincyaw/workbuddy/internal/registry"
-	"github.com/Lincyaw/workbuddy/internal/reporter"
-	runtimepkg "github.com/Lincyaw/workbuddy/internal/runtime"
 	"github.com/Lincyaw/workbuddy/internal/statemachine"
 	"github.com/Lincyaw/workbuddy/internal/store"
-	"github.com/Lincyaw/workbuddy/internal/workspace"
-	"github.com/google/uuid"
+	"github.com/Lincyaw/workbuddy/internal/taskprep"
 )
 
-// WorkerTask is the unit of work sent to an embedded Worker via channel.
-type WorkerTask struct {
-	TaskID       string
-	Repo         string
-	IssueNum     int
-	AgentName    string
-	Agent        *config.AgentConfig
-	Context      *runtimepkg.TaskContext
-	Workflow     string
-	State        string
-	WorktreePath string // path to isolated worktree, empty if isolation disabled
+// WorkerTask is re-exported from internal/taskprep so existing consumers
+// (cmd/serve.go, cmd/coordinator.go, internal/worker/embedded.go, tests)
+// continue to compile against router.WorkerTask. The canonical definition
+// lives on the preparer side because materialising a WorkerTask is the
+// preparer's responsibility.
+type WorkerTask = taskprep.WorkerTask
+
+// IssueDataReader is re-exported from internal/taskprep for the same reason.
+type IssueDataReader = taskprep.IssueDataReader
+
+// Decision is the output of the scheduling layer: "dispatch AgentName for
+// this issue in this workflow state". It is consumed by a Preparer that
+// materialises the task row + GH context.
+type Decision = taskprep.Decision
+
+// Preparer is the contract the Router delegates task materialisation to.
+// The concrete implementation lives in internal/taskprep.
+type Preparer interface {
+	Prepare(ctx context.Context, d Decision) error
 }
 
-type IssueDataReader interface {
-	ReadIssueSummary(repo string, issueNum int) (title, body string, labels []string, err error)
-	ReadIssueComments(repo string, issueNum int) ([]runtimepkg.IssueComment, error)
-	ListRelatedPRs(repo string, issueNum int) ([]runtimepkg.PRSummary, error)
+// readerAwarePreparer is an optional extension implemented by preparers that
+// accept a late IssueDataReader override (taskprep.Preparer does).
+type readerAwarePreparer interface {
+	Preparer
+	SetIssueDataReader(IssueDataReader)
 }
 
-// Router receives DispatchRequests from the StateMachine and routes them
-// to Workers. In v0.1.0 it sends tasks over a Go channel to the embedded Worker.
+// Router consumes DispatchRequests from the StateMachine, applies
+// scheduling policy (agent lookup, dependency gating) and hands the
+// resulting Decision to a Preparer.
+//
+// The registry is kept on the struct for call-site compatibility and for a
+// potential future when scheduling actually selects among multiple workers;
+// today the preparer either dispatches to the single embedded worker or
+// persists the task for a remote worker to claim.
 type Router struct {
-	agents             map[string]*config.AgentConfig
-	registry           *registry.Registry
-	store              *store.Store
-	repo               string
-	repoRoot           string
-	taskChan           chan<- WorkerTask
-	wsMgr              *workspace.Manager // nil = no workspace isolation
-	dispatchToEmbedded bool
-	reporter           *reporter.Reporter
-	gh                 IssueDataReader
+	agents    map[string]*config.AgentConfig
+	registry  *registry.Registry
+	gateStore dependency.GateStore
+	preparer  Preparer
 }
 
-// NewRouter creates a Router for v0.1.0 channel-based dispatch.
-// Pass nil for wsMgr to disable workspace isolation (agents use CWD).
+// NewRouter creates a Router wired for v0.1.0 channel-based dispatch. The
+// call signature matches the pre-split router.NewRouter so existing
+// consumers (cmd/serve.go, cmd/repo_runtime.go) don't have to be rewired.
+//
+// The wsMgr argument is retained for signature compatibility but is unused
+// by the router — workspace provisioning lives on the worker side.
 func NewRouter(
 	agents map[string]*config.AgentConfig,
 	reg *registry.Registry,
@@ -62,37 +80,38 @@ func NewRouter(
 	repo string,
 	repoRoot string,
 	taskChan chan<- WorkerTask,
-	wsMgr *workspace.Manager,
+	wsMgr any,
 	dispatchToEmbedded bool,
 ) *Router {
+	_ = repo // reserved for future multi-repo routing; Decision already carries repo per-dispatch
+	_ = wsMgr
 	return &Router{
-		agents:             agents,
-		registry:           reg,
-		store:              st,
-		repo:               repo,
-		repoRoot:           repoRoot,
-		taskChan:           taskChan,
-		wsMgr:              wsMgr,
-		dispatchToEmbedded: dispatchToEmbedded,
-		gh:                 ghadapter.NewCLI(),
+		agents:    agents,
+		registry:  reg,
+		gateStore: st,
+		preparer:  taskprep.NewPreparer(st, repoRoot, taskChan, dispatchToEmbedded),
 	}
 }
 
-// SetReporter sets the optional reporter used to post worktree failure comments.
-func (r *Router) SetReporter(rep *reporter.Reporter) {
-	r.reporter = rep
-}
-
-// SetIssueDataReader replaces the default GitHub issue-context reader.
+// SetIssueDataReader forwards the reader override to the underlying
+// preparer when it supports that hook. Kept for call-site compatibility
+// with the pre-split API.
 func (r *Router) SetIssueDataReader(reader IssueDataReader) {
-	if reader == nil {
-		r.gh = ghadapter.NewCLI()
-		return
+	if rs, ok := r.preparer.(readerAwarePreparer); ok {
+		rs.SetIssueDataReader(reader)
 	}
-	r.gh = reader
 }
 
-// Run reads from the dispatch channel and routes tasks. Blocks until ctx is cancelled.
+// SetPreparer swaps in an alternative Preparer. Intended for tests and for
+// cmd/* wiring that wants to construct a taskprep.Preparer with custom
+// options.
+func (r *Router) SetPreparer(p Preparer) {
+	if p != nil {
+		r.preparer = p
+	}
+}
+
+// Run consumes dispatch requests until ctx is cancelled.
 func (r *Router) Run(ctx context.Context, dispatchCh <-chan statemachine.DispatchRequest) error {
 	for {
 		select {
@@ -107,145 +126,42 @@ func (r *Router) Run(ctx context.Context, dispatchCh <-chan statemachine.Dispatc
 	}
 }
 
-// handleDispatch processes a single DispatchRequest.
+// handleDispatch applies scheduling policy and hands the decision to the
+// preparer.
 func (r *Router) handleDispatch(ctx context.Context, req statemachine.DispatchRequest) {
+	decision, ok := r.decide(req)
+	if !ok {
+		return
+	}
+	if err := r.preparer.Prepare(ctx, decision); err != nil {
+		log.Printf("[router] prepare failed for %s#%d: %v", req.Repo, req.IssueNum, err)
+	}
+}
+
+// decide is the pure scheduling core: no side effects other than logging.
+// Returns (decision, true) if the dispatch should proceed.
+func (r *Router) decide(req statemachine.DispatchRequest) (Decision, bool) {
 	agent, ok := r.agents[req.AgentName]
 	if !ok {
 		log.Printf("[router] agent %q not found, skipping dispatch for %s#%d", req.AgentName, req.Repo, req.IssueNum)
-		return
+		return Decision{}, false
 	}
-	depState, err := r.store.QueryIssueDependencyState(req.Repo, req.IssueNum)
+	blocked, err := dependency.IsBlocked(r.gateStore, req.Repo, req.IssueNum)
 	if err != nil {
 		log.Printf("[router] failed to query dependency state for %s#%d: %v", req.Repo, req.IssueNum, err)
-		return
+		return Decision{}, false
 	}
-	if depState != nil && (depState.Verdict == store.DependencyVerdictBlocked || depState.Verdict == store.DependencyVerdictNeedsHuman) {
-		log.Printf("[router] blocked dispatch for %s#%d due to dependency verdict %q", req.Repo, req.IssueNum, depState.Verdict)
-		return
+	if blocked {
+		log.Printf("[router] blocked dispatch for %s#%d due to dependency verdict", req.Repo, req.IssueNum)
+		return Decision{}, false
 	}
-
-	taskID := uuid.New().String()
-
-	// Record task in store
-	if err := r.store.InsertTask(store.TaskRecord{
-		ID:        taskID,
+	return Decision{
 		Repo:      req.Repo,
 		IssueNum:  req.IssueNum,
 		AgentName: req.AgentName,
-		Role:      agent.Role,
-		Runtime:   agent.Runtime,
+		Agent:     agent,
 		Workflow:  req.Workflow,
 		State:     req.State,
-		Status:    store.TaskStatusPending,
-	}); err != nil {
-		log.Printf("[router] failed to insert task: %v", err)
-		return
-	}
-
-	if !r.dispatchToEmbedded || r.taskChan == nil {
-		return
-	}
-
-	// Fetch issue details via the shared GitHub adapter for template rendering.
-	issueCtx := runtimepkg.IssueContext{Number: req.IssueNum}
-	if r.gh != nil {
-		if title, body, labels, err := r.gh.ReadIssueSummary(req.Repo, req.IssueNum); err != nil {
-			log.Printf("[router] warning: could not fetch issue details: %v", err)
-		} else {
-			issueCtx.Title = title
-			issueCtx.Body = body
-			issueCtx.Labels = labels
-		}
-		if comments, err := r.gh.ReadIssueComments(req.Repo, req.IssueNum); err != nil {
-			log.Printf("[router] warning: could not fetch issue comments: %v", err)
-		} else {
-			issueCtx.Comments = comments
-			issueCtx.CommentsText = formatComments(comments)
-		}
-	}
-	var relatedPRs []runtimepkg.PRSummary
-	if r.gh != nil {
-		var err error
-		relatedPRs, err = r.gh.ListRelatedPRs(req.Repo, req.IssueNum)
-		if err != nil {
-			log.Printf("[router] warning: could not fetch related PRs: %v", err)
-		}
-	}
-
-	var repoRoot string
-	var workDir string
-	if r.wsMgr == nil {
-		repoRoot = r.repoRoot
-		workDir, _ = os.Getwd()
-	} else {
-		// The worker executor owns worktree setup/cleanup so transport dispatch
-		// only carries the base repo path.
-		repoRoot = r.repoRoot
-		workDir = r.repoRoot
-	}
-
-	taskCtx := &runtimepkg.TaskContext{
-		Issue:          issueCtx,
-		Repo:           req.Repo,
-		RepoRoot:       repoRoot,
-		WorkDir:        workDir,
-		RelatedPRs:     relatedPRs,
-		RelatedPRsText: formatRelatedPRs(relatedPRs),
-		Session: runtimepkg.SessionContext{
-			ID: fmt.Sprintf("session-%s", taskID),
-		},
-	}
-
-	task := WorkerTask{
-		TaskID:       taskID,
-		Repo:         req.Repo,
-		IssueNum:     req.IssueNum,
-		AgentName:    req.AgentName,
-		Agent:        agent,
-		Context:      taskCtx,
-		Workflow:     req.Workflow,
-		State:        req.State,
-	}
-
-	select {
-	case r.taskChan <- task:
-		// Task status is updated to running by the worker when it actually
-		// starts executing, so pending tasks queued in the channel buffer
-		// don't appear as running.
-	case <-ctx.Done():
-		return
-	}
+	}, true
 }
 
-func formatComments(comments []runtimepkg.IssueComment) string {
-	if len(comments) == 0 {
-		return "(no comments)"
-	}
-	var b strings.Builder
-	for i, c := range comments {
-		if i > 0 {
-			b.WriteString("\n---\n")
-		}
-		fmt.Fprintf(&b, "[%s by %s]\n%s", c.CreatedAt, c.Author, c.Body)
-	}
-	return b.String()
-}
-
-func formatRelatedPRs(prs []runtimepkg.PRSummary) string {
-	if len(prs) == 0 {
-		return "(no related PRs)"
-	}
-	var b strings.Builder
-	for i, p := range prs {
-		if i > 0 {
-			b.WriteByte('\n')
-		}
-		draft := ""
-		if p.IsDraft {
-			draft = " [draft]"
-		}
-		fmt.Fprintf(&b, "#%d [%s]%s %s (head: %s, base: %s) - %s",
-			p.Number, p.State, draft, p.Title, p.HeadRefName, p.BaseRefName, p.URL)
-	}
-	return b.String()
-}

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -2,48 +2,27 @@ package router
 
 import (
 	"context"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/Lincyaw/workbuddy/internal/config"
 	"github.com/Lincyaw/workbuddy/internal/registry"
-	"github.com/Lincyaw/workbuddy/internal/reporter"
 	"github.com/Lincyaw/workbuddy/internal/statemachine"
 	"github.com/Lincyaw/workbuddy/internal/store"
-	"github.com/Lincyaw/workbuddy/internal/workspace"
 )
 
-type mockCommentWriter struct {
-	comments []string
+// fakePreparer captures the Decision the Router emits so scheduling
+// behaviour can be asserted in isolation from persistence / GH / dispatch.
+type fakePreparer struct {
+	got  []Decision
+	err  error
+	seen int
 }
 
-func (m *mockCommentWriter) WriteComment(_ string, _ int, body string) error {
-	m.comments = append(m.comments, body)
-	return nil
-}
-
-func setupFakeGHCLI(t *testing.T) {
-	t.Helper()
-	fakeBin := t.TempDir()
-	ghPath := filepath.Join(fakeBin, "gh")
-	script := `#!/bin/sh
-if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
-  echo '{"title":"Issue","body":"body","labels":[{"name":"workbuddy"}],"comments":[]}'
-  exit 0
-fi
-if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
-  echo '[]'
-  exit 0
-fi
-echo '{}'
-`
-	if err := os.WriteFile(ghPath, []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+func (f *fakePreparer) Prepare(_ context.Context, d Decision) error {
+	f.got = append(f.got, d)
+	f.seen++
+	return f.err
 }
 
 func newTestStore(t *testing.T) *store.Store {
@@ -56,15 +35,17 @@ func newTestStore(t *testing.T) *store.Store {
 	return st
 }
 
-func TestRouter_MatchingWorker(t *testing.T) {
+func newSchedulingRouter(t *testing.T, agents map[string]*config.AgentConfig) (*Router, *fakePreparer, *store.Store) {
+	t.Helper()
 	st := newTestStore(t)
 	reg := registry.NewRegistry(st, 30*time.Second)
+	r := NewRouter(agents, reg, st, "test/repo", t.TempDir(), nil, nil, false)
+	fp := &fakePreparer{}
+	r.SetPreparer(fp)
+	return r, fp, st
+}
 
-	// Register a worker
-	if err := reg.Register("worker-1", "test/repo", []string{"dev"}, "localhost"); err != nil {
-		t.Fatal(err)
-	}
-
+func TestRouter_EmitsDecisionForKnownAgent(t *testing.T) {
 	agents := map[string]*config.AgentConfig{
 		"dev-agent": {
 			Name:    "dev-agent",
@@ -74,355 +55,131 @@ func TestRouter_MatchingWorker(t *testing.T) {
 			Timeout: 5 * time.Minute,
 		},
 	}
+	r, fp, _ := newSchedulingRouter(t, agents)
 
-	taskCh := make(chan WorkerTask, 10)
-	r := NewRouter(agents, reg, st, "test/repo", t.TempDir(), taskCh, nil, true)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	dispatchCh := make(chan statemachine.DispatchRequest, 1)
-	dispatchCh <- statemachine.DispatchRequest{
+	r.handleDispatch(context.Background(), statemachine.DispatchRequest{
 		Repo:      "test/repo",
 		IssueNum:  1,
 		AgentName: "dev-agent",
 		Workflow:  "default",
 		State:     "developing",
+	})
+
+	if len(fp.got) != 1 {
+		t.Fatalf("preparer invocations = %d, want 1", len(fp.got))
 	}
-
-	go func() {
-		time.Sleep(5 * time.Second)
-		cancel()
-	}()
-
-	_ = r.Run(ctx, dispatchCh)
-
-	select {
-	case task := <-taskCh:
-		if task.AgentName != "dev-agent" {
-			t.Errorf("expected agent dev-agent, got %s", task.AgentName)
-		}
-		if task.IssueNum != 1 {
-			t.Errorf("expected issue 1, got %d", task.IssueNum)
-		}
-	default:
-		t.Error("expected task on channel, got none")
+	d := fp.got[0]
+	if d.AgentName != "dev-agent" || d.IssueNum != 1 || d.Workflow != "default" || d.State != "developing" {
+		t.Fatalf("unexpected decision: %+v", d)
+	}
+	if d.Agent == nil || d.Agent.Role != "dev" {
+		t.Fatalf("decision Agent not populated: %+v", d.Agent)
 	}
 }
 
-func TestRouter_AgentNotFound(t *testing.T) {
-	st := newTestStore(t)
-	reg := registry.NewRegistry(st, 30*time.Second)
+func TestRouter_SkipsUnknownAgent(t *testing.T) {
+	r, fp, _ := newSchedulingRouter(t, map[string]*config.AgentConfig{})
 
-	agents := map[string]*config.AgentConfig{} // empty
-
-	taskCh := make(chan WorkerTask, 10)
-	r := NewRouter(agents, reg, st, "test/repo", t.TempDir(), taskCh, nil, true)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	dispatchCh := make(chan statemachine.DispatchRequest, 1)
-	dispatchCh <- statemachine.DispatchRequest{
+	r.handleDispatch(context.Background(), statemachine.DispatchRequest{
 		Repo:      "test/repo",
 		IssueNum:  1,
 		AgentName: "nonexistent",
-	}
+	})
 
-	go func() {
-		time.Sleep(100 * time.Millisecond)
-		cancel()
-	}()
-
-	_ = r.Run(ctx, dispatchCh)
-
-	select {
-	case <-taskCh:
-		t.Error("should not have dispatched a task for unknown agent")
-	default:
-		// expected
+	if len(fp.got) != 0 {
+		t.Fatalf("expected no preparer invocation for unknown agent, got %d", len(fp.got))
 	}
 }
 
-func TestRouter_NoMatchingWorker(t *testing.T) {
-	st := newTestStore(t)
-	reg := registry.NewRegistry(st, 30*time.Second)
-	// No workers registered
-
+func TestRouter_BlocksDispatchOnDependencyVerdict(t *testing.T) {
 	agents := map[string]*config.AgentConfig{
-		"dev-agent": {
-			Name:    "dev-agent",
-			Role:    "dev",
-			Runtime: "claude-code",
-			Command: "echo hello",
-		},
+		"dev-agent": {Name: "dev-agent", Role: "dev", Runtime: "claude-code", Command: "echo hello"},
 	}
+	r, fp, st := newSchedulingRouter(t, agents)
 
-	taskCh := make(chan WorkerTask, 10)
-	r := NewRouter(agents, reg, st, "test/repo", t.TempDir(), taskCh, nil, true)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	dispatchCh := make(chan statemachine.DispatchRequest, 1)
-	dispatchCh <- statemachine.DispatchRequest{
-		Repo:      "test/repo",
-		IssueNum:  1,
-		AgentName: "dev-agent",
+	// Seed a blocked verdict for the issue.
+	if err := st.UpsertIssueDependencyState(store.IssueDependencyState{
+		Repo:     "test/repo",
+		IssueNum: 7,
+		Verdict:  store.DependencyVerdictBlocked,
+	}); err != nil {
+		t.Fatalf("UpsertIssueDependencyState: %v", err)
 	}
-
-	go func() {
-		time.Sleep(100 * time.Millisecond)
-		cancel()
-	}()
-
-	_ = r.Run(ctx, dispatchCh)
-
-	// Task should still be created in store as pending, but not dispatched to channel
-	// (since no worker available and the router just inserts + tries to dispatch)
-}
-
-func TestRouter_PersistOnlyModeLeavesTaskPending(t *testing.T) {
-	st := newTestStore(t)
-	reg := registry.NewRegistry(st, 30*time.Second)
-
-	agents := map[string]*config.AgentConfig{
-		"dev-agent": {
-			Name:    "dev-agent",
-			Role:    "dev",
-			Runtime: "codex",
-			Command: "echo hello",
-		},
-	}
-
-	r := NewRouter(agents, reg, st, "test/repo", t.TempDir(), nil, nil, false)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	dispatchCh := make(chan statemachine.DispatchRequest, 1)
-	dispatchCh <- statemachine.DispatchRequest{
-		Repo:      "test/repo",
-		IssueNum:  2,
-		AgentName: "dev-agent",
-		Workflow:  "default",
-		State:     "developing",
-	}
-
-	go func() {
-		time.Sleep(100 * time.Millisecond)
-		cancel()
-	}()
-
-	_ = r.Run(ctx, dispatchCh)
-
-	tasks, err := st.QueryTasks(store.TaskStatusPending)
-	if err != nil {
-		t.Fatalf("QueryTasks: %v", err)
-	}
-	if len(tasks) != 1 {
-		t.Fatalf("pending tasks = %d, want 1", len(tasks))
-	}
-	if tasks[0].Role != "dev" || tasks[0].Runtime != "codex" || tasks[0].Workflow != "default" || tasks[0].State != "developing" {
-		t.Fatalf("unexpected persisted task: %+v", tasks[0])
-	}
-}
-
-func TestRouter_PersistOnlyModeDoesNotCreateWorktree(t *testing.T) {
-	st := newTestStore(t)
-	reg := registry.NewRegistry(st, 30*time.Second)
-	repoRoot := initGitRepo(t)
-	wsMgr := workspace.NewManager(repoRoot)
-
-	agents := map[string]*config.AgentConfig{
-		"dev-agent": {
-			Name:    "dev-agent",
-			Role:    "dev",
-			Runtime: "codex",
-			Command: "echo hello",
-		},
-	}
-
-	r := NewRouter(agents, reg, st, "test/repo", repoRoot, nil, wsMgr, false)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	dispatchCh := make(chan statemachine.DispatchRequest, 1)
-	dispatchCh <- statemachine.DispatchRequest{
-		Repo:      "test/repo",
-		IssueNum:  41,
-		AgentName: "dev-agent",
-		Workflow:  "default",
-		State:     "developing",
-	}
-
-	go func() {
-		time.Sleep(100 * time.Millisecond)
-		cancel()
-	}()
-
-	_ = r.Run(ctx, dispatchCh)
-
-	if _, err := os.Stat(filepath.Join(repoRoot, ".workbuddy", "worktrees", "issue-41")); !os.IsNotExist(err) {
-		t.Fatalf("coordinator mode should not create a worktree, stat err = %v", err)
-	}
-}
-
-func TestRouter_DoesNotEagerlyCreateWorktreeAtDispatch(t *testing.T) {
-	setupFakeGHCLI(t)
-
-	st := newTestStore(t)
-	reg := registry.NewRegistry(st, 30*time.Second)
-	taskCh := make(chan WorkerTask, 1)
-	comments := &mockCommentWriter{}
-	repoRoot := initGitRepo(t)
-	wtPath := filepath.Join(repoRoot, ".workbuddy", "worktrees", "issue-5")
-	if err := os.MkdirAll(filepath.Dir(wtPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll: %v", err)
-	}
-	if err := os.WriteFile(wtPath, []byte("not a worktree"), 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-
-	r := NewRouter(
-		map[string]*config.AgentConfig{
-			"dev-agent": {
-				Name:    "dev-agent",
-				Role:    "dev",
-				Runtime: "claude-code",
-				Command: "echo hello",
-			},
-		},
-		reg,
-		st,
-		"test/repo",
-		repoRoot,
-		taskCh,
-		workspace.NewManager(repoRoot),
-		true,
-	)
-	r.SetReporter(reporter.NewReporter(comments))
 
 	r.handleDispatch(context.Background(), statemachine.DispatchRequest{
 		Repo:      "test/repo",
-		IssueNum:  5,
+		IssueNum:  7,
+		AgentName: "dev-agent",
+	})
+
+	if len(fp.got) != 0 {
+		t.Fatalf("expected no preparer invocation when dep verdict is blocked, got %d", len(fp.got))
+	}
+}
+
+func TestRouter_AllowsDispatchWhenReady(t *testing.T) {
+	agents := map[string]*config.AgentConfig{
+		"dev-agent": {Name: "dev-agent", Role: "dev", Runtime: "claude-code", Command: "echo hello"},
+	}
+	r, fp, st := newSchedulingRouter(t, agents)
+
+	if err := st.UpsertIssueDependencyState(store.IssueDependencyState{
+		Repo:     "test/repo",
+		IssueNum: 8,
+		Verdict:  store.DependencyVerdictReady,
+	}); err != nil {
+		t.Fatalf("UpsertIssueDependencyState: %v", err)
+	}
+
+	r.handleDispatch(context.Background(), statemachine.DispatchRequest{
+		Repo:      "test/repo",
+		IssueNum:  8,
 		AgentName: "dev-agent",
 		Workflow:  "default",
 		State:     "developing",
 	})
 
-	select {
-	case task := <-taskCh:
-		if task.Context == nil {
-			t.Fatal("expected dispatched task context")
-		}
-		if task.Context.RepoRoot != repoRoot {
-			t.Fatalf("RepoRoot = %q, want %q", task.Context.RepoRoot, repoRoot)
-		}
-		if task.Context.WorkDir != repoRoot {
-			t.Fatalf("WorkDir = %q, want %q", task.Context.WorkDir, repoRoot)
-		}
-	default:
-		t.Fatal("expected dispatched task")
-	}
-
-	tasks, err := st.QueryTasks(store.TaskStatusFailed)
-	if err != nil {
-		t.Fatalf("QueryTasks: %v", err)
-	}
-	if len(tasks) != 0 {
-		t.Fatalf("failed tasks = %d, want 0", len(tasks))
-	}
-
-	if len(comments.comments) != 0 {
-		t.Fatalf("comment count = %d, want 0", len(comments.comments))
+	if len(fp.got) != 1 {
+		t.Fatalf("preparer invocations = %d, want 1", len(fp.got))
 	}
 }
 
-func TestRouter_DispatchUsesBaseRepoRootAndWorkDir(t *testing.T) {
-	setupFakeGHCLI(t)
+func TestRouter_RunConsumesDispatchChannel(t *testing.T) {
+	agents := map[string]*config.AgentConfig{
+		"dev-agent": {Name: "dev-agent", Role: "dev", Runtime: "claude-code", Command: "echo"},
+	}
+	r, fp, _ := newSchedulingRouter(t, agents)
 
-	st := newTestStore(t)
-	reg := registry.NewRegistry(st, 30*time.Second)
-	taskCh := make(chan WorkerTask, 1)
-	repoRoot := initGitRepo(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	r := NewRouter(
-		map[string]*config.AgentConfig{
-			"dev-agent": {
-				Name:    "dev-agent",
-				Role:    "dev",
-				Runtime: "codex",
-				Command: "echo hello",
-			},
-		},
-		reg,
-		st,
-		"test/repo",
-		repoRoot,
-		taskCh,
-		workspace.NewManager(repoRoot),
-		true,
-	)
-
-	r.handleDispatch(context.Background(), statemachine.DispatchRequest{
+	dispatchCh := make(chan statemachine.DispatchRequest, 1)
+	dispatchCh <- statemachine.DispatchRequest{
 		Repo:      "test/repo",
-		IssueNum:  6,
+		IssueNum:  42,
 		AgentName: "dev-agent",
 		Workflow:  "default",
 		State:     "developing",
-	})
-
-	select {
-	case task := <-taskCh:
-		if task.WorktreePath != "" {
-			t.Fatalf("WorktreePath = %q, want empty transport payload", task.WorktreePath)
-		}
-		if task.Context == nil {
-			t.Fatal("expected dispatched task context")
-		}
-		if task.Context.RepoRoot != repoRoot {
-			t.Fatalf("RepoRoot = %q, want %q", task.Context.RepoRoot, repoRoot)
-		}
-		if task.Context.WorkDir != repoRoot {
-			t.Fatalf("WorkDir = %q, want %q", task.Context.WorkDir, repoRoot)
-		}
-	default:
-		t.Fatal("expected dispatched task")
-	}
-}
-
-func initGitRepo(t *testing.T) string {
-	t.Helper()
-	dir := t.TempDir()
-
-	for _, args := range [][]string{
-		{"init"},
-		{"config", "user.email", "test@test.com"},
-		{"config", "user.name", "Test"},
-	} {
-		cmd := exec.Command("git", args...)
-		cmd.Dir = dir
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %s: %v", args, out, err)
-		}
 	}
 
-	readme := filepath.Join(dir, "README.md")
-	if err := os.WriteFile(readme, []byte("test repo"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	cmd := exec.Command("git", "add", ".")
-	cmd.Dir = dir
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("git add: %s: %v", out, err)
-	}
-	cmd = exec.Command("git", "commit", "-m", "init")
-	cmd.Dir = dir
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("git commit: %s: %v", out, err)
-	}
+	done := make(chan struct{})
+	go func() {
+		_ = r.Run(ctx, dispatchCh)
+		close(done)
+	}()
 
-	return dir
+	// Wait for the preparer to observe the decision, then cancel.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if fp.seen > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	if fp.seen != 1 {
+		t.Fatalf("preparer invocations = %d, want 1", fp.seen)
+	}
 }

--- a/internal/taskprep/taskprep.go
+++ b/internal/taskprep/taskprep.go
@@ -1,0 +1,230 @@
+// Package taskprep materialises a scheduling decision into an executable
+// WorkerTask: it loads GitHub issue context, persists the task row, and
+// hands the task off to the embedded-worker channel.
+//
+// It lives outside internal/router so the scheduling decision (which agent,
+// is it gated) stays decoupled from context gathering, persistence, and
+// filesystem prep (see issue #145 finding #8).
+package taskprep
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/Lincyaw/workbuddy/internal/config"
+	"github.com/Lincyaw/workbuddy/internal/ghadapter"
+	runtimepkg "github.com/Lincyaw/workbuddy/internal/runtime"
+	"github.com/Lincyaw/workbuddy/internal/store"
+	"github.com/google/uuid"
+)
+
+// WorkerTask is the unit of work sent to an embedded Worker via channel.
+// It is defined here (rather than in internal/router) because materialising
+// it is the preparer's responsibility. internal/router re-exports it as a
+// type alias so existing consumers keep compiling.
+type WorkerTask struct {
+	TaskID       string
+	Repo         string
+	IssueNum     int
+	AgentName    string
+	Agent        *config.AgentConfig
+	Context      *runtimepkg.TaskContext
+	Workflow     string
+	State        string
+	WorktreePath string // path to isolated worktree, empty if isolation disabled
+}
+
+// IssueDataReader loads the minimal GitHub context needed to render an agent
+// prompt. It is intentionally narrow so taskprep tests can use a fake.
+type IssueDataReader interface {
+	ReadIssueSummary(repo string, issueNum int) (title, body string, labels []string, err error)
+	ReadIssueComments(repo string, issueNum int) ([]runtimepkg.IssueComment, error)
+	ListRelatedPRs(repo string, issueNum int) ([]runtimepkg.PRSummary, error)
+}
+
+// Decision is what the scheduling layer hands to the preparer. It carries
+// enough identity to persist a task row and render an agent prompt, but has
+// no GitHub or filesystem side-effects of its own.
+type Decision struct {
+	Repo      string
+	IssueNum  int
+	AgentName string
+	Agent     *config.AgentConfig
+	Workflow  string
+	State     string
+}
+
+// TaskStore is the narrow persistence surface the preparer needs.
+type TaskStore interface {
+	InsertTask(rec store.TaskRecord) error
+}
+
+// Preparer turns a Decision into a dispatched WorkerTask.
+//
+// Responsibilities:
+//   - persist a Task row in the store
+//   - (if dispatching to an embedded worker) load GH context + push the
+//     WorkerTask onto the supplied channel
+//
+// Workspace / worktree provisioning is intentionally NOT here — it lives on
+// the worker side (internal/worker/executor.go) so transport-level dispatch
+// does not do filesystem work.
+type Preparer struct {
+	store              TaskStore
+	repoRoot           string
+	taskChan           chan<- WorkerTask
+	dispatchToEmbedded bool
+	gh                 IssueDataReader
+}
+
+// NewPreparer constructs a Preparer. Pass dispatchToEmbedded=false for
+// coordinator-only mode: the task row is persisted but the in-process
+// channel is not used (a remote worker will claim it instead).
+func NewPreparer(
+	st TaskStore,
+	repoRoot string,
+	taskChan chan<- WorkerTask,
+	dispatchToEmbedded bool,
+) *Preparer {
+	return &Preparer{
+		store:              st,
+		repoRoot:           repoRoot,
+		taskChan:           taskChan,
+		dispatchToEmbedded: dispatchToEmbedded,
+		gh:                 ghadapter.NewCLI(),
+	}
+}
+
+// SetIssueDataReader replaces the default GitHub issue-context reader.
+// Passing nil restores the default CLI-backed reader.
+func (p *Preparer) SetIssueDataReader(reader IssueDataReader) {
+	if reader == nil {
+		p.gh = ghadapter.NewCLI()
+		return
+	}
+	p.gh = reader
+}
+
+// Prepare persists the task and, when dispatching to the embedded worker,
+// loads GitHub context and pushes the WorkerTask onto the channel.
+//
+// Context cancellation during the channel send returns silently — this
+// matches the legacy router behaviour where shutdown races are not treated
+// as dispatch failures.
+func (p *Preparer) Prepare(ctx context.Context, d Decision) error {
+	if d.Agent == nil {
+		return fmt.Errorf("taskprep: nil agent for %s#%d", d.Repo, d.IssueNum)
+	}
+	taskID := uuid.New().String()
+
+	if err := p.store.InsertTask(store.TaskRecord{
+		ID:        taskID,
+		Repo:      d.Repo,
+		IssueNum:  d.IssueNum,
+		AgentName: d.AgentName,
+		Role:      d.Agent.Role,
+		Runtime:   d.Agent.Runtime,
+		Workflow:  d.Workflow,
+		State:     d.State,
+		Status:    store.TaskStatusPending,
+	}); err != nil {
+		return fmt.Errorf("taskprep: insert task: %w", err)
+	}
+
+	if !p.dispatchToEmbedded || p.taskChan == nil {
+		return nil
+	}
+
+	issueCtx := runtimepkg.IssueContext{Number: d.IssueNum}
+	var relatedPRs []runtimepkg.PRSummary
+	if p.gh != nil {
+		if title, body, labels, err := p.gh.ReadIssueSummary(d.Repo, d.IssueNum); err != nil {
+			log.Printf("[taskprep] warning: could not fetch issue details for %s#%d: %v", d.Repo, d.IssueNum, err)
+		} else {
+			issueCtx.Title = title
+			issueCtx.Body = body
+			issueCtx.Labels = labels
+		}
+		if comments, err := p.gh.ReadIssueComments(d.Repo, d.IssueNum); err != nil {
+			log.Printf("[taskprep] warning: could not fetch issue comments for %s#%d: %v", d.Repo, d.IssueNum, err)
+		} else {
+			issueCtx.Comments = comments
+			issueCtx.CommentsText = FormatComments(comments)
+		}
+		prs, err := p.gh.ListRelatedPRs(d.Repo, d.IssueNum)
+		if err != nil {
+			log.Printf("[taskprep] warning: could not fetch related PRs for %s#%d: %v", d.Repo, d.IssueNum, err)
+		} else {
+			relatedPRs = prs
+		}
+	}
+
+	taskCtx := &runtimepkg.TaskContext{
+		Issue:          issueCtx,
+		Repo:           d.Repo,
+		RepoRoot:       p.repoRoot,
+		WorkDir:        p.repoRoot,
+		RelatedPRs:     relatedPRs,
+		RelatedPRsText: FormatRelatedPRs(relatedPRs),
+		Session: runtimepkg.SessionContext{
+			ID: fmt.Sprintf("session-%s", taskID),
+		},
+	}
+
+	task := WorkerTask{
+		TaskID:    taskID,
+		Repo:      d.Repo,
+		IssueNum:  d.IssueNum,
+		AgentName: d.AgentName,
+		Agent:     d.Agent,
+		Context:   taskCtx,
+		Workflow:  d.Workflow,
+		State:     d.State,
+	}
+
+	select {
+	case p.taskChan <- task:
+	case <-ctx.Done():
+	}
+	return nil
+}
+
+// FormatComments renders issue comments into a human-readable blob for
+// agent prompt templates. Exported so callers that build their own
+// TaskContext can reuse the same format.
+func FormatComments(comments []runtimepkg.IssueComment) string {
+	if len(comments) == 0 {
+		return "(no comments)"
+	}
+	var b strings.Builder
+	for i, c := range comments {
+		if i > 0 {
+			b.WriteString("\n---\n")
+		}
+		fmt.Fprintf(&b, "[%s by %s]\n%s", c.CreatedAt, c.Author, c.Body)
+	}
+	return b.String()
+}
+
+// FormatRelatedPRs renders related PR summaries into a human-readable blob
+// for agent prompt templates.
+func FormatRelatedPRs(prs []runtimepkg.PRSummary) string {
+	if len(prs) == 0 {
+		return "(no related PRs)"
+	}
+	var b strings.Builder
+	for i, p := range prs {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		draft := ""
+		if p.IsDraft {
+			draft = " [draft]"
+		}
+		fmt.Fprintf(&b, "#%d [%s]%s %s (head: %s, base: %s) - %s",
+			p.Number, p.State, draft, p.Title, p.HeadRefName, p.BaseRefName, p.URL)
+	}
+	return b.String()
+}

--- a/internal/taskprep/taskprep_test.go
+++ b/internal/taskprep/taskprep_test.go
@@ -1,0 +1,195 @@
+package taskprep
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/Lincyaw/workbuddy/internal/config"
+	runtimepkg "github.com/Lincyaw/workbuddy/internal/runtime"
+	"github.com/Lincyaw/workbuddy/internal/store"
+)
+
+// fakeReader satisfies IssueDataReader without shelling out.
+type fakeReader struct{}
+
+func (fakeReader) ReadIssueSummary(_ string, _ int) (string, string, []string, error) {
+	return "Issue", "body", []string{"workbuddy"}, nil
+}
+func (fakeReader) ReadIssueComments(_ string, _ int) ([]runtimepkg.IssueComment, error) {
+	return nil, nil
+}
+func (fakeReader) ListRelatedPRs(_ string, _ int) ([]runtimepkg.PRSummary, error) {
+	return nil, nil
+}
+
+func newTestStore(t *testing.T) *store.Store {
+	t.Helper()
+	st, err := store.NewStore(t.TempDir() + "/test.db")
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return st
+}
+
+func initGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	for _, args := range [][]string{
+		{"init"},
+		{"config", "user.email", "test@test.com"},
+		{"config", "user.name", "Test"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %s: %v", args, out, err)
+		}
+	}
+
+	readme := filepath.Join(dir, "README.md")
+	if err := os.WriteFile(readme, []byte("test repo"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "add", ".")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git add: %s: %v", out, err)
+	}
+	cmd = exec.Command("git", "commit", "-m", "init")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git commit: %s: %v", out, err)
+	}
+
+	return dir
+}
+
+func newDecision(agentCfg *config.AgentConfig, issue int) Decision {
+	return Decision{
+		Repo:      "test/repo",
+		IssueNum:  issue,
+		AgentName: agentCfg.Name,
+		Agent:     agentCfg,
+		Workflow:  "default",
+		State:     "developing",
+	}
+}
+
+func TestPreparer_PersistOnlyModeLeavesTaskPending(t *testing.T) {
+	st := newTestStore(t)
+	p := NewPreparer(st, t.TempDir(), nil, false)
+	p.SetIssueDataReader(fakeReader{})
+
+	agent := &config.AgentConfig{Name: "dev-agent", Role: "dev", Runtime: "codex", Command: "echo"}
+	if err := p.Prepare(context.Background(), newDecision(agent, 2)); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	tasks, err := st.QueryTasks(store.TaskStatusPending)
+	if err != nil {
+		t.Fatalf("QueryTasks: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("pending tasks = %d, want 1", len(tasks))
+	}
+	got := tasks[0]
+	if got.Role != "dev" || got.Runtime != "codex" || got.Workflow != "default" || got.State != "developing" {
+		t.Fatalf("unexpected persisted task: %+v", got)
+	}
+}
+
+func TestPreparer_PersistOnlyModeDoesNotCreateWorktree(t *testing.T) {
+	st := newTestStore(t)
+	repoRoot := initGitRepo(t)
+	p := NewPreparer(st, repoRoot, nil, false)
+	p.SetIssueDataReader(fakeReader{})
+
+	agent := &config.AgentConfig{Name: "dev-agent", Role: "dev", Runtime: "codex", Command: "echo"}
+	if err := p.Prepare(context.Background(), newDecision(agent, 41)); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(repoRoot, ".workbuddy", "worktrees", "issue-41")); !os.IsNotExist(err) {
+		t.Fatalf("coordinator mode should not create a worktree, stat err = %v", err)
+	}
+}
+
+func TestPreparer_DispatchDoesNotEagerlyCreateWorktree(t *testing.T) {
+	st := newTestStore(t)
+	repoRoot := initGitRepo(t)
+	taskCh := make(chan WorkerTask, 1)
+	p := NewPreparer(st, repoRoot, taskCh, true)
+	p.SetIssueDataReader(fakeReader{})
+
+	agent := &config.AgentConfig{Name: "dev-agent", Role: "dev", Runtime: "claude-code", Command: "echo"}
+	if err := p.Prepare(context.Background(), newDecision(agent, 5)); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	select {
+	case task := <-taskCh:
+		if task.Context == nil {
+			t.Fatal("expected dispatched task context")
+		}
+		if task.Context.RepoRoot != repoRoot {
+			t.Fatalf("RepoRoot = %q, want %q", task.Context.RepoRoot, repoRoot)
+		}
+		if task.Context.WorkDir != repoRoot {
+			t.Fatalf("WorkDir = %q, want %q", task.Context.WorkDir, repoRoot)
+		}
+		if task.WorktreePath != "" {
+			t.Fatalf("WorktreePath = %q, want empty transport payload", task.WorktreePath)
+		}
+	default:
+		t.Fatal("expected dispatched task")
+	}
+
+	failed, err := st.QueryTasks(store.TaskStatusFailed)
+	if err != nil {
+		t.Fatalf("QueryTasks: %v", err)
+	}
+	if len(failed) != 0 {
+		t.Fatalf("failed tasks = %d, want 0", len(failed))
+	}
+}
+
+func TestPreparer_DispatchUsesBaseRepoRootAndWorkDir(t *testing.T) {
+	st := newTestStore(t)
+	repoRoot := initGitRepo(t)
+	taskCh := make(chan WorkerTask, 1)
+	p := NewPreparer(st, repoRoot, taskCh, true)
+	p.SetIssueDataReader(fakeReader{})
+
+	agent := &config.AgentConfig{Name: "dev-agent", Role: "dev", Runtime: "codex", Command: "echo"}
+	if err := p.Prepare(context.Background(), newDecision(agent, 6)); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	select {
+	case task := <-taskCh:
+		if task.Context == nil {
+			t.Fatal("expected dispatched task context")
+		}
+		if task.Context.RepoRoot != repoRoot {
+			t.Fatalf("RepoRoot = %q, want %q", task.Context.RepoRoot, repoRoot)
+		}
+		if task.Context.WorkDir != repoRoot {
+			t.Fatalf("WorkDir = %q, want %q", task.Context.WorkDir, repoRoot)
+		}
+	default:
+		t.Fatal("expected dispatched task")
+	}
+}
+
+func TestPreparer_NilAgentReturnsError(t *testing.T) {
+	st := newTestStore(t)
+	p := NewPreparer(st, t.TempDir(), nil, false)
+	if err := p.Prepare(context.Background(), Decision{Repo: "test/repo", IssueNum: 1, AgentName: "missing"}); err == nil {
+		t.Fatal("expected error for nil agent")
+	}
+}

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -396,8 +396,12 @@ requirements:
       - "AC-004-8: 单元测试：有匹配 Worker、无匹配 Worker、agent 不存在 3 种场景"
     code:
       - internal/router/router.go
+      - internal/taskprep/taskprep.go
+      - internal/dependency/gate.go
     tests:
       - internal/router/router_test.go
+      - internal/taskprep/taskprep_test.go
+      - internal/dependency/gate_test.go
     deps: [REQ-001, REQ-003, REQ-023, REQ-024]
 
   - id: REQ-005
@@ -1151,6 +1155,7 @@ requirements:
     code:
       - cmd/serve.go
       - internal/dependency/dependency.go
+      - internal/dependency/gate.go
       - internal/poller/poller.go
       - internal/statemachine/statemachine.go
       - internal/router/router.go
@@ -1161,6 +1166,7 @@ requirements:
       - docs/implemented/issue-dependencies.md
     tests:
       - internal/dependency/dependency_test.go
+      - internal/dependency/gate_test.go
       - internal/store/store_test.go
       - internal/poller/poller_test.go
       - internal/statemachine/statemachine_test.go


### PR DESCRIPTION
Addresses finding #8 of #145 (`internal/router` is not just a router).

## Scope note up front

#145 finding #8 was written before #152 landed. After #152, worktree
creation and setup-failure reporting had already moved out of the
router (to `internal/worker/executor.go`). The remaining mixing was
narrower than the finding described: persistence + dependency gating +
GH context loading were still inline in `router.handleDispatch`. This
PR does the smaller, still-meaningful cut rather than inventing extra
packages for responsibilities the router no longer held.

## Responsibility table

| Concern                              | Before                            | After                                |
| ------------------------------------ | --------------------------------- | ------------------------------------ |
| Agent lookup (scheduling)            | `internal/router/router.go`       | `internal/router/router.go` (kept)   |
| Dependency verdict gating            | inline in router dispatch         | `internal/dependency/gate.go` helper |
| Task row persistence (`InsertTask`)  | inline in router dispatch         | `internal/taskprep/taskprep.go`      |
| GH issue summary/comments/PR loading | inline in router dispatch         | `internal/taskprep/taskprep.go`      |
| Embedded-worker channel dispatch     | inline in router dispatch         | `internal/taskprep/taskprep.go`      |
| Workspace/worktree provisioning      | already in worker (since #152)    | unchanged (worker side)              |
| Worktree setup-failure reporting     | dead field on router (since #152) | removed; worker side owns it         |

## Call-site changes

- `cmd/serve.go`: removed the single-line `rt.SetReporter(rep)` wire
  (the router field was unused after #152). Replaced with a comment
  noting the new ownership. `rep` itself still used by poller/state
  machine paths.
- `cmd/coordinator.go`, `cmd/repo_runtime.go`: no wiring changes —
  `router.NewRouter(...)` signature is preserved and internally builds
  a `taskprep.Preparer`.
- `router.WorkerTask` and `router.IssueDataReader` become type aliases
  over the canonical `taskprep.WorkerTask` / `taskprep.IssueDataReader`
  so the 10+ call sites across `cmd/*`, `internal/worker/*`, and tests
  continue to compile unchanged.

## Test split

- `internal/router/router_test.go` — scheduling only, via a fake
  `Preparer`: decision emission, unknown-agent skip, dep-verdict gate
  (blocked/needs_human reject; ready/override allow), and `Run` loop
  wiring.
- `internal/taskprep/taskprep_test.go` — persistence + dispatch
  behaviour moved from the old router tests: persist-only mode leaves
  task pending, no eager worktree creation in either mode, correct
  RepoRoot/WorkDir on the dispatched `WorkerTask`, nil-agent guard.
- `internal/dependency/gate_test.go` — verdict matrix + error
  propagation on the new `IsBlocked` helper.

## Intentionally left behind

- `Router.registry` field retained for signature compatibility
  (`NewRouter` still takes `*registry.Registry`). Today it is not
  consulted — actual worker selection happens in the preparer/worker
  layer. Kept because changing the signature would collide with
  #145-7's in-flight `cmd/*` assembly refactor.
- `wsMgr` argument to `NewRouter` retained as `any` and ignored; same
  call-site-stability reason. A follow-up can drop both once the
  assembly-layer refactor lands.
- `AC-058-6` in `project-index.yaml` still mentions "Embedded router
  reports worktree failures as user-visible comments". That AC was
  already stale after #152 (worker owns that now) and is not this PR's
  scope to rewrite; left untouched.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1`
- [x] `python3 ~/.autoharness/scripts/validate_index.py project-index.yaml`