### PR TITLE
runtime+validate: workflow-injected transition footer and L5 lint (#204 batch 3 of 3)

### DIFF
--- a/.github/workbuddy/agents/dev-agent.md
+++ b/.github/workbuddy/agents/dev-agent.md
@@ -30,11 +30,11 @@ Previous comments (including review feedback):
 Related PRs:
 {{.RelatedPRsText}}
 
-Read the issue body for a `## Acceptance Criteria` section.
+Read the issue body for an acceptance-criteria section.
 
-- If the section is missing or lists no verifiable criteria: add label
-  `status:blocked`, remove `status:developing`, post a comment explaining
-  exactly what acceptance criteria are needed, then stop.
+- If the section is missing or lists no verifiable criteria: post a comment
+  explaining exactly what acceptance criteria are needed, then transition the
+  issue to the blocked outcome (see the Transition footer below) and stop.
 - Otherwise: produce the artifact that satisfies every criterion — code,
   docs, dependency bump, investigation report, whatever fits. For any
   verifiable criterion, include tests or checks that demonstrate it holds.
@@ -49,9 +49,12 @@ When the artifact is ready:
    issue #{{.Issue.Number}}.
 2. Push the branch to origin: `git push -u origin workbuddy/issue-{{.Issue.Number}}`.
 3. You MUST have an open PR for this branch before proceeding. If no open PR
-   exists, create one with `gh pr create --title "..." --body "Fixes #{{.Issue.Number}}"`
+   exists, create one (`gh pr create --title "..." --body "Fixes #{{.Issue.Number}}"`)
    and capture the PR URL.
-4. ONLY after the PR exists: remove `status:developing`, add `status:reviewing`,
-   and post a comment including the PR URL. Do NOT change labels if there is no PR.
+4. Post a comment on the issue with the PR URL so the reviewer can find it.
+
+Once the PR exists and the comment is posted, follow the Transition footer
+below to move the issue to the reviewing outcome. Do NOT transition the issue
+if no PR exists.
 
 Use the repo's own CLAUDE.md / skills for project-specific dev-loop, PR conventions, and tooling.

--- a/.github/workbuddy/agents/review-agent.md
+++ b/.github/workbuddy/agents/review-agent.md
@@ -32,8 +32,8 @@ Previous comments (including earlier dev reports and review verdicts):
 Related PRs:
 {{.RelatedPRsText}}
 
-Read the issue's `## Acceptance Criteria` section AND the artifact (PR,
-comment, or report linked to the issue).
+Read the issue's acceptance-criteria section AND the artifact (PR, comment,
+or report linked to the issue).
 
 BEFORE evaluating criteria, verify there is an open PR for this issue
 (check `Related PRs` above or run `gh pr list --search "Fixes #{{.Issue.Number}}"`).
@@ -41,12 +41,13 @@ If no open PR exists, the review FAILS immediately with the reason:
 "No open PR found for issue #{{.Issue.Number}}. The dev agent must create a PR before review."
 
 Evaluate EACH criterion as pass / fail / cannot-judge, with concrete
-evidence (file:line, test name, or quoted text).
+evidence (file:line, test name, or quoted text). Post a comment on the issue
+with the criterion-by-criterion verdict regardless of outcome.
 
-- If every criterion passes: remove `status:reviewing`, add `status:done`,
-  and post a comment with the criterion-by-criterion verdict.
-- If any criterion fails: remove `status:reviewing`, add
-  `status:developing`, and post a comment listing the failing criteria plus
-  what the dev agent needs to address on the next pass.
+After posting the verdict comment, follow the Transition footer below:
+- If every criterion passes, choose the "all criteria pass" outcome.
+- If any criterion fails, choose the "fixes needed" outcome — your verdict
+  comment should already list the failing criteria and what the dev agent
+  needs to address on the next pass.
 
 Use the repo's own CLAUDE.md / skills for project-specific review conventions.

--- a/cmd/initdata/agents/dev-agent.md
+++ b/cmd/initdata/agents/dev-agent.md
@@ -22,15 +22,15 @@ Title: {{.Issue.Title}}
 Body:
 {{.Issue.Body}}
 
-Read the issue body for a `## Acceptance Criteria` section.
+Read the issue body for an acceptance-criteria section.
 
-- If the section is missing or lists no verifiable criteria: add label
-  `status:blocked`, remove `status:developing`, post a comment explaining
-  exactly what acceptance criteria are needed, then stop.
+- If the section is missing or lists no verifiable criteria: post a comment
+  explaining exactly what acceptance criteria are needed, then transition the
+  issue to the blocked outcome (see the Transition footer below) and stop.
 - Otherwise: produce the artifact that satisfies every criterion — code,
   docs, dependency bump, investigation report, whatever fits. For any
   verifiable criterion, include tests or checks that demonstrate it holds.
-- When the artifact is ready: remove `status:developing`, add
-  `status:reviewing`.
+- When the artifact is ready, follow the Transition footer below to move
+  the issue to the reviewing outcome.
 
 Use the repo's own CLAUDE.md / skills for project-specific dev-loop, PR conventions, and tooling. Report the artifact link when finished.

--- a/cmd/initdata/agents/review-agent.md
+++ b/cmd/initdata/agents/review-agent.md
@@ -1,6 +1,6 @@
 ---
 name: review-agent
-description: Review agent - verifies the artifact against issue acceptance criteria
+description: Review agent - verifies the artifact produced for issue acceptance criteria
 triggers:
   - state: reviewing
 role: review
@@ -22,16 +22,17 @@ Title: {{.Issue.Title}}
 Body:
 {{.Issue.Body}}
 
-Read the issue's `## Acceptance Criteria` section AND the artifact (PR,
-comment, or report linked to the issue).
+Read the issue's acceptance-criteria section AND the artifact (PR, comment,
+or report linked to the issue).
 
 Evaluate EACH criterion as pass / fail / cannot-judge, with concrete
-evidence (file:line, test name, or quoted text).
+evidence (file:line, test name, or quoted text). Post a comment on the issue
+with the criterion-by-criterion verdict regardless of outcome.
 
-- If every criterion passes: remove `status:reviewing`, add `status:done`,
-  and post a comment with the criterion-by-criterion verdict.
-- If any criterion fails: remove `status:reviewing`, add
-  `status:developing`, and post a comment listing the failing criteria plus
-  what the dev agent needs to address on the next pass.
+After posting the verdict comment, follow the Transition footer below:
+- If every criterion passes, choose the "all criteria pass" outcome.
+- If any criterion fails, choose the "fixes needed" outcome — your verdict
+  comment should already list the failing criteria and what the dev agent
+  needs to address on the next pass.
 
 Use the repo's own CLAUDE.md / skills for project-specific review conventions.

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -215,6 +215,7 @@ func runServeWithOutput(opts *serveOpts, ghReader poller.GHReader, launcherOverr
 	_ = wsMgr.Prune()
 
 	rt := router.NewRouter(cfg.Agents, reg, st, cfg.Global.Repo, repoDir, taskCh, wsMgr, true)
+	rt.SetWorkflows(cfg.Workflows)
 	if issueDataReader, ok := ghReader.(router.IssueDataReader); ok {
 		rt.SetIssueDataReader(issueDataReader)
 	}

--- a/internal/app/repo_runtime.go
+++ b/internal/app/repo_runtime.go
@@ -264,6 +264,7 @@ func (pm *PollerManager) StartOrUpdate(rec store.RepoRegistrationRecord) error {
 	sm.SetIssueClaim(BuildIssueClaimerID("coordinator-"+HostnameOrUnknown(), os.Getpid()), statemachine.DefaultIssueClaimLease)
 	depResolver := dependency.NewResolver(pm.store, pm.ghReader, pm.eventlog, pm.alertBus)
 	rt := router.NewRouter(cfg.Agents, pm.registry, pm.store, rec.Repo, pm.repoRoot, nil, nil, false)
+	rt.SetWorkflows(cfg.Workflows)
 	if issueDataReader, ok := pm.ghReader.(router.IssueDataReader); ok {
 		rt.SetIssueDataReader(issueDataReader)
 	}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -62,6 +62,7 @@ type readerAwarePreparer interface {
 // persists the task for a remote worker to claim.
 type Router struct {
 	agents    map[string]*config.AgentConfig
+	workflows map[string]*config.WorkflowConfig
 	registry  *registry.Registry
 	gateStore dependency.GateStore
 	preparer  Preparer
@@ -109,6 +110,15 @@ func (r *Router) SetPreparer(p Preparer) {
 	if p != nil {
 		r.preparer = p
 	}
+}
+
+// SetWorkflows wires workflow definitions into the router so it can attach
+// state metadata to dispatch decisions. The state metadata travels onward to
+// the Preparer (and the runtime task context) so the transition footer can
+// be synthesized at prompt-render time without reaching back into the
+// state-machine. Calling with nil clears the registry.
+func (r *Router) SetWorkflows(workflows map[string]*config.WorkflowConfig) {
+	r.workflows = workflows
 }
 
 // Run consumes dispatch requests until ctx is cancelled.
@@ -162,6 +172,25 @@ func (r *Router) decide(req statemachine.DispatchRequest) (Decision, bool) {
 		Agent:     agent,
 		Workflow:  req.Workflow,
 		State:     req.State,
+		StateDef:  r.lookupState(req.Workflow, req.State),
 	}, true
+}
+
+// lookupState returns the *config.State for a (workflow, state) pair, or nil
+// when the workflow registry is not wired or the state is unknown. nil is
+// fine — the preparer treats it as "no footer".
+func (r *Router) lookupState(workflowName, stateName string) *config.State {
+	if r.workflows == nil {
+		return nil
+	}
+	wf, ok := r.workflows[workflowName]
+	if !ok || wf == nil {
+		return nil
+	}
+	state, ok := wf.States[stateName]
+	if !ok {
+		return nil
+	}
+	return state
 }
 

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -144,6 +144,72 @@ func TestRouter_AllowsDispatchWhenReady(t *testing.T) {
 	}
 }
 
+// TestRouter_AttachesStateDef verifies that when SetWorkflows wires the
+// router to a workflow registry, the Decision emitted by handleDispatch
+// carries the *config.State pointer (used by the preparer to attach the
+// workflow-state metadata to the runtime TaskContext for transition footer
+// rendering — issue #204 batch 3).
+func TestRouter_AttachesStateDef(t *testing.T) {
+	agents := map[string]*config.AgentConfig{
+		"dev-agent": {Name: "dev-agent", Role: "dev", Runtime: "claude-code", Command: "echo"},
+	}
+	r, fp, _ := newSchedulingRouter(t, agents)
+	state := &config.State{
+		EnterLabel: "status:developing",
+		Transitions: map[string]string{
+			"status:reviewing": "reviewing",
+			"status:blocked":   "blocked",
+		},
+	}
+	r.SetWorkflows(map[string]*config.WorkflowConfig{
+		"default": {
+			Name:   "default",
+			States: map[string]*config.State{"developing": state},
+		},
+	})
+
+	r.handleDispatch(context.Background(), statemachine.DispatchRequest{
+		Repo:      "test/repo",
+		IssueNum:  10,
+		AgentName: "dev-agent",
+		Workflow:  "default",
+		State:     "developing",
+	})
+
+	if len(fp.got) != 1 {
+		t.Fatalf("preparer invocations = %d, want 1", len(fp.got))
+	}
+	if fp.got[0].StateDef != state {
+		t.Fatalf("StateDef pointer mismatch; want the wired state, got %+v", fp.got[0].StateDef)
+	}
+}
+
+// TestRouter_NilStateDefWhenWorkflowsUnwired makes sure the existing
+// dispatch path is unaffected for callers that have not yet wired
+// SetWorkflows — Decision.StateDef stays nil and the preparer treats that
+// as "no footer".
+func TestRouter_NilStateDefWhenWorkflowsUnwired(t *testing.T) {
+	agents := map[string]*config.AgentConfig{
+		"dev-agent": {Name: "dev-agent", Role: "dev", Runtime: "claude-code", Command: "echo"},
+	}
+	r, fp, _ := newSchedulingRouter(t, agents)
+
+	r.handleDispatch(context.Background(), statemachine.DispatchRequest{
+		Repo:      "test/repo",
+		IssueNum:  11,
+		AgentName: "dev-agent",
+		Workflow:  "default",
+		State:     "developing",
+	})
+
+	if len(fp.got) != 1 {
+		t.Fatalf("preparer invocations = %d, want 1", len(fp.got))
+	}
+	if fp.got[0].StateDef != nil {
+		t.Fatalf("StateDef = %+v, want nil when workflows registry is unwired", fp.got[0].StateDef)
+	}
+}
+
 func TestRouter_RunConsumesDispatchChannel(t *testing.T) {
 	agents := map[string]*config.AgentConfig{
 		"dev-agent": {Name: "dev-agent", Role: "dev", Runtime: "claude-code", Command: "echo"},

--- a/internal/runtime/agent_bridge.go
+++ b/internal/runtime/agent_bridge.go
@@ -240,10 +240,12 @@ func (s *AgentBridgeSession) Close() error {
 
 func resolvePrompt(agentCfg *config.AgentConfig, task *TaskContext) string {
 	if p := strings.TrimSpace(agentCfg.Prompt); p != "" {
-		rendered, err := RenderCommandRaw(p, task)
+		rendered, err := RenderAgentPrompt(p, task)
 		if err == nil {
 			return rendered
 		}
+		// Fall back to the body without the footer if the combined render
+		// fails (parse error in the agent body itself).
 		return p
 	}
 	if cmd := strings.TrimSpace(agentCfg.Command); cmd != "" {

--- a/internal/runtime/footer.go
+++ b/internal/runtime/footer.go
@@ -1,0 +1,92 @@
+package runtime
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Lincyaw/workbuddy/internal/config"
+)
+
+// BuildTransitionFooter returns the footer text to append to an agent prompt
+// based on the state's outgoing transitions. It is rendered per dispatch from
+// the workflow's `transitions` map (issue #204 batch 3) so prompt bodies do
+// not have to hard-code label syntax.
+//
+// The returned string is itself a Go template — it embeds {{.Issue.Number}}
+// and {{.Repo}} so a single text/template Execute call can render the body
+// and footer together against the same TaskContext.
+//
+// Terminal states (no outgoing transitions) return the empty string; the
+// caller should append nothing in that case.
+func BuildTransitionFooter(currentStateName, currentStateLabel string, transitions map[string]string) string {
+	if len(transitions) == 0 {
+		return ""
+	}
+
+	// Sort by label string for deterministic output. Tests diff this string.
+	labels := make([]string, 0, len(transitions))
+	for label := range transitions {
+		if strings.TrimSpace(label) == "" {
+			continue
+		}
+		labels = append(labels, label)
+	}
+	if len(labels) == 0 {
+		return ""
+	}
+	sort.Strings(labels)
+
+	var b strings.Builder
+	b.WriteString("---\n\n")
+	b.WriteString("## Transition\n\n")
+	b.WriteString("When you finish, transition this issue by editing labels.\n\n")
+	b.WriteString("| Add this label | Resulting state |\n")
+	b.WriteString("|----------------|-----------------|\n")
+	for _, label := range labels {
+		target := transitions[label]
+		fmt.Fprintf(&b, "| `%s` | `%s` |\n", label, target)
+	}
+	b.WriteString("\nRun:\n\n")
+	b.WriteString("```\n")
+	b.WriteString("gh issue edit {{.Issue.Number}} --repo {{.Repo}}")
+	if strings.TrimSpace(currentStateLabel) != "" {
+		fmt.Fprintf(&b, " --remove-label \"%s\"", currentStateLabel)
+	} else {
+		b.WriteString(" --remove-label \"<current-label>\"")
+	}
+	b.WriteString(" --add-label \"<chosen-label>\"\n")
+	b.WriteString("```\n\n")
+	if strings.TrimSpace(currentStateLabel) != "" {
+		fmt.Fprintf(&b, "The label you remove is `%s` (the enter_label of the `%s` state). "+
+			"Pick the `<chosen-label>` from the table above that matches your outcome.\n",
+			currentStateLabel, currentStateName)
+	} else {
+		fmt.Fprintf(&b,
+			"Replace `<current-label>` with the enter_label of the `%s` state. "+
+				"Pick the `<chosen-label>` from the table above that matches your outcome.\n",
+			currentStateName)
+	}
+	return b.String()
+}
+
+// BuildTransitionFooterFromState is a thin convenience wrapper that pulls the
+// fields out of a *config.State. Returns "" for nil/terminal states.
+func BuildTransitionFooterFromState(stateName string, state *config.State) string {
+	if state == nil {
+		return ""
+	}
+	return BuildTransitionFooter(stateName, state.EnterLabel, state.Transitions)
+}
+
+// AssemblePrompt concatenates the agent prompt body and the runtime-generated
+// transition footer. The combined string is still a Go template — both halves
+// are rendered together so the footer can use TaskContext expressions such as
+// {{.Issue.Number}}. Empty footers (terminal state) return the body unchanged.
+func AssemblePrompt(body, footer string) string {
+	body = strings.TrimRight(body, "\n")
+	if strings.TrimSpace(footer) == "" {
+		return body
+	}
+	return body + "\n\n" + footer
+}

--- a/internal/runtime/footer_test.go
+++ b/internal/runtime/footer_test.go
@@ -1,0 +1,139 @@
+package runtime
+
+import (
+	"strings"
+	"testing"
+	"text/template"
+)
+
+// TestBuildTransitionFooter_Developing pins the exact rendered footer for the
+// canonical `developing` state in the default workflow. This is the snapshot
+// that callers (skill docs, agent prompts) refer to when reasoning about what
+// the agent actually sees.
+func TestBuildTransitionFooter_Developing(t *testing.T) {
+	transitions := map[string]string{
+		"status:reviewing": "reviewing",
+		"status:blocked":   "blocked",
+	}
+	got := BuildTransitionFooter("developing", "status:developing", transitions)
+
+	want := "---\n\n" +
+		"## Transition\n\n" +
+		"When you finish, transition this issue by editing labels.\n\n" +
+		"| Add this label | Resulting state |\n" +
+		"|----------------|-----------------|\n" +
+		"| `status:blocked` | `blocked` |\n" +
+		"| `status:reviewing` | `reviewing` |\n" +
+		"\nRun:\n\n" +
+		"```\n" +
+		"gh issue edit {{.Issue.Number}} --repo {{.Repo}} --remove-label \"status:developing\" --add-label \"<chosen-label>\"\n" +
+		"```\n\n" +
+		"The label you remove is `status:developing` (the enter_label of the `developing` state). " +
+		"Pick the `<chosen-label>` from the table above that matches your outcome.\n"
+
+	if got != want {
+		t.Fatalf("footer mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+// TestBuildTransitionFooter_Terminal — terminal states (no transitions) emit
+// the empty string so the dispatch path appends nothing.
+func TestBuildTransitionFooter_Terminal(t *testing.T) {
+	if got := BuildTransitionFooter("done", "status:done", nil); got != "" {
+		t.Fatalf("terminal footer should be empty, got %q", got)
+	}
+	if got := BuildTransitionFooter("done", "status:done", map[string]string{}); got != "" {
+		t.Fatalf("terminal footer (empty map) should be empty, got %q", got)
+	}
+}
+
+// TestBuildTransitionFooter_DeterministicOrder — the table rows must be
+// sorted by label so the rendered string is byte-stable for diff-style tests.
+func TestBuildTransitionFooter_DeterministicOrder(t *testing.T) {
+	transitions := map[string]string{
+		"status:zzz": "z",
+		"status:aaa": "a",
+		"status:mmm": "m",
+	}
+	got := BuildTransitionFooter("s", "status:s", transitions)
+	idxA := strings.Index(got, "status:aaa")
+	idxM := strings.Index(got, "status:mmm")
+	idxZ := strings.Index(got, "status:zzz")
+	if !(idxA >= 0 && idxA < idxM && idxM < idxZ) {
+		t.Fatalf("expected aaa < mmm < zzz in rendered footer, got order:\n%s", got)
+	}
+}
+
+// TestAssembleAgentPrompt_RenderableTemplate ensures the assembled body+footer
+// parses + executes as a single Go text/template against TaskContext, with
+// {{.Issue.Number}} / {{.Repo}} resolving correctly.
+func TestAssembleAgentPrompt_RenderableTemplate(t *testing.T) {
+	body := "You are dev-agent for repo {{.Repo}}, issue #{{.Issue.Number}}."
+	task := &TaskContext{
+		Repo:  "octo/example",
+		Issue: IssueContext{Number: 42},
+	}
+	task.SetWorkflowState("developing", "status:developing", map[string]string{
+		"status:reviewing": "reviewing",
+		"status:blocked":   "blocked",
+	})
+
+	combined := AssembleAgentPrompt(body, task)
+	tmpl, err := template.New("t").Funcs(TemplateFuncMap()).Parse(combined)
+	if err != nil {
+		t.Fatalf("combined prompt failed to parse: %v", err)
+	}
+	var sb strings.Builder
+	if err := tmpl.Execute(&sb, task); err != nil {
+		t.Fatalf("combined prompt failed to execute: %v", err)
+	}
+	rendered := sb.String()
+
+	for _, want := range []string{
+		"octo/example",
+		"issue #42",
+		"## Transition",
+		"`status:reviewing` | `reviewing`",
+		"`status:blocked` | `blocked`",
+		"gh issue edit 42 --repo octo/example --remove-label \"status:developing\"",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("rendered prompt missing %q:\n%s", want, rendered)
+		}
+	}
+}
+
+// TestAssembleAgentPrompt_NoStateMetadata — a TaskContext with no workflow
+// state attached returns the body unchanged (back-compat for callers that
+// have not been migrated to thread state metadata).
+func TestAssembleAgentPrompt_NoStateMetadata(t *testing.T) {
+	body := "Hello {{.Repo}}"
+	task := &TaskContext{Repo: "octo/x"}
+	combined := AssembleAgentPrompt(body, task)
+	if combined != strings.TrimRight(body, "\n") {
+		t.Fatalf("expected unchanged body for state-less task, got: %q", combined)
+	}
+}
+
+// TestRenderAgentPrompt_E2E — exercise the rendering convenience wrapper end
+// to end so dispatch sites can rely on a single call.
+func TestRenderAgentPrompt_E2E(t *testing.T) {
+	body := "Repo: {{.Repo}}\nIssue: #{{.Issue.Number}}"
+	task := &TaskContext{Repo: "octo/x", Issue: IssueContext{Number: 7}}
+	task.SetWorkflowState("developing", "status:developing", map[string]string{
+		"status:reviewing": "reviewing",
+	})
+	got, err := RenderAgentPrompt(body, task)
+	if err != nil {
+		t.Fatalf("RenderAgentPrompt: %v", err)
+	}
+	if !strings.Contains(got, "Repo: octo/x") {
+		t.Fatalf("rendered prompt missing repo line:\n%s", got)
+	}
+	if !strings.Contains(got, "## Transition") {
+		t.Fatalf("rendered prompt missing transition footer:\n%s", got)
+	}
+	if !strings.Contains(got, "gh issue edit 7 --repo octo/x") {
+		t.Fatalf("rendered prompt missing rendered gh command:\n%s", got)
+	}
+}

--- a/internal/runtime/process.go
+++ b/internal/runtime/process.go
@@ -127,7 +127,7 @@ func (s *ProcessSession) Run(ctx context.Context, events chan<- launcherevents.E
 
 func (s *ProcessSession) BuildCommand(execCtx context.Context) (*exec.Cmd, error) {
 	if IsClaudeRuntime(s.RuntimeName) && strings.TrimSpace(s.Agent.Prompt) != "" {
-		prompt, err := RenderCommandRaw(s.Agent.Prompt, s.Task)
+		prompt, err := RenderAgentPrompt(s.Agent.Prompt, s.Task)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/runtime/template.go
+++ b/internal/runtime/template.go
@@ -76,6 +76,36 @@ func RenderCommandRaw(cmdTemplate string, task *TaskContext) (string, error) {
 	return buf.String(), nil
 }
 
+// AssembleAgentPrompt combines the agent's prompt body with the runtime-
+// generated transition footer (from the workflow state metadata attached to
+// task) and returns the unrendered template string. Callers that want the
+// final rendered prompt should follow up with RenderCommandRaw or
+// RenderCommand on the result.
+//
+// When task carries no workflow-state metadata, or the state is terminal
+// (no outgoing transitions), the body is returned unchanged. The combined
+// output preserves the body's leading content and appends the footer with a
+// single blank line of separation, matching AssemblePrompt.
+func AssembleAgentPrompt(promptBody string, task *TaskContext) string {
+	if task == nil {
+		return promptBody
+	}
+	enterLabel, transitions := task.WorkflowStateMetadata()
+	footer := BuildTransitionFooter(task.WorkflowStateName(), enterLabel, transitions)
+	return AssemblePrompt(promptBody, footer)
+}
+
+// RenderAgentPrompt is a convenience wrapper that assembles body+footer and
+// renders the result against task. Used at dispatch boundaries that send the
+// rendered prompt directly to a runtime adapter (claude / codex bridge).
+func RenderAgentPrompt(promptBody string, task *TaskContext) (string, error) {
+	combined := AssembleAgentPrompt(promptBody, task)
+	if strings.TrimSpace(combined) == "" {
+		return "", nil
+	}
+	return RenderCommandRaw(combined, task)
+}
+
 var promptPattern = regexp.MustCompile(`^claude\s+.*-p\s+["']`)
 
 func ExtractPrompt(rendered string) (prompt string, extraArgs []string, ok bool) {

--- a/internal/runtime/types.go
+++ b/internal/runtime/types.go
@@ -75,6 +75,24 @@ type TaskContext struct {
 	RelatedPRs     []PRSummary
 	RelatedPRsText string
 	sessionHandle  *ManagedSession
+
+	// stateName / state carry the workflow state metadata used to synthesize
+	// the transition footer that is appended to the agent prompt at dispatch
+	// (issue #204 batch 3). They are intentionally unexported so they do not
+	// appear in the TaskContext schema and cannot be referenced directly from
+	// agent prompt templates as `{{.State…}}` — the footer is the only way
+	// state metadata leaks into the rendered prompt.
+	stateName string
+	state     *stateMetadata
+}
+
+// stateMetadata mirrors the subset of *config.State that the footer renderer
+// needs. Storing only the values (rather than the pointer to config.State)
+// keeps the runtime package free of a circular dependency on internal/config
+// for TaskContext, while still letting the Preparer attach the data once.
+type stateMetadata struct {
+	EnterLabel  string
+	Transitions map[string]string
 }
 
 type IssueContext struct {
@@ -128,6 +146,49 @@ func (t *TaskContext) SetSessionHandle(handle *ManagedSession) {
 		return
 	}
 	t.sessionHandle = handle
+}
+
+// SetWorkflowState attaches workflow-state metadata used by the runtime to
+// build the transition footer appended to the agent prompt. Pass an empty
+// stateName and nil transitions to clear it.
+//
+// The runtime package owns this seam intentionally so internal/config is not
+// imported into TaskContext directly.
+func (t *TaskContext) SetWorkflowState(stateName, enterLabel string, transitions map[string]string) {
+	if t == nil {
+		return
+	}
+	t.stateName = stateName
+	if stateName == "" && enterLabel == "" && len(transitions) == 0 {
+		t.state = nil
+		return
+	}
+	cloned := make(map[string]string, len(transitions))
+	for k, v := range transitions {
+		cloned[k] = v
+	}
+	t.state = &stateMetadata{EnterLabel: enterLabel, Transitions: cloned}
+}
+
+// WorkflowStateName returns the workflow state attached via SetWorkflowState.
+func (t *TaskContext) WorkflowStateName() string {
+	if t == nil {
+		return ""
+	}
+	return t.stateName
+}
+
+// WorkflowStateMetadata returns the enter_label and transitions attached via
+// SetWorkflowState. The returned map is a defensive copy.
+func (t *TaskContext) WorkflowStateMetadata() (enterLabel string, transitions map[string]string) {
+	if t == nil || t.state == nil {
+		return "", nil
+	}
+	cloned := make(map[string]string, len(t.state.Transitions))
+	for k, v := range t.state.Transitions {
+		cloned[k] = v
+	}
+	return t.state.EnterLabel, cloned
 }
 
 type SessionRef struct {

--- a/internal/taskprep/taskprep.go
+++ b/internal/taskprep/taskprep.go
@@ -54,6 +54,11 @@ type Decision struct {
 	Agent     *config.AgentConfig
 	Workflow  string
 	State     string
+	// StateDef is the workflow state object, attached so the preparer can
+	// synthesize the transition footer (issue #204 batch 3) without reaching
+	// back into the state-machine. May be nil for legacy callers; the
+	// preparer treats a nil StateDef as "no footer".
+	StateDef *config.State
 }
 
 // TaskStore is the narrow persistence surface the preparer needs.
@@ -171,6 +176,14 @@ func (p *Preparer) Prepare(ctx context.Context, d Decision) error {
 		Session: runtimepkg.SessionContext{
 			ID: fmt.Sprintf("session-%s-%s", taskID, uuid.New().String()[:8]),
 		},
+	}
+	// Attach workflow-state metadata so the runtime can synthesize the
+	// transition footer at prompt-render time. Terminal / nil states result
+	// in no footer (BuildTransitionFooter returns "").
+	if d.StateDef != nil {
+		taskCtx.SetWorkflowState(d.State, d.StateDef.EnterLabel, d.StateDef.Transitions)
+	} else {
+		taskCtx.SetWorkflowState(d.State, "", nil)
 	}
 
 	task := WorkerTask{

--- a/internal/taskprep/taskprep_test.go
+++ b/internal/taskprep/taskprep_test.go
@@ -186,6 +186,55 @@ func TestPreparer_DispatchUsesBaseRepoRootAndWorkDir(t *testing.T) {
 	}
 }
 
+// TestPreparer_AttachesWorkflowStateMetadata verifies that the Decision's
+// StateDef (the *config.State pointer the router looks up) is propagated
+// onto the dispatched WorkerTask's TaskContext via SetWorkflowState. This
+// is the wiring that drives the runtime-injected transition footer (issue
+// #204 batch 3).
+func TestPreparer_AttachesWorkflowStateMetadata(t *testing.T) {
+	st := newTestStore(t)
+	repoRoot := initGitRepo(t)
+	taskCh := make(chan WorkerTask, 1)
+	p := NewPreparer(st, repoRoot, taskCh, true)
+	p.SetIssueDataReader(fakeReader{})
+
+	agent := &config.AgentConfig{Name: "dev-agent", Role: "dev", Runtime: "claude-code", Command: "echo"}
+	state := &config.State{
+		EnterLabel: "status:developing",
+		Transitions: map[string]string{
+			"status:reviewing": "reviewing",
+			"status:blocked":   "blocked",
+		},
+	}
+	d := newDecision(agent, 99)
+	d.StateDef = state
+	if err := p.Prepare(context.Background(), d); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	select {
+	case task := <-taskCh:
+		if task.Context == nil {
+			t.Fatal("expected dispatched task context")
+		}
+		if got := task.Context.WorkflowStateName(); got != "developing" {
+			t.Fatalf("WorkflowStateName = %q, want %q", got, "developing")
+		}
+		enterLabel, transitions := task.Context.WorkflowStateMetadata()
+		if enterLabel != "status:developing" {
+			t.Fatalf("enterLabel = %q, want %q", enterLabel, "status:developing")
+		}
+		if len(transitions) != 2 {
+			t.Fatalf("transitions = %v, want 2 entries", transitions)
+		}
+		if transitions["status:reviewing"] != "reviewing" || transitions["status:blocked"] != "blocked" {
+			t.Fatalf("transitions = %v, want reviewing/blocked targets", transitions)
+		}
+	default:
+		t.Fatal("expected dispatched task")
+	}
+}
+
 func TestPreparer_NilAgentReturnsError(t *testing.T) {
 	st := newTestStore(t)
 	p := NewPreparer(st, t.TempDir(), nil, false)

--- a/internal/validate/lint_check.go
+++ b/internal/validate/lint_check.go
@@ -1,0 +1,141 @@
+package validate
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// L-layer diagnostic codes ("lint") flag drift between content and control
+// flow introduced in issue #204 batch 3. These are warnings — they fire on
+// `workbuddy validate` but only fail the exit code under `--strict`.
+const (
+	// CodeAgentPromptInlinesGhEdit — the agent prompt body contains the
+	// literal substring `gh issue edit`. Label transitions are now footer-
+	// injected by the runtime (BuildTransitionFooter); embedding the same
+	// command in the prompt body duplicates intent and causes drift when the
+	// workflow's transitions map is updated.
+	CodeAgentPromptInlinesGhEdit = "WB-L001"
+
+	// CodeAgentPromptInlinesStatusLabel — the agent prompt body contains a
+	// `status:<word>` literal. Status labels live exclusively in the
+	// workflow's transitions map; the footer surfaces them at dispatch time.
+	CodeAgentPromptInlinesStatusLabel = "WB-L002"
+
+	// CodeWorkflowProseTemplateExpr — the workflow markdown body, outside
+	// the fenced `states:` YAML block, contains a `{{.X}}` Go template
+	// expression. Workflow prose is documentation, not a prompt template;
+	// `{{...}}` will not be evaluated and is almost always a copy/paste from
+	// an agent prompt.
+	CodeWorkflowProseTemplateExpr = "WB-L003"
+)
+
+// statusLabelPattern matches `status:<token>` anywhere in text — used by
+// WB-L002. The trailing token must contain at least one non-whitespace, non-
+// punctuation character; we keep this lenient (e.g. `status:reviewing`,
+// `status:blocked`, `status:done`) and let the message clarify why it fired.
+var statusLabelPattern = regexp.MustCompile(`status:[A-Za-z][A-Za-z0-9_-]*`)
+
+// templateExprPattern matches `{{ .Field }}` style Go template expressions.
+// We require the leading `.` so we don't false-positive on `{{`-style
+// shorthand used in unrelated documentation (e.g. shell parameter expansion
+// like `${{ ... }}` is excluded by the literal `{{.`).
+var templateExprPattern = regexp.MustCompile(`\{\{\s*\.[A-Za-z_]`)
+
+// validateAgentPromptLint runs WB-L001 / WB-L002 against an agent prompt body.
+//
+// Both checks are pure substring scans — code fences inside the prompt are
+// NOT excluded, since agents commonly hide the offending example commands in
+// fences and then accidentally rely on them. We lean toward false positives
+// over false negatives; the diagnostic message documents the rule.
+func validateAgentPromptLint(agent *agentDoc) []Diagnostic {
+	if agent == nil {
+		return nil
+	}
+	if strings.TrimSpace(agent.Prompt) == "" {
+		return nil
+	}
+
+	var diags []Diagnostic
+	lines := strings.Split(agent.Prompt, "\n")
+
+	// WB-L001 — `gh issue edit` literal anywhere in the body.
+	for i, line := range lines {
+		if strings.Contains(line, "gh issue edit") {
+			diags = append(diags, Diagnostic{
+				Path:     agent.Path,
+				Line:     promptLineFor(agent.PromptLine, i+1),
+				Severity: SeverityWarning,
+				Code:     CodeAgentPromptInlinesGhEdit,
+				Message: fmt.Sprintf(
+					"agent %q prompt body contains literal %q; label transitions are now injected by the runtime as a footer (issue #204 batch 3) — remove the inline command",
+					agent.Name, "gh issue edit",
+				),
+			})
+			break // one diagnostic per agent is enough; the cleanup is structural.
+		}
+	}
+
+	// WB-L002 — `status:<word>` literal anywhere in the body. We only fire
+	// once per agent so the diagnostic list stays readable; the message
+	// names the first offending match.
+	for i, line := range lines {
+		match := statusLabelPattern.FindString(line)
+		if match == "" {
+			continue
+		}
+		diags = append(diags, Diagnostic{
+			Path:     agent.Path,
+			Line:     promptLineFor(agent.PromptLine, i+1),
+			Severity: SeverityWarning,
+			Code:     CodeAgentPromptInlinesStatusLabel,
+			Message: fmt.Sprintf(
+				"agent %q prompt body contains the label literal %q; status labels live in the workflow's transitions map and are surfaced at dispatch by the footer (issue #204 batch 3) — remove the inline label reference",
+				agent.Name, match,
+			),
+		})
+		break
+	}
+
+	return diags
+}
+
+// validateWorkflowProseLint runs WB-L003 against a workflow markdown body.
+// We scan every line of the body that is NOT inside the fenced `states:`
+// YAML block; matching `{{.X}}` patterns are reported once per line.
+func validateWorkflowProseLint(wf *workflowDoc) []Diagnostic {
+	if wf == nil || wf.Body == "" {
+		return nil
+	}
+	bodyLines := strings.Split(wf.Body, "\n")
+	yamlStart := wf.StatesYAMLStartLine
+	yamlEnd := wf.StatesYAMLEndLine
+
+	var diags []Diagnostic
+	for i, line := range bodyLines {
+		absLine := wf.BodyStartLine + i
+		if yamlStart > 0 && yamlEnd >= yamlStart {
+			// The fenced YAML block runs from yamlStart to yamlEnd inclusive;
+			// the opening ```yaml fence is at yamlStart - 1. Skip the entire
+			// fenced range so authors can write `{{.X}}` examples inside the
+			// workflow's structured YAML without tripping the lint.
+			if absLine >= yamlStart-1 && absLine <= yamlEnd {
+				continue
+			}
+		}
+		if !templateExprPattern.MatchString(line) {
+			continue
+		}
+		diags = append(diags, Diagnostic{
+			Path:     wf.Path,
+			Line:     absLine,
+			Severity: SeverityWarning,
+			Code:     CodeWorkflowProseTemplateExpr,
+			Message: fmt.Sprintf(
+				"workflow %q prose contains a Go-template expression (%q); workflow markdown is documentation, not a prompt template — agents only render `{{.X}}` from agent prompt bodies",
+				wf.Name, strings.TrimSpace(templateExprPattern.FindString(line)),
+			),
+		})
+	}
+	return diags
+}

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -122,6 +122,18 @@ type workflowDoc struct {
 	NameLine   int
 	StateOrder []string
 	States     map[string]*stateDoc
+	// Body is the markdown body (everything after the closing frontmatter
+	// `---`), preserved for diagnostics that need to scan documentation
+	// prose (e.g. WB-L003).
+	Body string
+	// BodyStartLine is the absolute file line where Body begins (1-based).
+	BodyStartLine int
+	// StatesYAMLStartLine and StatesYAMLEndLine are the absolute file line
+	// numbers (1-based, inclusive) of the embedded ```yaml states: ... ```
+	// fenced block. Used by lint passes that need to skip the structured
+	// YAML when scanning workflow prose.
+	StatesYAMLStartLine int
+	StatesYAMLEndLine   int
 }
 
 type stateDoc struct {
@@ -255,6 +267,15 @@ func ValidateDirWithOptions(configDir string, opts Options) ([]Diagnostic, error
 
 	// Layer 4 — semantic / cross-knob consistency (WB-S001..S004).
 	diags = append(diags, validateSemantics(configDir, agents, workflows, semanticsOptions(opts))...)
+
+	// Layer L — content/control-flow drift lint (WB-L001..L003). All
+	// warnings; default exit 0, gated by --strict.
+	for _, name := range agentNames {
+		diags = append(diags, validateAgentPromptLint(agents[name])...)
+	}
+	for _, wf := range workflows {
+		diags = append(diags, validateWorkflowProseLint(wf)...)
+	}
 
 	sort.Slice(diags, func(i, j int) bool {
 		a := diags[i]
@@ -461,7 +482,7 @@ func parseWorkflowFile(path string) (*workflowDoc, []Diagnostic) {
 		return nil, []Diagnostic{{Path: path, Line: fmStartLine, Message: "empty workflow frontmatter"}}
 	}
 
-	yamlBlock, yamlStartLine, ok := firstYAMLCodeBlock(body, bodyStartLine)
+	yamlBlock, yamlStartLine, yamlEndLine, ok := firstYAMLCodeBlockBounded(body, bodyStartLine)
 	if !ok {
 		return nil, []Diagnostic{{Path: path, Line: bodyStartLine, Message: "missing workflow states yaml block"}}
 	}
@@ -476,8 +497,12 @@ func parseWorkflowFile(path string) (*workflowDoc, []Diagnostic) {
 
 	root := frontmatter.Content[0]
 	workflow := &workflowDoc{
-		Path:   path,
-		States: make(map[string]*stateDoc),
+		Path:                path,
+		States:              make(map[string]*stateDoc),
+		Body:                body,
+		BodyStartLine:       bodyStartLine,
+		StatesYAMLStartLine: yamlStartLine,
+		StatesYAMLEndLine:   yamlEndLine,
 	}
 	workflow.Name, workflow.NameLine = scalarValue(root, "name", fmStartLine)
 
@@ -620,6 +645,14 @@ func splitFrontmatter(content string) (frontmatter string, body string, fmStartL
 }
 
 func firstYAMLCodeBlock(body string, bodyStartLine int) (string, int, bool) {
+	block, startLine, _, ok := firstYAMLCodeBlockBounded(body, bodyStartLine)
+	return block, startLine, ok
+}
+
+// firstYAMLCodeBlockBounded behaves like firstYAMLCodeBlock but also returns
+// the absolute file line of the closing ``` fence (inclusive). Used by lint
+// passes that need to skip the YAML block when scanning workflow prose.
+func firstYAMLCodeBlockBounded(body string, bodyStartLine int) (string, int, int, bool) {
 	lines := strings.Split(body, "\n")
 	for i := 0; i < len(lines); i++ {
 		if strings.TrimSpace(lines[i]) != "```yaml" {
@@ -627,12 +660,12 @@ func firstYAMLCodeBlock(body string, bodyStartLine int) (string, int, bool) {
 		}
 		for j := i + 1; j < len(lines); j++ {
 			if strings.TrimSpace(lines[j]) == "```" {
-				return strings.Join(lines[i+1:j], "\n"), bodyStartLine + i + 1, true
+				return strings.Join(lines[i+1:j], "\n"), bodyStartLine + i + 1, bodyStartLine + j, true
 			}
 		}
-		return "", bodyStartLine + i, false
+		return "", bodyStartLine + i, 0, false
 	}
-	return "", 0, false
+	return "", 0, 0, false
 }
 
 func scalarValue(node *yaml.Node, key string, baseLine int) (string, int) {

--- a/internal/validate/validate_codes_test.go
+++ b/internal/validate/validate_codes_test.go
@@ -224,6 +224,54 @@ func TestValidateDir_CodeFixtures(t *testing.T) {
 			opts:    Options{SkipRuntimeBinaryCheck: true},
 			wantHas: CodeAgentInTerminalState,
 		},
+		{
+			name: "WB-L001 prompt body inlines gh issue edit",
+			files: map[string]string{
+				"config.yaml": "repo: octo/x\n",
+				"agents/dev-agent.md": fixtureAgent(
+					"dev-agent", "developing", "dev", "claude-code",
+					"Repo: {{.Repo}}\nWhen finished, run `gh issue edit 1 --add-label foo`.",
+				),
+				"workflows/default.md": fixtureWorkflow(map[string]workflowState{
+					"developing": {EnterLabel: "status:developing", Agent: "dev-agent", Transitions: []string{"reviewing"}},
+					"reviewing":  {EnterLabel: "status:reviewing"},
+				}),
+			},
+			opts:    Options{SkipRuntimeBinaryCheck: true},
+			wantHas: CodeAgentPromptInlinesGhEdit,
+		},
+		{
+			name: "WB-L002 prompt body inlines status: label",
+			files: map[string]string{
+				"config.yaml": "repo: octo/x\n",
+				"agents/dev-agent.md": fixtureAgent(
+					"dev-agent", "developing", "dev", "claude-code",
+					"Repo: {{.Repo}}\nIf the criterion fails, set status:blocked and stop.",
+				),
+				"workflows/default.md": fixtureWorkflow(map[string]workflowState{
+					"developing": {EnterLabel: "status:developing", Agent: "dev-agent", Transitions: []string{"reviewing"}},
+					"reviewing":  {EnterLabel: "status:reviewing"},
+				}),
+			},
+			opts:    Options{SkipRuntimeBinaryCheck: true},
+			wantHas: CodeAgentPromptInlinesStatusLabel,
+		},
+		{
+			name: "WB-L003 workflow prose contains template expression",
+			files: map[string]string{
+				"config.yaml":         "repo: octo/x\n",
+				"agents/dev-agent.md": fixtureAgent("dev-agent", "developing", "dev", "claude-code", "Repo: {{.Repo}}"),
+				"workflows/default.md": fixtureWorkflowWithProse(
+					map[string]workflowState{
+						"developing": {EnterLabel: "status:developing", Agent: "dev-agent", Transitions: []string{"reviewing"}},
+						"reviewing":  {EnterLabel: "status:reviewing"},
+					},
+					"\nIssue {{.Issue.Number}} flows through this graph.\n",
+				),
+			},
+			opts:    Options{SkipRuntimeBinaryCheck: true},
+			wantHas: CodeWorkflowProseTemplateExpr,
+		},
 	}
 
 	for _, tc := range cases {
@@ -455,6 +503,26 @@ type orderedState struct {
 // helper synthesises the driving label as `status:<target>` so the tests
 // remain compact.
 func fixtureOrderedWorkflow(states []orderedState) string {
+	return fixtureOrderedWorkflowWithTrailing(states, "")
+}
+
+// fixtureWorkflowWithProse appends `trailing` text after the closing fence
+// of the states YAML block — used by lint cases (WB-L003) that need to put
+// arbitrary prose into the workflow body.
+func fixtureWorkflowWithProse(states map[string]workflowState, trailing string) string {
+	names := make([]string, 0, len(states))
+	for n := range states {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	ordered := make([]orderedState, 0, len(states))
+	for _, n := range names {
+		ordered = append(ordered, orderedState{Name: n, State: states[n]})
+	}
+	return fixtureOrderedWorkflowWithTrailing(ordered, trailing)
+}
+
+func fixtureOrderedWorkflowWithTrailing(states []orderedState, trailing string) string {
 	var b strings.Builder
 	b.WriteString("---\nname: default\ndescription: t\ntrigger:\n  issue_label: \"workbuddy\"\n---\n## W\n\n```yaml\nstates:\n")
 	for _, item := range states {
@@ -473,6 +541,9 @@ func fixtureOrderedWorkflow(states []orderedState) string {
 		}
 	}
 	b.WriteString("```\n")
+	if trailing != "" {
+		b.WriteString(trailing)
+	}
 	return b.String()
 }
 

--- a/internal/worker/distributed.go
+++ b/internal/worker/distributed.go
@@ -111,6 +111,19 @@ func (w *DistributedWorker) ExecuteTask(ctx context.Context, task *workerclient.
 	}
 
 	launchCtx := BuildRemoteTaskContext(task, w.deps.Reader, w.deps.WorkDir)
+	// Attach workflow-state metadata so the runtime can synthesize the
+	// transition footer at prompt-render time. The remote Task does not carry
+	// the State definition over the wire, so the worker resolves it locally
+	// from its own config (issue #204 batch 3).
+	if w.deps.Config != nil {
+		if wf, ok := w.deps.Config.Workflows[task.Workflow]; ok && wf != nil {
+			if state, ok := wf.States[task.State]; ok && state != nil {
+				launchCtx.SetWorkflowState(task.State, state.EnterLabel, state.Transitions)
+			} else {
+				launchCtx.SetWorkflowState(task.State, "", nil)
+			}
+		}
+	}
 	sessionID := launchCtx.Session.ID
 
 	taskCtx, taskCancel := context.WithCancel(ctx)

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -2612,3 +2612,100 @@ requirements:
       - internal/validate/validate_codes_test.go
     deps: [REQ-072, REQ-076]
 
+  - id: REQ-081
+    title: Workflow-injected transition footer in agent prompts
+    description: >
+      Issue #204 batch 3: at dispatch time the runtime synthesizes a
+      "Transition" footer from the workflow state's transitions map and
+      appends it to the agent prompt body. The combined string is rendered
+      as a single Go text/template against TaskContext so footer lines such
+      as `gh issue edit {{.Issue.Number}} --repo {{.Repo}}` resolve
+      correctly. Terminal states (no transitions) inject no footer. State
+      metadata travels via Decision.StateDef into the Preparer (and the
+      remote-task path through worker.distributed.BuildRemoteTaskContext +
+      a workflow lookup on the worker's local config) and is attached to
+      TaskContext through SetWorkflowState so the runtime can read it back
+      via WorkflowStateMetadata. The body+footer assembly happens in
+      runtime.AssembleAgentPrompt / runtime.RenderAgentPrompt; the existing
+      ProcessSession.BuildCommand and runtime.resolvePrompt call sites are
+      the only injection points.
+    priority: P1
+    version: v0.5.0
+    status: tested
+    acceptance_criteria:
+      - "AC-081-1: Non-terminal states emit a deterministic footer with rows sorted by label"
+      - "AC-081-2: Terminal states (empty transitions map) emit no footer"
+      - "AC-081-3: The combined body+footer template parses + executes against TaskContext"
+      - "AC-081-4: Workflow state metadata reaches both the embedded preparer path and the distributed worker path"
+    code:
+      - internal/runtime/footer.go
+      - internal/runtime/template.go
+      - internal/runtime/types.go
+      - internal/runtime/process.go
+      - internal/runtime/agent_bridge.go
+      - internal/router/router.go
+      - internal/taskprep/taskprep.go
+      - internal/worker/distributed.go
+      - cmd/serve.go
+      - internal/app/repo_runtime.go
+    tests:
+      - internal/runtime/footer_test.go
+    deps: [REQ-076, REQ-079]
+
+  - id: REQ-082
+    title: L-layer lint for content vs control-flow drift (WB-L001/L002/L003)
+    description: >
+      Three new validator diagnostic codes (warnings, gated by --strict)
+      that catch agent/workflow files which still embed control-flow
+      details that now belong to the runtime-injected footer or the
+      workflow's transitions map. WB-L001 fires when the agent prompt body
+      contains the literal `gh issue edit`. WB-L002 fires when the agent
+      prompt body contains a `status:<word>` label literal. WB-L003 fires
+      when the workflow markdown body — outside the fenced `states:` YAML
+      block — contains a `{{.X}}` Go-template-style expression. Each is
+      SeverityWarning so default `workbuddy validate` exits 0; passing
+      `--strict` upgrades them to failures.
+    priority: P1
+    version: v0.5.0
+    status: tested
+    acceptance_criteria:
+      - "AC-082-1: WB-L001 fires on agent body containing `gh issue edit`"
+      - "AC-082-2: WB-L002 fires on agent body containing `status:<token>`"
+      - "AC-082-3: WB-L003 fires on workflow prose with `{{.Field}}` outside the YAML block"
+      - "AC-082-4: All three codes are tagged SeverityWarning so default validate exits 0"
+      - "AC-082-5: --strict promotes the warnings to a non-zero exit"
+    code:
+      - internal/validate/lint_check.go
+      - internal/validate/validate.go
+    tests:
+      - internal/validate/validate_codes_test.go
+    deps: [REQ-076, REQ-081]
+
+  - id: REQ-083
+    title: Agent prompt fixture migration to footer-injected layout
+    description: >
+      The repo's own agent fixtures and the cmd/initdata/agents copies are
+      migrated to the batch-3 layout: prompt prose owns the semantic
+      decision ("transition to the blocked outcome / reviewing outcome /
+      pass / fail") and references a "Transition footer below"; literal
+      label values and `gh issue edit` commands are removed. After
+      migration, `workbuddy validate --strict` against the repo's own
+      .github/workbuddy directory exits 0 with no WB-L001 or WB-L002
+      warnings, demonstrating the lint+fixture pair shipping together.
+    priority: P1
+    version: v0.5.0
+    status: tested
+    acceptance_criteria:
+      - "AC-083-1: .github/workbuddy/agents/dev-agent.md no longer mentions `gh issue edit` or `status:*` labels"
+      - "AC-083-2: .github/workbuddy/agents/review-agent.md no longer mentions `gh issue edit` or `status:*` labels"
+      - "AC-083-3: cmd/initdata/agents/{dev,review}-agent.md mirror the same migration so `workbuddy init` produces footer-friendly prompts"
+      - "AC-083-4: workbuddy validate --strict --config-dir .github/workbuddy exits 0"
+    code:
+      - .github/workbuddy/agents/dev-agent.md
+      - .github/workbuddy/agents/review-agent.md
+      - cmd/initdata/agents/dev-agent.md
+      - cmd/initdata/agents/review-agent.md
+    tests:
+      - internal/validate/validate_codes_test.go
+    deps: [REQ-081, REQ-082]
+

--- a/schemas/agent.schema.json
+++ b/schemas/agent.schema.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/Lincyaw/workbuddy/schemas/agent.schema.json",
-  "title": "Workbuddy Agent (Batch 2 — issue #204)",
-  "description": "Schema for the YAML frontmatter of .github/workbuddy/agents/*.md. The Markdown body below the closing `---` IS the prompt template (rendered as a Go text/template against runtime.TaskContext). Frontmatter no longer accepts `prompt:`. Keep this in sync with internal/config/types.go (AgentConfig).",
-  "$comment": "Batch 2 hard-cut: `prompt:` is removed; `context:` is required and lists every TaskContext field path the prompt body references; `triggers[].state:` references workflow state names symbolically (not raw labels).",
+  "title": "Workbuddy Agent (Batch 3 — issue #204)",
+  "description": "Schema for the YAML frontmatter of .github/workbuddy/agents/*.md. The Markdown body below the closing `---` IS the prompt template (rendered as a Go text/template against runtime.TaskContext). Frontmatter no longer accepts `prompt:`. As of batch 3, label-flip instructions (the `gh issue edit` command and the available `status:*` outcomes) are NOT authored in the prompt body — the runtime injects them automatically as a transition footer derived from the workflow state's transitions map. Linter codes WB-L001/WB-L002 fire when the body still inlines `gh issue edit` or a `status:` literal. Keep this in sync with internal/config/types.go (AgentConfig).",
+  "$comment": "Batch 3: transition footer is runtime-generated from the workflow state's transitions map and appended to the prompt body at dispatch. The prompt body should describe the agent's job in prose; do not embed the gh issue edit command or status:* labels manually.",
   "type": "object",
   "additionalProperties": false,
   "required": ["name", "description", "triggers", "role", "runtime", "context", "policy"],

--- a/schemas/workflow.schema.json
+++ b/schemas/workflow.schema.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/Lincyaw/workbuddy/schemas/workflow.schema.json",
-  "title": "Workbuddy Workflow (Batch 2 — issue #204)",
-  "description": "Schema for the YAML frontmatter of .github/workbuddy/workflows/*.md. The state machine itself lives in a fenced ```yaml code block in the Markdown body and is parsed by the loader, not this schema (see $comment). Keep this in sync with internal/config/types.go (WorkflowConfig).",
-  "$comment": "Batch 2 hard-cut: state transitions are now a `label → target_state_name` map (e.g. `\"status:reviewing\": reviewing`), not a list of `{to, when}` entries. JSON Schema cannot validate content embedded in a Markdown code block; the Go validator enforces it (codes WB-X001/X005/S004 etc.). Editor integrations get coverage of the frontmatter only.",
+  "title": "Workbuddy Workflow (Batch 3 — issue #204)",
+  "description": "Schema for the YAML frontmatter of .github/workbuddy/workflows/*.md. The state machine itself lives in a fenced ```yaml code block in the Markdown body and is parsed by the loader, not this schema (see $comment). As of batch 3, the runtime synthesizes the agent prompt's transition footer from each state's transitions map; agent prompt bodies no longer author label-flip instructions. Workflow markdown OUTSIDE the fenced YAML block is plain documentation — Go template expressions like {{.Issue.Number}} are NOT evaluated and will trip linter code WB-L003. Keep this in sync with internal/config/types.go (WorkflowConfig).",
+  "$comment": "Batch 3: transitions stay as `label → target_state_name` (no schema change). Footer injection happens entirely at the prompt-rendering boundary in internal/runtime; workflows do not declare a custom footer template. JSON Schema cannot validate content embedded in a Markdown code block; the Go validator enforces it (codes WB-X001/X005/S004 etc.) and the L-layer lint covers prose drift (WB-L003).",
   "type": "object",
   "additionalProperties": false,
   "required": ["name", "description", "trigger", "max_retries"],


### PR DESCRIPTION
## Summary

This is the **FINAL batch** of issue #204. It closes the loop on content vs control-flow separation:

- The **runtime** now synthesizes a "Transition" footer from the workflow state's `transitions` map and appends it to the agent prompt body at dispatch. Body+footer render together as a single Go template so footer lines like `gh issue edit {{.Issue.Number}} --repo {{.Repo}}` resolve against the same `TaskContext`. Terminal states inject no footer.
- **Agent prompt fixtures** (`.github/workbuddy/agents/{dev,review}-agent.md` and the `cmd/initdata` copies) are migrated: literal `gh issue edit` commands and `status:*` labels are removed; the semantic prose now points at the runtime-injected "Transition footer below".
- **Three new lint codes** (warnings, gated by `--strict`):
  - **WB-L001** — agent prompt body contains the literal `gh issue edit`.
  - **WB-L002** — agent prompt body contains a `status:<token>` label literal.
  - **WB-L003** — workflow markdown body, *outside* the fenced `states:` YAML block, contains a `{{.X}}` Go-template expression.
- **No schema change** — `transitions` stays `map[string]string` (label → target_state). Schema files only get description / `$comment` refreshes pointing readers at the new footer behaviour.

After fixture cleanup, `./workbuddy validate --strict --config-dir .github/workbuddy` exits 0 with no WB-L warnings on the repo's own config.

State metadata is threaded statemachine → DispatchRequest → router.Decision → taskprep.Preparer → `TaskContext.SetWorkflowState`. The remote-worker path resolves the state from its own local config (the wire payload `workerclient.Task` is unchanged).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1`
- [x] `python3 ~/.autoharness/scripts/validate_index.py project-index.yaml`
- [x] `./workbuddy validate --strict --config-dir .github/workbuddy` exit 0
- [x] Footer for the `developing` state byte-pinned in `internal/runtime/footer_test.go`
- [x] Combined body+footer parses + executes against `TaskContext` (`TestAssembleAgentPrompt_RenderableTemplate`)
- [x] Router attaches `StateDef` when `SetWorkflows` is wired and stays `nil` otherwise (back-compat)
- [x] Preparer propagates state metadata onto the dispatched `WorkerTask`'s `TaskContext`
- [x] WB-L001/L002/L003 fire on the expected fixtures and stay quiet on the migrated repo config

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)