### PR TITLE
fix(workspace): refcount shared worktrees to prevent dev→review race

### DIFF
--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -17,14 +17,32 @@ import (
 const worktreeDir = ".workbuddy/worktrees"
 
 // Manager handles creation and cleanup of git worktrees for agent tasks.
+//
+// When multiple agents share the same per-issue worktree (e.g. dev-agent
+// finishes and review-agent starts while dev-agent's cleanup is still
+// pending), the manager tracks an active-session reference count per
+// worktree path. Remove only performs the actual git removal when the last
+// active reference releases; earlier Remove calls decrement the count and
+// return nil so a late defer from a finished agent cannot pull the
+// filesystem out from under a still-running one.
 type Manager struct {
 	baseDir string // root of the main repo (where .git lives)
 	mu      sync.Mutex
+	refs    map[string]int // absolute worktree path -> active session count
 }
 
 // NewManager creates a Manager rooted at the given repo directory.
 func NewManager(baseDir string) *Manager {
-	return &Manager{baseDir: baseDir}
+	return &Manager{baseDir: baseDir, refs: make(map[string]int)}
+}
+
+// refKey returns the canonical refcount key for a worktree path.
+func refKey(wtPath string) string {
+	abs, err := filepath.Abs(wtPath)
+	if err != nil {
+		return wtPath
+	}
+	return abs
 }
 
 // Create creates a new git worktree for the given task and returns its path.
@@ -68,7 +86,9 @@ func (m *Manager) Create(issueNum int, taskID string) (string, error) {
 		if err := m.syncExistingWorktree(wtPath, branchName); err != nil {
 			return "", err
 		}
-		log.Printf("[workspace] reused worktree %s (branch %s) for issue #%d", wtPath, branchName, issueNum)
+		m.refs[refKey(wtPath)]++
+		log.Printf("[workspace] reused worktree %s (branch %s) for issue #%d (active=%d)",
+			wtPath, branchName, issueNum, m.refs[refKey(wtPath)])
 		return wtPath, nil
 	}
 
@@ -98,6 +118,7 @@ func (m *Manager) Create(issueNum int, taskID string) (string, error) {
 		log.Printf("[workspace] created worktree %s (branch %s from %s) for issue #%d",
 			wtPath, branchName, baseRef, issueNum)
 	}
+	m.refs[refKey(wtPath)]++
 	return wtPath, nil
 }
 
@@ -147,13 +168,38 @@ func (m *Manager) gitIsClean(wtPath string) bool {
 	return strings.TrimSpace(string(out)) == ""
 }
 
-// Remove cleans up a worktree and its associated branch.
-// Best-effort: if worktree removal fails but prune succeeds, no error is returned.
-// Returns a combined error only when cleanup truly fails (both remove+prune fail,
-// or branch deletion fails).
+// Remove releases one active reference to the worktree and, when the last
+// reference is released, performs the actual git worktree removal and branch
+// deletion.
+//
+// Sharing: the same per-issue worktree is reused across a dev-agent → review-agent
+// handoff. Each Create/Remove pair is a reference, not necessarily a full
+// lifecycle; the underlying worktree must survive until every active agent
+// has released its reference. A Remove on a path whose refcount is > 1
+// decrements the count and returns nil (no-op) to preserve the filesystem for
+// the still-running sessions.
+//
+// A Remove on a path with no tracked refcount (e.g. recovery paths, Prune,
+// callers from before this change) proceeds with the actual removal, matching
+// prior behaviour.
+//
+// Best-effort on the actual removal: if worktree removal fails but prune
+// succeeds, no error is returned. Returns a combined error only when cleanup
+// truly fails (both remove+prune fail, or branch deletion fails).
 func (m *Manager) Remove(wtPath string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	key := refKey(wtPath)
+	if count, tracked := m.refs[key]; tracked {
+		if count > 1 {
+			m.refs[key] = count - 1
+			log.Printf("[workspace] retaining worktree %s (still in use by %d session(s))",
+				wtPath, count-1)
+			return nil
+		}
+		delete(m.refs, key)
+	}
 
 	var errs []error
 

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -352,3 +352,80 @@ func TestCreate_ExistingGitRepoButNotRegisteredWorktreeRefuse(t *testing.T) {
 		t.Fatalf("expected registered worktree error, got: %v", err)
 	}
 }
+
+// TestRemove_RetainsWorktreeWhileSecondSessionActive reproduces the race
+// from issue #169: a dev-agent and review-agent share the same per-issue
+// worktree across a handoff; when the dev-agent's Execute defers Remove
+// after the review-agent has already re-acquired the worktree, the worktree
+// must survive so the review-agent's cwd is not pulled away.
+func TestRemove_RetainsWorktreeWhileSecondSessionActive(t *testing.T) {
+	repoDir := initTestRepo(t)
+	mgr := NewManager(repoDir)
+
+	// dev-agent acquires
+	wtPath, err := mgr.Create(42, "dev-task")
+	if err != nil {
+		t.Fatalf("Create (dev): %v", err)
+	}
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("worktree missing after first Create: %v", err)
+	}
+
+	// review-agent acquires the same worktree (reuse path)
+	wtPath2, err := mgr.Create(42, "review-task")
+	if err != nil {
+		t.Fatalf("Create (review): %v", err)
+	}
+	if wtPath2 != wtPath {
+		t.Fatalf("expected same worktree reused, got %s vs %s", wtPath2, wtPath)
+	}
+
+	// dev-agent's deferred Remove fires — must be a no-op on disk
+	if err := mgr.Remove(wtPath); err != nil {
+		t.Fatalf("Remove (dev, expected no-op): %v", err)
+	}
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("worktree was removed while review session still active: %v", err)
+	}
+
+	// review-agent finishes — now the actual removal must happen
+	if err := mgr.Remove(wtPath); err != nil {
+		t.Fatalf("Remove (review): %v", err)
+	}
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Fatalf("worktree still present after final Remove: stat err=%v", err)
+	}
+
+	// a subsequent Remove on an untracked path proceeds without crashing
+	// (backward compat: recovery/prune callers)
+	if err := mgr.Remove(wtPath); err != nil {
+		// remove of a gone worktree logs a warning but is not a hard error
+		// as long as prune succeeds; tolerate either nil or non-fatal err.
+		t.Logf("Remove on already-gone worktree returned: %v (tolerated)", err)
+	}
+}
+
+// TestRemove_UntrackedPathProceeds asserts that a Remove on a worktree the
+// manager never tracked (e.g. recovery tools, or Prune) still performs the
+// actual git removal instead of silently skipping because the refcount map
+// has no entry.
+func TestRemove_UntrackedPathProceeds(t *testing.T) {
+	repoDir := initTestRepo(t)
+
+	// First manager creates the worktree.
+	mgrA := NewManager(repoDir)
+	wtPath, err := mgrA.Create(7, "task-a")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Second manager instance — simulates a recovery/prune path that inherits
+	// worktrees without knowing their history. No refcount entry.
+	mgrB := NewManager(repoDir)
+	if err := mgrB.Remove(wtPath); err != nil {
+		t.Fatalf("Remove from recovery manager: %v", err)
+	}
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Fatalf("worktree not removed by recovery-path Remove: stat err=%v", err)
+	}
+}

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -1975,6 +1975,7 @@ requirements:
       - "AC-058-5: Remote worker (cmd/worker.go) reports worktree failures on the issue as a user-visible comment via Reporter and releases the claimed task back to the coordinator queue"
       - "AC-058-6: Embedded router (internal/router/router.go) reports worktree failures on the issue as a user-visible comment via Reporter and updates the task status to failed"
       - "AC-058-7: Unit tests cover stale metadata + prune rescue, existing-clean reuse, existing-dirty refuse, and stale-add failure"
+      - "AC-058-8: When multiple agents share the same per-issue worktree (dev→review handoff), Manager tracks active references; Remove decrements the count and only performs the actual git worktree remove + branch delete when the last reference releases, so a late defer from a finished agent does not invalidate cwd for a still-running agent"
     code:
       - internal/workspace/workspace.go
       - internal/worker/embedded.go


### PR DESCRIPTION
## Summary

- Track active references per worktree path in `internal/workspace.Manager`
- `Remove` decrements the count; actual `git worktree remove` only fires at 0
- Closes #169 — reproduced live on 2026-04-22 across #161-#164 where all four review-agent sessions died in ~12s because the dev-agent's deferred Remove yanked the cwd while the review-agent was already running in it

## Root cause

When state machine transitions developing → reviewing, the review-agent is dispatched and acquires the same `.workbuddy/worktrees/issue-N` path via `Manager.Create` (reuse path). Meanwhile the dev-agent's `executor.go:105` defer fires and calls `Manager.Remove` on the same path. With no refcount, the defer always executed `git worktree remove --force`, and codex's next `exec_command` failed with `No such file or directory (os error 2)` followed by a panic in `plugins/store.rs`.

## Fix

`Manager.Create` and `Manager.Remove` now coordinate on a per-absolute-path refcount:

- `Create` increments on every successful acquire (fresh-create and reuse paths)
- `Remove` decrements; if count > 1, logs `retaining worktree ... still in use by N session(s)` and returns nil (no-op)
- The actual `git worktree remove --force` + branch delete only run when the count drops to 0
- `Remove` on an untracked path (recovery/prune callers that never called `Create`) still performs the actual cleanup, preserving prior behaviour

## Tests

- `TestRemove_RetainsWorktreeWhileSecondSessionActive` replays the dev→review handoff: two `Create`s, first `Remove` must be a no-op on disk, second `Remove` actually cleans up.
- `TestRemove_UntrackedPathProceeds` asserts recovery-path callers with no refcount entry still remove the worktree (non-regression for prune/recovery).
- `go build ./... && go vet ./... && go test ./... -count=1` all green.
- `project-index.yaml` REQ-058 extended with `AC-058-8`; `validate_index.py` passes.

## Test plan

- [x] go build
- [x] go vet
- [x] go test ./... -count=1
- [x] validate_index.py
- [ ] After merge: redeploy, re-dispatch #161 / #162 / #164, verify review-agent survives handoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)