### PR TITLE
Add dev↔review cycle cap + long-flight stuck detector (#214)

### DIFF
--- a/.github/workbuddy/workflows/default.md
+++ b/.github/workbuddy/workflows/default.md
@@ -4,6 +4,7 @@ description: Default 2-agent lifecycle for any workbuddy-tracked issue
 trigger:
   issue_label: "workbuddy"
 max_retries: 3
+max_review_cycles: 3
 ---
 
 ## Default Workflow
@@ -49,6 +50,16 @@ states:
 
 `failed` 仍然是 workflow schema 中可识别的终态 label，但当前 Go runtime 不会在 retry 超限时直接写入
 `status:failed` 或 `needs-human`；它只记录 retry/failure intent，后续 label 写回仍由 agent 或人工执行。
+
+`max_review_cycles` (default 3) caps the orchestrator-level dev↔review
+round-trip count: every developing→reviewing→developing increment counts as
+one cycle. On cap-hit the Coordinator stops dispatching `dev-agent` and
+`review-agent`, posts a needs-human comment with a rejection-trail digest
+(assembled from existing `completed` events — no agent re-invocation), and
+emits a `dev_review_cycle_cap_reached` event + alert. A heads-up alert fires
+when `cycles == max_review_cycles - 1` so an operator can intervene
+preemptively. Use `workbuddy issue restart` to clear the counter after human
+intervention.
 
 `status:done` is the post-merge terminal label; the review-agent (or the human
 who merged the PR) is responsible for closing the issue. The state machine

--- a/.github/workbuddy/workflows/default.md
+++ b/.github/workbuddy/workflows/default.md
@@ -58,8 +58,16 @@ one cycle. On cap-hit the Coordinator stops dispatching `dev-agent` and
 (assembled from existing `completed` events — no agent re-invocation), and
 emits a `dev_review_cycle_cap_reached` event + alert. A heads-up alert fires
 when `cycles == max_review_cycles - 1` so an operator can intervene
-preemptively. Use `workbuddy issue restart` to clear the counter after human
-intervention.
+preemptively.
+
+To resume work after a cap-hit (or any other manual block), a human flips
+`status:blocked` → `status:developing` on the issue. The Coordinator
+detects this label transition and **resets the cycle counter to zero**
+(Option A semantics: "give the agent another shot"). The
+blocked→developing transition itself does not count as a round-trip, so
+the next genuine review→developing increments to 1, not cap+1.
+`workbuddy issue restart` is still available for explicit, full-state
+restarts that also clear `first_dispatch_at` (long-flight clock).
 
 `status:done` is the post-merge terminal label; the review-agent (or the human
 who merged the PR) is responsible for closing the issue. The state machine

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,9 +69,10 @@ One runtime topology: the Worker always talks to the Coordinator over HTTP.
    - v0.2.0 target: >= 80%
    - Measure: SQLite query on events table (completed vs dispatch counts)
 
-6. **State machine correctness** — 0 issues stuck in intermediate states > 1 hour
-   - v0.2.0 target: 0 stuck issues in 24h test run
-   - Measure: `workbuddy status --stuck`
+6. **State machine correctness** — 0 issues stuck in intermediate states > 1h **and** dev↔review cycle count ≤ configured cap
+   - v0.2.0 target: 0 stuck issues in 24h test run (per-state dwell-time signal)
+   - v0.5.0 addition: per-issue `dev_review_cycle_count ≤ max_review_cycles` (default 3); cap-hit auto-stops dispatch and posts a needs-human comment
+   - Measure: `workbuddy status --stuck` surfaces both per-state dwell and long-flight (>4h) signals; `cycles=N` is rendered for any issue with `dev_review_cycle_count > 0`
 
 7. **Retry effectiveness** — % of retried issues that eventually reach done (not failed)
    - v0.2.0 target: >= 60%

--- a/cmd/admin_restart_issue.go
+++ b/cmd/admin_restart_issue.go
@@ -31,6 +31,7 @@ type restartIssueResult struct {
 	CacheCleared           bool   `json:"cache_cleared"`
 	DependencyStateCleared bool   `json:"dependency_state_cleared"`
 	ClaimCleared           bool   `json:"claim_cleared"`
+	CycleStateCleared      bool   `json:"cycle_state_cleared"`
 	ClaimOwner             string `json:"claim_owner,omitempty"`
 	EventLogged            bool   `json:"event_logged"`
 }
@@ -157,6 +158,7 @@ func runRestartIssueWithOpts(_ context.Context, opts *restartIssueOpts, stdout i
 			fmt.Sprintf("clear issue cache: %t", preview.CacheCleared),
 			fmt.Sprintf("clear dependency state: %t", preview.DependencyStateCleared),
 			fmt.Sprintf("clear issue claim: %t", preview.ClaimCleared),
+			fmt.Sprintf("clear dev↔review cycle state: %t", preview.CycleStateCleared),
 			"log issue_restarted event",
 		},
 	)
@@ -193,7 +195,7 @@ func writeRestartIssueResult(stdout io.Writer, result restartIssueResult, dryRun
 	if dryRun {
 		prefix = "dry-run: "
 	}
-	_, _ = fmt.Fprintf(stdout, "%s%s#%d: cache=%t dependency_state=%t claim=%t", prefix, result.Repo, result.IssueNum, result.CacheCleared, result.DependencyStateCleared, result.ClaimCleared)
+	_, _ = fmt.Fprintf(stdout, "%s%s#%d: cache=%t dependency_state=%t claim=%t cycle_state=%t", prefix, result.Repo, result.IssueNum, result.CacheCleared, result.DependencyStateCleared, result.ClaimCleared, result.CycleStateCleared)
 	if result.ClaimOwner != "" {
 		_, _ = fmt.Fprintf(stdout, " held_by=%s", result.ClaimOwner)
 	}
@@ -227,6 +229,14 @@ func inspectRestartIssueStore(st *store.Store, repo string, issueNum int) (resta
 		result.ClaimCleared = true
 		result.ClaimOwner = claim.WorkerID
 	}
+
+	cycleState, err := st.QueryIssueCycleState(repo, issueNum)
+	if err != nil {
+		return result, fmt.Errorf("restart-issue: query cycle state #%d: %w", issueNum, err)
+	}
+	if cycleState != nil {
+		result.CycleStateCleared = true
+	}
 	return result, nil
 }
 
@@ -253,6 +263,11 @@ func runRestartIssueStore(st *store.Store, repo string, issueNum int, source str
 		}
 		result.ClaimCleared = deletedClaim
 	}
+	if result.CycleStateCleared {
+		if err := st.ResetIssueCycleState(repo, issueNum); err != nil {
+			return result, fmt.Errorf("restart-issue: reset cycle state #%d: %w", issueNum, err)
+		}
+	}
 
 	payload, err := json.Marshal(map[string]any{
 		"repo":                     repo,
@@ -261,6 +276,7 @@ func runRestartIssueStore(st *store.Store, repo string, issueNum int, source str
 		"cache_cleared":            result.CacheCleared,
 		"dependency_state_cleared": result.DependencyStateCleared,
 		"claim_cleared":            result.ClaimCleared,
+		"cycle_state_cleared":      result.CycleStateCleared,
 		"claim_owner":              result.ClaimOwner,
 	})
 	if err != nil {

--- a/cmd/admin_restart_issue_test.go
+++ b/cmd/admin_restart_issue_test.go
@@ -110,6 +110,9 @@ func TestRunRestartIssueStoreClearsCacheClaimAndLogsEvent(t *testing.T) {
 	if !result.CacheCleared || !result.DependencyStateCleared || !result.ClaimCleared || !result.EventLogged {
 		t.Fatalf("unexpected result: %+v", result)
 	}
+	if result.CycleStateCleared {
+		t.Fatalf("CycleStateCleared = true unexpectedly: %+v", result)
+	}
 	if result.ClaimOwner != "coordinator-host-pid-123" {
 		t.Fatalf("ClaimOwner = %q", result.ClaimOwner)
 	}
@@ -128,6 +131,48 @@ func TestRunRestartIssueStoreClearsCacheClaimAndLogsEvent(t *testing.T) {
 	}
 	if latest == nil || latest.Type != eventlog.TypeIssueRestarted {
 		t.Fatalf("latest event = %+v, want %q", latest, eventlog.TypeIssueRestarted)
+	}
+}
+
+func TestRunRestartIssueStoreClearsCycleState(t *testing.T) {
+	st, err := store.NewStore(filepath.Join(t.TempDir(), "restart-cycle.db"))
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	const (
+		repo     = "owner/repo"
+		issueNum = 211
+	)
+	if err := st.UpsertIssueCache(store.IssueCache{
+		Repo:     repo,
+		IssueNum: issueNum,
+		Labels:   `["workbuddy","status:developing"]`,
+		State:    "open",
+	}); err != nil {
+		t.Fatalf("UpsertIssueCache: %v", err)
+	}
+	if _, err := st.IncrementDevReviewCycleCount(repo, issueNum); err != nil {
+		t.Fatalf("IncrementDevReviewCycleCount: %v", err)
+	}
+	if err := st.MarkIssueCycleCapHit(repo, issueNum); err != nil {
+		t.Fatalf("MarkIssueCycleCapHit: %v", err)
+	}
+
+	result, err := runRestartIssueStore(st, repo, issueNum, "test")
+	if err != nil {
+		t.Fatalf("runRestartIssueStore: %v", err)
+	}
+	if !result.CycleStateCleared {
+		t.Fatalf("CycleStateCleared = false: %+v", result)
+	}
+	state, err := st.QueryIssueCycleState(repo, issueNum)
+	if err != nil {
+		t.Fatalf("QueryIssueCycleState: %v", err)
+	}
+	if state != nil {
+		t.Fatalf("expected nil cycle state after restart, got %+v", state)
 	}
 }
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -60,13 +60,16 @@ type statusClient struct {
 }
 
 type statusIssue struct {
-	Repo              string     `json:"repo"`
-	IssueNum          int        `json:"issue_num"`
-	CurrentState      string     `json:"current_state"`
-	CycleCount        int        `json:"cycle_count"`
-	DependencyVerdict string     `json:"dependency_verdict"`
-	LastEventAt       *time.Time `json:"last_event_at,omitempty"`
-	Stuck             bool       `json:"stuck"`
+	Repo                string     `json:"repo"`
+	IssueNum            int        `json:"issue_num"`
+	CurrentState        string     `json:"current_state"`
+	CycleCount          int        `json:"cycle_count"`
+	DevReviewCycleCount int        `json:"dev_review_cycle_count"`
+	DependencyVerdict   string     `json:"dependency_verdict"`
+	LastEventAt         *time.Time `json:"last_event_at,omitempty"`
+	Stuck               bool       `json:"stuck"`
+	StuckReason         string     `json:"stuck_reason,omitempty"`
+	LongFlight          bool       `json:"long_flight"`
 }
 
 type statusResponse struct {
@@ -726,13 +729,16 @@ func runStatusSummary(ctx context.Context, opts *statusOpts, client *statusClien
 			continue
 		}
 		entry := statusIssue{
-			Repo:              issue.Repo,
-			IssueNum:          issue.IssueNum,
-			CurrentState:      issue.CurrentState,
-			CycleCount:        issue.CycleCount,
-			DependencyVerdict: issue.DependencyVerdict,
-			LastEventAt:       issue.LastEventAt,
-			Stuck:             issue.Stuck,
+			Repo:                issue.Repo,
+			IssueNum:            issue.IssueNum,
+			CurrentState:        issue.CurrentState,
+			CycleCount:          issue.CycleCount,
+			DevReviewCycleCount: issue.DevReviewCycleCount,
+			DependencyVerdict:   issue.DependencyVerdict,
+			LastEventAt:         issue.LastEventAt,
+			Stuck:               issue.Stuck,
+			StuckReason:         issue.StuckReason,
+			LongFlight:          issue.LongFlight,
 		}
 		if opts.stuck && !entry.Stuck {
 			continue
@@ -1173,16 +1179,29 @@ func renderStatusTable(w io.Writer, resp statusResponse) {
 		if issue.LastEventAt != nil {
 			lastEvent = issue.LastEventAt.UTC().Format(time.RFC3339)
 		}
+		// Render the dev↔review counter inline when > 0 so an issue cycling
+		// fast between developing and reviewing is visible at a glance.
+		// Format: "<transition_count>/cycles=N" — preserves the existing
+		// CYCLES column for transition counts and adds the new orchestrator
+		// counter without changing the column count.
+		cycles := fmt.Sprintf("%d", issue.CycleCount)
+		if issue.DevReviewCycleCount > 0 {
+			cycles = fmt.Sprintf("%d (cycles=%d)", issue.CycleCount, issue.DevReviewCycleCount)
+		}
+		stuck := fmt.Sprintf("%t", issue.Stuck)
+		if issue.Stuck && issue.StuckReason != "" {
+			stuck = fmt.Sprintf("true (%s)", issue.StuckReason)
+		}
 		_, _ = fmt.Fprintf(
 			tw,
-			"%s\t#%d\t%s\t%d\t%s\t%s\t%t\n",
+			"%s\t#%d\t%s\t%s\t%s\t%s\t%s\n",
 			issue.Repo,
 			issue.IssueNum,
 			issue.CurrentState,
-			issue.CycleCount,
+			cycles,
 			issue.DependencyVerdict,
 			lastEvent,
-			issue.Stuck,
+			stuck,
 		)
 	}
 	_ = tw.Flush()

--- a/internal/alertbus/alertbus.go
+++ b/internal/alertbus/alertbus.go
@@ -23,6 +23,9 @@ const (
 	KindRepeatedFailure        = "repeated_failure"
 	KindTaskCompletedSuccess    = "task_completed"
 	KindDispatchBlocked         = "dispatch_blocked"
+	KindDevReviewCycleApproaching = "dev_review_cycle_approaching"
+	KindDevReviewCycleCapReached  = "dev_review_cycle_cap_reached"
+	KindLongFlightStuck           = "long_flight_stuck_detected"
 )
 
 // AlertEvent is the payload emitted by system components for notification.

--- a/internal/app/cycle_cap.go
+++ b/internal/app/cycle_cap.go
@@ -1,0 +1,82 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/Lincyaw/workbuddy/internal/eventlog"
+	"github.com/Lincyaw/workbuddy/internal/reporter"
+	"github.com/Lincyaw/workbuddy/internal/statemachine"
+	"github.com/Lincyaw/workbuddy/internal/store"
+)
+
+// cycleCapReporterAdapter bridges statemachine.CycleCapReporter to the
+// production reporter.Reporter. It exists because internal/reporter must not
+// import internal/statemachine (avoids a wiring-package cycle).
+type cycleCapReporterAdapter struct {
+	rep *reporter.Reporter
+}
+
+func (a *cycleCapReporterAdapter) ReportDevReviewCycleCap(ctx context.Context, repo string, issueNum int, info statemachine.CycleCapInfo) error {
+	if a == nil || a.rep == nil {
+		return nil
+	}
+	return a.rep.ReportDevReviewCycleCap(ctx, repo, issueNum, info.WorkflowName, info.CycleCount, info.MaxReviewCycles, info.HitAt)
+}
+
+// CycleCapTrailLoader reads completed-task events for an issue and converts
+// failed/timed-out review-agent runs into a chronological digest the Reporter
+// embeds in its needs-human comment. The digest is intentionally built from
+// stored events — no agent re-invocation is required (REQ-085 AC-3).
+type cycleCapTrailLoader struct {
+	store *store.Store
+}
+
+// NewCycleCapTrailLoader builds the production trail loader bound to the
+// given store. Exposed for wiring in repo_runtime.go.
+func NewCycleCapTrailLoader(st *store.Store) reporter.CycleCapTrailLoader {
+	return &cycleCapTrailLoader{store: st}
+}
+
+func (l *cycleCapTrailLoader) LoadCycleCapTrail(_ context.Context, repo string, issueNum int) ([]reporter.CycleRejectionEntry, string, string, error) {
+	if l == nil || l.store == nil {
+		return nil, "", "", nil
+	}
+	events, err := l.store.QueryEventsFiltered(store.EventQueryFilter{
+		Repo:     repo,
+		IssueNum: issueNum,
+		Type:     eventlog.TypeCompleted,
+	})
+	if err != nil {
+		return nil, "", "", fmt.Errorf("load cycle-cap trail events: %w", err)
+	}
+	out := make([]reporter.CycleRejectionEntry, 0, len(events))
+	for _, ev := range events {
+		var payload struct {
+			AgentName string `json:"agent_name"`
+			ExitCode  int    `json:"exit_code"`
+		}
+		if strings.TrimSpace(ev.Payload) == "" {
+			continue
+		}
+		if err := json.Unmarshal([]byte(ev.Payload), &payload); err != nil {
+			continue
+		}
+		// Only review-agent failures count toward the rejection trail. A
+		// dev-agent failure is a separate signal handled by the per-agent
+		// failure cap; surfacing it here would muddy the digest.
+		if payload.AgentName != "review-agent" {
+			continue
+		}
+		if payload.ExitCode == 0 {
+			continue
+		}
+		out = append(out, reporter.CycleRejectionEntry{
+			Timestamp: ev.TS.UTC(),
+			Summary:   fmt.Sprintf("review-agent rejected (exit=%d)", payload.ExitCode),
+		})
+	}
+	return out, "", "", nil
+}

--- a/internal/app/repo_runtime.go
+++ b/internal/app/repo_runtime.go
@@ -262,6 +262,10 @@ func (pm *PollerManager) StartOrUpdate(rec store.RepoRegistrationRecord) error {
 	// The claimer id is process-scoped so two coordinators on the same host do
 	// not collapse onto the same logical owner.
 	sm.SetIssueClaim(BuildIssueClaimerID("coordinator-"+HostnameOrUnknown(), os.Getpid()), statemachine.DefaultIssueClaimLease)
+	if pm.reporter != nil {
+		pm.reporter.SetCycleCapTrailLoader(NewCycleCapTrailLoader(pm.store))
+		sm.SetCycleCapReporter(&cycleCapReporterAdapter{rep: pm.reporter})
+	}
 	depResolver := dependency.NewResolver(pm.store, pm.ghReader, pm.eventlog, pm.alertBus)
 	rt := router.NewRouter(cfg.Agents, pm.registry, pm.store, rec.Repo, pm.repoRoot, nil, nil, false)
 	rt.SetWorkflows(cfg.Workflows)

--- a/internal/audit/http.go
+++ b/internal/audit/http.go
@@ -16,7 +16,10 @@ import (
 	"github.com/Lincyaw/workbuddy/internal/store"
 )
 
-const stuckThreshold = time.Hour
+const (
+	stuckThreshold      = time.Hour
+	longFlightThreshold = 4 * time.Hour
+)
 
 type HTTPHandler struct {
 	store *store.Store
@@ -37,14 +40,18 @@ type EventsResponse struct {
 }
 
 type IssueStateResponse struct {
-	Repo              string     `json:"repo"`
-	IssueNum          int        `json:"issue_num"`
-	IssueState        string     `json:"issue_state"`
-	CurrentState      string     `json:"current_state"`
-	CycleCount        int        `json:"cycle_count"`
-	DependencyVerdict string     `json:"dependency_verdict"`
-	LastEventAt       *time.Time `json:"last_event_at,omitempty"`
-	Stuck             bool       `json:"stuck"`
+	Repo                string     `json:"repo"`
+	IssueNum            int        `json:"issue_num"`
+	IssueState          string     `json:"issue_state"`
+	CurrentState        string     `json:"current_state"`
+	CycleCount          int        `json:"cycle_count"`
+	DevReviewCycleCount int        `json:"dev_review_cycle_count"`
+	DependencyVerdict   string     `json:"dependency_verdict"`
+	LastEventAt         *time.Time `json:"last_event_at,omitempty"`
+	FirstDispatchAt     *time.Time `json:"first_dispatch_at,omitempty"`
+	Stuck               bool       `json:"stuck"`
+	StuckReason         string     `json:"stuck_reason,omitempty"`
+	LongFlight          bool       `json:"long_flight"`
 }
 
 func NewHTTPHandler(st *store.Store) *HTTPHandler {
@@ -162,6 +169,11 @@ func (h *HTTPHandler) queryIssueState(repo string, issueNum int) (IssueStateResp
 		dependencyVerdict = depState.Verdict
 	}
 
+	cycleState, err := h.store.QueryIssueCycleState(repo, issueNum)
+	if err != nil {
+		return IssueStateResponse{}, err
+	}
+
 	resp := IssueStateResponse{
 		Repo:              repo,
 		IssueNum:          issueNum,
@@ -170,11 +182,33 @@ func (h *HTTPHandler) queryIssueState(repo string, issueNum int) (IssueStateResp
 		CycleCount:        maxTransitionCount(counts),
 		DependencyVerdict: dependencyVerdict,
 	}
+	if cycleState != nil {
+		resp.DevReviewCycleCount = cycleState.DevReviewCycleCount
+		if !cycleState.FirstDispatchAt.IsZero() {
+			fd := cycleState.FirstDispatchAt
+			resp.FirstDispatchAt = &fd
+			if cache.State == "open" && isIntermediateState(currentState) && h.now().Sub(fd) > longFlightThreshold {
+				resp.LongFlight = true
+			}
+		}
+	}
+	stuckByDwell := false
 	if lastEvent != nil {
 		resp.LastEventAt = &lastEvent.TS
-		resp.Stuck = cache.State == "open" &&
+		stuckByDwell = cache.State == "open" &&
 			isIntermediateState(currentState) &&
 			(lastEvent.Type == eventlog.TypeDispatchSkippedClaim || h.now().Sub(lastEvent.TS) > stuckThreshold)
+	}
+	switch {
+	case stuckByDwell && resp.LongFlight:
+		resp.Stuck = true
+		resp.StuckReason = "dwell_and_long_flight"
+	case stuckByDwell:
+		resp.Stuck = true
+		resp.StuckReason = "dwell"
+	case resp.LongFlight:
+		resp.Stuck = true
+		resp.StuckReason = "long_flight"
 	}
 	return resp, nil
 }

--- a/internal/audit/http_long_flight_test.go
+++ b/internal/audit/http_long_flight_test.go
@@ -1,0 +1,151 @@
+package audit
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Lincyaw/workbuddy/internal/eventlog"
+	"github.com/Lincyaw/workbuddy/internal/store"
+)
+
+func newAuditTestStore(t *testing.T) *store.Store {
+	t.Helper()
+	dir := t.TempDir()
+	st, err := store.NewStore(filepath.Join(dir, "audit.db"))
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return st
+}
+
+// TestQueryIssueStateLongFlight: an issue first dispatched > 4h ago that is
+// still in an intermediate state must surface long_flight=true even when no
+// per-state stuck signal would fire.
+func TestQueryIssueStateLongFlight(t *testing.T) {
+	st := newAuditTestStore(t)
+	repo := "owner/repo"
+	issueNum := 1
+
+	if err := st.UpsertIssueCache(store.IssueCache{
+		Repo:     repo,
+		IssueNum: issueNum,
+		Labels:   `["workbuddy","status:developing"]`,
+		State:    "open",
+	}); err != nil {
+		t.Fatalf("UpsertIssueCache: %v", err)
+	}
+	if err := st.TouchIssueFirstDispatch(repo, issueNum); err != nil {
+		t.Fatalf("TouchIssueFirstDispatch: %v", err)
+	}
+
+	// Insert a recent event so the dwell-time signal would NOT trip.
+	if _, err := st.InsertEvent(store.Event{
+		Type:     eventlog.TypeStateEntry,
+		Repo:     repo,
+		IssueNum: issueNum,
+		Payload:  `{}`,
+	}); err != nil {
+		t.Fatalf("InsertEvent: %v", err)
+	}
+
+	h := &HTTPHandler{
+		store: st,
+		// Pretend now() is 5h after first dispatch.
+		now: func() time.Time { return time.Now().Add(5 * time.Hour) },
+	}
+	resp, err := h.queryIssueState(repo, issueNum)
+	if err != nil {
+		t.Fatalf("queryIssueState: %v", err)
+	}
+	if !resp.LongFlight {
+		t.Fatalf("LongFlight = false, want true")
+	}
+	if !resp.Stuck {
+		t.Fatalf("Stuck = false, want true (surfaced via long_flight)")
+	}
+	if !strings.Contains(resp.StuckReason, "long_flight") {
+		t.Fatalf("StuckReason = %q, want it to contain long_flight", resp.StuckReason)
+	}
+}
+
+// TestQueryIssueStateNoLongFlightWhenRecent: an issue first dispatched < 4h
+// ago must not be flagged as long-flight regardless of dwell.
+func TestQueryIssueStateNoLongFlightWhenRecent(t *testing.T) {
+	st := newAuditTestStore(t)
+	repo := "owner/repo"
+	issueNum := 2
+
+	if err := st.UpsertIssueCache(store.IssueCache{
+		Repo:     repo,
+		IssueNum: issueNum,
+		Labels:   `["workbuddy","status:developing"]`,
+		State:    "open",
+	}); err != nil {
+		t.Fatalf("UpsertIssueCache: %v", err)
+	}
+	if err := st.TouchIssueFirstDispatch(repo, issueNum); err != nil {
+		t.Fatalf("TouchIssueFirstDispatch: %v", err)
+	}
+	if _, err := st.InsertEvent(store.Event{
+		Type:     eventlog.TypeStateEntry,
+		Repo:     repo,
+		IssueNum: issueNum,
+		Payload:  `{}`,
+	}); err != nil {
+		t.Fatalf("InsertEvent: %v", err)
+	}
+
+	h := &HTTPHandler{store: st, now: func() time.Time { return time.Now().Add(30 * time.Minute) }}
+	resp, err := h.queryIssueState(repo, issueNum)
+	if err != nil {
+		t.Fatalf("queryIssueState: %v", err)
+	}
+	if resp.LongFlight {
+		t.Fatalf("LongFlight = true, want false")
+	}
+	if resp.Stuck {
+		t.Fatalf("Stuck = true, want false")
+	}
+}
+
+// TestQueryIssueStateExposesDevReviewCycleCount: the audit response includes
+// the dev_review_cycle_count from issue_cycle_state.
+func TestQueryIssueStateExposesDevReviewCycleCount(t *testing.T) {
+	st := newAuditTestStore(t)
+	repo := "owner/repo"
+	issueNum := 3
+
+	if err := st.UpsertIssueCache(store.IssueCache{
+		Repo:     repo,
+		IssueNum: issueNum,
+		Labels:   `["workbuddy","status:developing"]`,
+		State:    "open",
+	}); err != nil {
+		t.Fatalf("UpsertIssueCache: %v", err)
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := st.IncrementDevReviewCycleCount(repo, issueNum); err != nil {
+			t.Fatalf("IncrementDevReviewCycleCount: %v", err)
+		}
+	}
+	if _, err := st.InsertEvent(store.Event{
+		Type:     eventlog.TypeStateEntry,
+		Repo:     repo,
+		IssueNum: issueNum,
+		Payload:  `{}`,
+	}); err != nil {
+		t.Fatalf("InsertEvent: %v", err)
+	}
+
+	h := &HTTPHandler{store: st, now: time.Now}
+	resp, err := h.queryIssueState(repo, issueNum)
+	if err != nil {
+		t.Fatalf("queryIssueState: %v", err)
+	}
+	if resp.DevReviewCycleCount != 2 {
+		t.Fatalf("DevReviewCycleCount = %d, want 2", resp.DevReviewCycleCount)
+	}
+}

--- a/internal/auditapi/handler.go
+++ b/internal/auditapi/handler.go
@@ -101,14 +101,16 @@ type eventFilterEcho struct {
 }
 
 type issueStateResponse struct {
-	Repo              string                    `json:"repo"`
-	IssueNum          int                       `json:"issue_num"`
-	State             string                    `json:"state,omitempty"`
-	Labels            []string                  `json:"labels"`
-	CycleCount        int                       `json:"cycle_count"`
-	DependencyVerdict string                    `json:"dependency_verdict,omitempty"`
-	DependencyState   *dependencyStateResponse  `json:"dependency_state,omitempty"`
-	TransitionCounts  []transitionCountResponse `json:"transition_counts,omitempty"`
+	Repo                string                    `json:"repo"`
+	IssueNum            int                       `json:"issue_num"`
+	State               string                    `json:"state,omitempty"`
+	Labels              []string                  `json:"labels"`
+	CycleCount          int                       `json:"cycle_count"`
+	DevReviewCycleCount int                       `json:"dev_review_cycle_count"`
+	CapHit              bool                      `json:"cap_hit,omitempty"`
+	DependencyVerdict   string                    `json:"dependency_verdict,omitempty"`
+	DependencyState     *dependencyStateResponse  `json:"dependency_state,omitempty"`
+	TransitionCounts    []transitionCountResponse `json:"transition_counts,omitempty"`
 }
 
 type dependencyStateResponse struct {
@@ -424,6 +426,15 @@ func (h *Handler) handleIssueState(w http.ResponseWriter, r *http.Request) {
 			ToState:   tc.ToState,
 			Count:     tc.Count,
 		})
+	}
+	cycleState, err := h.store.QueryIssueCycleState(repo, issueNum)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to query cycle state")
+		return
+	}
+	if cycleState != nil {
+		resp.DevReviewCycleCount = cycleState.DevReviewCycleCount
+		resp.CapHit = !cycleState.CapHitAt.IsZero()
 	}
 	if depState != nil {
 		resp.DependencyVerdict = depState.Verdict

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -411,6 +411,9 @@ func parseWorkflowFile(path string) (*WorkflowConfig, error) {
 	if wf.MaxRetries == 0 {
 		wf.MaxRetries = 3
 	}
+	if wf.MaxReviewCycles == 0 {
+		wf.MaxReviewCycles = 3
+	}
 
 	fname := filepath.Base(path)
 	match := yamlCodeBlockRe.FindStringSubmatch(body)

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -145,11 +145,16 @@ type TriggerRule struct {
 
 // WorkflowConfig defines a workflow loaded from .github/workbuddy/workflows/*.md.
 type WorkflowConfig struct {
-	Name        string            `yaml:"name"`
-	Description string            `yaml:"description"`
-	Trigger     WorkflowTrigger   `yaml:"trigger"`
-	MaxRetries  int               `yaml:"max_retries"`
-	States      map[string]*State // parsed from embedded YAML code block
+	Name        string          `yaml:"name"`
+	Description string          `yaml:"description"`
+	Trigger     WorkflowTrigger `yaml:"trigger"`
+	MaxRetries  int             `yaml:"max_retries"`
+	// MaxReviewCycles caps the number of dev↔review round-trips
+	// (developing→reviewing→developing transitions) the orchestrator will
+	// dispatch automatically before flagging the issue as needing human review.
+	// Default: 3. Set to 0 in YAML to inherit the default.
+	MaxReviewCycles int               `yaml:"max_review_cycles"`
+	States          map[string]*State // parsed from embedded YAML code block
 }
 
 // WorkflowTrigger defines what issue label activates this workflow.

--- a/internal/eventlog/eventlog.go
+++ b/internal/eventlog/eventlog.go
@@ -48,6 +48,10 @@ const (
 	TypeIssueClaimExpired           = "issue_claim_expired"
 	TypeIssueRestarted              = "issue_restarted"
 	TypeInfraFailure                = "infra_failure"
+	TypeDevReviewCycleCount         = "dev_review_cycle_count"
+	TypeDevReviewCycleApproaching   = "dev_review_cycle_approaching"
+	TypeDevReviewCycleCapReached    = "dev_review_cycle_cap_reached"
+	TypeLongFlightStuck             = "long_flight_stuck_detected"
 )
 
 // AllEventTypes lists every recognised event type.
@@ -85,6 +89,10 @@ var AllEventTypes = []string{
 	TypeIssueClaimExpired,
 	TypeIssueRestarted,
 	TypeInfraFailure,
+	TypeDevReviewCycleCount,
+	TypeDevReviewCycleApproaching,
+	TypeDevReviewCycleCapReached,
+	TypeLongFlightStuck,
 }
 
 // EventFilter specifies optional criteria for querying events.

--- a/internal/eventlog/eventlog.go
+++ b/internal/eventlog/eventlog.go
@@ -51,6 +51,7 @@ const (
 	TypeDevReviewCycleCount         = "dev_review_cycle_count"
 	TypeDevReviewCycleApproaching   = "dev_review_cycle_approaching"
 	TypeDevReviewCycleCapReached    = "dev_review_cycle_cap_reached"
+	TypeDevReviewCycleCountReset    = "dev_review_cycle_count_reset"
 	TypeLongFlightStuck             = "long_flight_stuck_detected"
 )
 
@@ -92,6 +93,7 @@ var AllEventTypes = []string{
 	TypeDevReviewCycleCount,
 	TypeDevReviewCycleApproaching,
 	TypeDevReviewCycleCapReached,
+	TypeDevReviewCycleCountReset,
 	TypeLongFlightStuck,
 }
 

--- a/internal/reporter/cycle_cap_format_test.go
+++ b/internal/reporter/cycle_cap_format_test.go
@@ -1,0 +1,120 @@
+package reporter
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+type recordingCommentWriter struct {
+	repo  string
+	issue int
+	body  string
+}
+
+func (r *recordingCommentWriter) WriteComment(repo string, issueNum int, body string) error {
+	r.repo = repo
+	r.issue = issueNum
+	r.body = body
+	return nil
+}
+
+type fakeCycleCapTrailLoader struct {
+	trail  []CycleRejectionEntry
+	prURL  string
+	branch string
+	err    error
+}
+
+func (f *fakeCycleCapTrailLoader) LoadCycleCapTrail(_ context.Context, _ string, _ int) ([]CycleRejectionEntry, string, string, error) {
+	return f.trail, f.prURL, f.branch, f.err
+}
+
+// TestFormatCycleCapReportContainsKeyFacts: the assembled comment includes the
+// cycle/cap counts, workflow name, and each rejection-trail entry. AC-085-3.
+func TestFormatCycleCapReportContainsKeyFacts(t *testing.T) {
+	trail := []CycleRejectionEntry{
+		{Timestamp: time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC), Summary: "review-agent rejected (exit=1)"},
+		{Timestamp: time.Date(2026, 4, 29, 13, 0, 0, 0, time.UTC), Summary: "review-agent rejected (exit=1)"},
+	}
+	body := FormatCycleCapReport(CycleCapData{
+		WorkflowName:    "default",
+		CycleCount:      3,
+		MaxReviewCycles: 3,
+		HitAt:           time.Date(2026, 4, 29, 14, 30, 0, 0, time.UTC),
+		RejectionTrail:  trail,
+	})
+
+	for _, want := range []string{
+		"Dev↔Review Cycle Cap Reached",
+		"3-cycle dev↔review cap",
+		"`default`",
+		"Cycle count",
+		"`3`",
+		"2026-04-29T14:30:00Z",
+		"2026-04-29T12:00:00Z",
+		"2026-04-29T13:00:00Z",
+		"review-agent rejected",
+		"Required action",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("comment body missing %q\n--body--\n%s", want, body)
+		}
+	}
+}
+
+// TestReportDevReviewCycleCapPostsCommentViaLoader: the Reporter consults the
+// trail loader and posts the assembled body. AC-085-2 + AC-085-3.
+func TestReportDevReviewCycleCapPostsCommentViaLoader(t *testing.T) {
+	gh := &recordingCommentWriter{}
+	rep := NewReporter(gh)
+	rep.SetCycleCapTrailLoader(&fakeCycleCapTrailLoader{
+		trail: []CycleRejectionEntry{
+			{Timestamp: time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC), Summary: "review-agent rejected (exit=1)"},
+		},
+		prURL:  "https://github.com/owner/repo/pull/12",
+		branch: "workbuddy/issue-9",
+	})
+
+	hitAt := time.Date(2026, 4, 29, 14, 30, 0, 0, time.UTC)
+	if err := rep.ReportDevReviewCycleCap(context.Background(), "owner/repo", 9, "default", 3, 3, hitAt); err != nil {
+		t.Fatalf("ReportDevReviewCycleCap: %v", err)
+	}
+	if gh.repo != "owner/repo" || gh.issue != 9 {
+		t.Fatalf("comment routed to %s#%d", gh.repo, gh.issue)
+	}
+	for _, want := range []string{
+		"Dev↔Review Cycle Cap Reached",
+		"https://github.com/owner/repo/pull/12",
+		"workbuddy/issue-9",
+		"review-agent rejected",
+	} {
+		if !strings.Contains(gh.body, want) {
+			t.Errorf("posted body missing %q", want)
+		}
+	}
+}
+
+// TestReportDevReviewCycleCapWithLoaderErrorStillPosts: loader failure must
+// not block the cap-hit notification — the comment is posted with an empty
+// trail. AC-085-3 (digest is best-effort).
+func TestReportDevReviewCycleCapWithLoaderErrorStillPosts(t *testing.T) {
+	gh := &recordingCommentWriter{}
+	rep := NewReporter(gh)
+	rep.SetCycleCapTrailLoader(&fakeCycleCapTrailLoader{err: errFake})
+
+	hitAt := time.Date(2026, 4, 29, 14, 30, 0, 0, time.UTC)
+	if err := rep.ReportDevReviewCycleCap(context.Background(), "owner/repo", 9, "default", 3, 3, hitAt); err != nil {
+		t.Fatalf("ReportDevReviewCycleCap: %v", err)
+	}
+	if !strings.Contains(gh.body, "Dev↔Review Cycle Cap Reached") {
+		t.Fatalf("loader error suppressed comment: %s", gh.body)
+	}
+}
+
+type fakeError struct{ msg string }
+
+func (e fakeError) Error() string { return e.msg }
+
+var errFake = fakeError{"loader broken"}

--- a/internal/reporter/format.go
+++ b/internal/reporter/format.go
@@ -219,6 +219,81 @@ func FormatNeedsHumanReport(d NeedsHumanData) string {
 	return b.String()
 }
 
+// CycleCapData holds the canonical facts for a dev↔review cycle-cap
+// needs-human comment. Rejection trail entries are summarized one-per-line
+// in the order they occurred (oldest first).
+type CycleCapData struct {
+	WorkflowName    string
+	CycleCount      int
+	MaxReviewCycles int
+	HitAt           time.Time
+	RejectionTrail  []CycleRejectionEntry
+	LatestPRURL     string
+	BranchName      string
+}
+
+// CycleRejectionEntry summarizes a single review-agent rejection round used
+// in the rejection-trail digest assembled by Coordinator Go code.
+type CycleRejectionEntry struct {
+	Timestamp time.Time
+	Summary   string
+}
+
+// FormatCycleCapReport assembles the needs-human comment posted when an
+// issue trips the dev↔review cycle cap.
+func FormatCycleCapReport(d CycleCapData) string {
+	var b strings.Builder
+
+	b.WriteString("## :rotating_light: Dev↔Review Cycle Cap Reached\n\n")
+	fmt.Fprintf(&b,
+		"This issue hit the configured **%d-cycle dev↔review cap** and will not be auto-dispatched again until a human intervenes.\n\n",
+		d.MaxReviewCycles,
+	)
+
+	b.WriteString("| Field | Value |\n")
+	b.WriteString("|-------|-------|\n")
+	fmt.Fprintf(&b, "| Workflow | `%s` |\n", d.WorkflowName)
+	fmt.Fprintf(&b, "| Cycle count | `%d` (cap: `%d`) |\n", d.CycleCount, d.MaxReviewCycles)
+	fmt.Fprintf(&b, "| Cap hit at | %s |\n", d.HitAt.UTC().Format(time.RFC3339))
+	if d.LatestPRURL != "" {
+		fmt.Fprintf(&b, "| Latest PR | %s |\n", d.LatestPRURL)
+	}
+	if d.BranchName != "" {
+		fmt.Fprintf(&b, "| Branch | `%s` |\n", d.BranchName)
+	}
+	b.WriteString("\n")
+
+	if len(d.RejectionTrail) > 0 {
+		b.WriteString("### Rejection trail (oldest first)\n\n")
+		for i, entry := range d.RejectionTrail {
+			summary := strings.TrimSpace(entry.Summary)
+			if summary == "" {
+				summary = "(no summary captured)"
+			}
+			fmt.Fprintf(&b, "%d. `%s` — %s\n",
+				i+1,
+				entry.Timestamp.UTC().Format(time.RFC3339),
+				summary,
+			)
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("### What this means\n\n")
+	b.WriteString("- Coordinator stopped dispatching `dev-agent` and `review-agent` for this issue.\n")
+	b.WriteString("- Either the dev↔review loop was not converging, or the disagreement is architectural and needs human judgement.\n\n")
+
+	b.WriteString("### Required action\n\n")
+	b.WriteString("A human reviewer must inspect the rejection trail above, decide on the path forward, then either:\n\n")
+	b.WriteString("- Flip the label to `status:blocked` to signal the issue needs human authorship; or\n")
+	b.WriteString("- Resolve the disagreement, run `workbuddy issue restart --repo <repo> --issue <num>` to reset the counter, and re-add `status:developing`.\n\n")
+
+	b.WriteString("---\n")
+	fmt.Fprintf(&b, "*workbuddy coordinator | %s*\n", d.HitAt.UTC().Format(time.RFC3339))
+
+	return b.String()
+}
+
 // FormatStartedReport generates a Markdown "Agent Started" notification comment.
 func FormatStartedReport(d StartedData) string {
 	var b strings.Builder

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -127,12 +127,13 @@ type EventRecorder interface {
 
 // Reporter writes execution reports as GitHub Issue comments.
 type Reporter struct {
-	gh        GHCommentWriter
-	reactions ReactionManager
-	baseURL   string // e.g. "http://localhost:8080", empty to omit session links
-	eventlog  EventRecorder
-	verifier  ClaimVerifier
-	now       func() time.Time
+	gh             GHCommentWriter
+	reactions      ReactionManager
+	baseURL        string // e.g. "http://localhost:8080", empty to omit session links
+	eventlog       EventRecorder
+	verifier       ClaimVerifier
+	now            func() time.Time
+	cycleCapLoader CycleCapTrailLoader
 }
 
 var (
@@ -224,6 +225,54 @@ func (r *Reporter) ReportNeedsHuman(ctx context.Context, repo string, issueNum i
 		Timestamp: time.Now(),
 	})
 	return r.writeWithRateLimitRetry(ctx, repo, issueNum, "needs_human", func() error {
+		return r.gh.WriteComment(repo, issueNum, body)
+	})
+}
+
+// CycleCapTrailLoader fetches the rejection-trail digest entries that are
+// rendered into the dev↔review cycle-cap needs-human comment. The Reporter
+// calls this when posting a cap-hit comment so digest assembly stays in
+// Coordinator Go code (no agent re-invocation, AC-3).
+type CycleCapTrailLoader interface {
+	LoadCycleCapTrail(ctx context.Context, repo string, issueNum int) ([]CycleRejectionEntry, string, string, error)
+}
+
+// SetCycleCapTrailLoader installs the loader used by ReportDevReviewCycleCap
+// to assemble the rejection-trail digest. When unset the comment is still
+// posted but with an empty trail.
+func (r *Reporter) SetCycleCapTrailLoader(l CycleCapTrailLoader) {
+	r.cycleCapLoader = l
+}
+
+// ReportDevReviewCycleCap posts the needs-human comment when an issue has
+// tripped the dev↔review cycle cap. The comment includes a rejection-trail
+// digest built from existing event metadata (no agent re-invocation, AC-3).
+//
+// info is the StateMachine's CycleCapInfo expressed locally so this package
+// does not depend on internal/statemachine. Callers in production wiring
+// translate at the boundary.
+func (r *Reporter) ReportDevReviewCycleCap(ctx context.Context, repo string, issueNum int, workflowName string, cycleCount, maxReviewCycles int, hitAt time.Time) error {
+	d := CycleCapData{
+		WorkflowName:    workflowName,
+		CycleCount:      cycleCount,
+		MaxReviewCycles: maxReviewCycles,
+		HitAt:           hitAt,
+	}
+	if r.cycleCapLoader != nil {
+		trail, prURL, branch, err := r.cycleCapLoader.LoadCycleCapTrail(ctx, repo, issueNum)
+		if err != nil {
+			// Non-fatal: post the comment with an empty trail rather than
+			// failing the cap notification because the digest source is
+			// unavailable.
+			fmt.Fprintf(os.Stderr, "reporter: load cycle-cap trail for %s#%d: %v\n", repo, issueNum, err)
+		} else {
+			d.RejectionTrail = trail
+			d.LatestPRURL = prURL
+			d.BranchName = branch
+		}
+	}
+	body := FormatCycleCapReport(d)
+	return r.writeWithRateLimitRetry(ctx, repo, issueNum, "dev_review_cycle_cap", func() error {
 		return r.gh.WriteComment(repo, issueNum, body)
 	})
 }

--- a/internal/statemachine/cycle_cap_test.go
+++ b/internal/statemachine/cycle_cap_test.go
@@ -1,0 +1,276 @@
+package statemachine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Lincyaw/workbuddy/internal/alertbus"
+	"github.com/Lincyaw/workbuddy/internal/config"
+	"github.com/Lincyaw/workbuddy/internal/eventlog"
+	"github.com/Lincyaw/workbuddy/internal/poller"
+)
+
+// fakeCycleCapReporter records ReportDevReviewCycleCap calls so tests can
+// assert the cap-hit handler invoked the comment side-effect.
+type fakeCycleCapReporter struct {
+	calls []CycleCapInfo
+}
+
+func (f *fakeCycleCapReporter) ReportDevReviewCycleCap(_ context.Context, _ string, _ int, info CycleCapInfo) error {
+	f.calls = append(f.calls, info)
+	return nil
+}
+
+// newCapTestSM builds a StateMachine wired with the default-style workflow
+// (developing/reviewing/done/blocked) and the supplied max_review_cycles.
+func newCapTestSM(t *testing.T, maxReviewCycles int) (*StateMachine, *fakeRecorder, chan DispatchRequest, *alertbus.Bus, *fakeCycleCapReporter) {
+	t.Helper()
+	st := newTestStore(t)
+	rec := &fakeRecorder{}
+	dispatch := make(chan DispatchRequest, 16)
+	bus := alertbus.NewBus(64)
+	wf := &config.WorkflowConfig{
+		Name:            "dev-flow",
+		MaxRetries:      99, // do not interfere with the new cap
+		MaxReviewCycles: maxReviewCycles,
+		Trigger:         config.WorkflowTrigger{IssueLabel: "workbuddy"},
+		States: map[string]*config.State{
+			"developing": {
+				EnterLabel: "status:developing",
+				Agent:      "dev-agent",
+				Transitions: map[string]string{
+					"status:reviewing": "reviewing",
+					"status:blocked":   "blocked",
+				},
+			},
+			"reviewing": {
+				EnterLabel: "status:reviewing",
+				Agent:      "review-agent",
+				Transitions: map[string]string{
+					"status:developing": "developing",
+					"status:done":       "done",
+				},
+			},
+			"blocked": {EnterLabel: "status:blocked"},
+			"done":    {EnterLabel: "status:done"},
+		},
+	}
+	sm := NewStateMachine(map[string]*config.WorkflowConfig{"dev-flow": wf}, st, dispatch, rec, bus)
+	rep := &fakeCycleCapReporter{}
+	sm.SetCycleCapReporter(rep)
+	return sm, rec, dispatch, bus, rep
+}
+
+// stepStateEntry simulates a production state-entry (atomic label swap)
+// for a single workflow state. Use this between MarkAgentCompleted and
+// the next HandleEvent to advance the state machine the way the poller
+// would after an agent flips labels.
+func stepStateEntry(t *testing.T, sm *StateMachine, repo string, issueNum int, enterLabel string) {
+	t.Helper()
+	if err := sm.HandleEvent(context.Background(), ChangeEvent{
+		Type:     poller.EventLabelAdded,
+		Repo:     repo,
+		IssueNum: issueNum,
+		Labels:   []string{"workbuddy", enterLabel},
+		Detail:   enterLabel,
+	}); err != nil {
+		t.Fatalf("HandleEvent %s: %v", enterLabel, err)
+	}
+	sm.ResetDedup()
+}
+
+// TestCycleCapCleanIssueNoExtraCycle: a fresh issue entering developing once
+// must not increment dev_review_cycle_count.
+func TestCycleCapCleanIssueNoExtraCycle(t *testing.T) {
+	sm, _, dispatch, _, rep := newCapTestSM(t, 3)
+	const repo = "test/repo"
+	const issue = 100
+
+	stepStateEntry(t, sm, repo, issue, "status:developing")
+	<-dispatch
+	sm.MarkAgentCompleted(repo, issue, "task-dev-1", "dev-agent", 0, []string{"workbuddy", "status:developing"})
+
+	state, err := sm.store.QueryIssueCycleState(repo, issue)
+	if err != nil {
+		t.Fatalf("QueryIssueCycleState: %v", err)
+	}
+	if state != nil && state.DevReviewCycleCount != 0 {
+		t.Fatalf("dev_review_cycle_count = %d, want 0", state.DevReviewCycleCount)
+	}
+	if len(rep.calls) != 0 {
+		t.Fatalf("unexpected cap-hit calls: %+v", rep.calls)
+	}
+}
+
+// TestCycleCapOneCycleIncrementsCounter: developing→reviewing→developing
+// (one full round-trip) must set dev_review_cycle_count to 1 and still
+// dispatch the second dev-agent run.
+func TestCycleCapOneCycleIncrementsCounter(t *testing.T) {
+	sm, _, dispatch, _, rep := newCapTestSM(t, 3)
+	const repo = "test/repo"
+	const issue = 200
+
+	// Initial entry into developing.
+	stepStateEntry(t, sm, repo, issue, "status:developing")
+	<-dispatch
+	sm.MarkAgentCompleted(repo, issue, "t1", "dev-agent", 0, []string{"workbuddy", "status:developing"})
+
+	// Dev-agent flipped to reviewing.
+	stepStateEntry(t, sm, repo, issue, "status:reviewing")
+	<-dispatch
+	sm.MarkAgentCompleted(repo, issue, "t2", "review-agent", 1, []string{"workbuddy", "status:reviewing"})
+
+	// Review-agent rejected → flipped back to developing.
+	stepStateEntry(t, sm, repo, issue, "status:developing")
+	select {
+	case req := <-dispatch:
+		if req.AgentName != "dev-agent" {
+			t.Fatalf("expected dev-agent dispatch on second developing entry, got %q", req.AgentName)
+		}
+	default:
+		t.Fatalf("expected dev-agent dispatch on second developing entry")
+	}
+
+	state, err := sm.store.QueryIssueCycleState(repo, issue)
+	if err != nil {
+		t.Fatalf("QueryIssueCycleState: %v", err)
+	}
+	if state == nil || state.DevReviewCycleCount != 1 {
+		t.Fatalf("dev_review_cycle_count = %+v, want 1", state)
+	}
+	if len(rep.calls) != 0 {
+		t.Fatalf("unexpected cap-hit calls at cycle 1: %+v", rep.calls)
+	}
+}
+
+// TestCycleCapApproachingAlertAtCapMinusOne: at cycle == cap - 1 the
+// state machine must publish a heads-up alert AND continue to dispatch.
+func TestCycleCapApproachingAlertAtCapMinusOne(t *testing.T) {
+	sm, _, dispatch, bus, _ := newCapTestSM(t, 3)
+	subID, ch := bus.Subscribe()
+	t.Cleanup(func() { bus.Unsubscribe(subID) })
+
+	const repo = "test/repo"
+	const issue = 300
+
+	// Initial entry.
+	stepStateEntry(t, sm, repo, issue, "status:developing")
+	<-dispatch
+	sm.MarkAgentCompleted(repo, issue, "t1", "dev-agent", 0, []string{"workbuddy", "status:developing"})
+
+	// Cycle 1: review→dev.
+	stepStateEntry(t, sm, repo, issue, "status:reviewing")
+	<-dispatch
+	sm.MarkAgentCompleted(repo, issue, "t2", "review-agent", 1, []string{"workbuddy", "status:reviewing"})
+	stepStateEntry(t, sm, repo, issue, "status:developing")
+	<-dispatch // dev-agent re-dispatched
+	sm.MarkAgentCompleted(repo, issue, "t3", "dev-agent", 0, []string{"workbuddy", "status:developing"})
+
+	// Cycle 2 (cap-1=2 should trigger heads-up).
+	stepStateEntry(t, sm, repo, issue, "status:reviewing")
+	<-dispatch
+	sm.MarkAgentCompleted(repo, issue, "t4", "review-agent", 1, []string{"workbuddy", "status:reviewing"})
+	stepStateEntry(t, sm, repo, issue, "status:developing")
+	select {
+	case req := <-dispatch:
+		if req.AgentName != "dev-agent" {
+			t.Fatalf("expected dev-agent dispatch at cap-1, got %q", req.AgentName)
+		}
+	default:
+		t.Fatalf("expected dev-agent dispatch at cap-1")
+	}
+
+	// Drain alert events looking for the approaching kind.
+	gotApproaching := false
+	for drain := true; drain; {
+		select {
+		case ev := <-ch:
+			if ev.Kind == alertbus.KindDevReviewCycleApproaching {
+				gotApproaching = true
+			}
+		default:
+			drain = false
+		}
+	}
+	if !gotApproaching {
+		t.Fatalf("expected dev_review_cycle_approaching alert at cycle %d/%d", 2, 3)
+	}
+}
+
+// TestCycleCapHitBlocksDispatchAndPostsComment: at cycle == cap the
+// state machine must NOT dispatch, must record cap_hit_at, and must
+// invoke the cycle-cap reporter callback.
+func TestCycleCapHitBlocksDispatchAndPostsComment(t *testing.T) {
+	sm, rec, dispatch, _, rep := newCapTestSM(t, 2) // cap=2 so we hit it on the second dev re-entry
+	const repo = "test/repo"
+	const issue = 400
+
+	stepStateEntry(t, sm, repo, issue, "status:developing")
+	<-dispatch
+	sm.MarkAgentCompleted(repo, issue, "t1", "dev-agent", 0, []string{"workbuddy", "status:developing"})
+
+	// Cycle 1.
+	stepStateEntry(t, sm, repo, issue, "status:reviewing")
+	<-dispatch
+	sm.MarkAgentCompleted(repo, issue, "t2", "review-agent", 1, []string{"workbuddy", "status:reviewing"})
+	stepStateEntry(t, sm, repo, issue, "status:developing")
+	<-dispatch
+	sm.MarkAgentCompleted(repo, issue, "t3", "dev-agent", 0, []string{"workbuddy", "status:developing"})
+
+	// Cycle 2 — should hit cap=2.
+	stepStateEntry(t, sm, repo, issue, "status:reviewing")
+	<-dispatch
+	sm.MarkAgentCompleted(repo, issue, "t4", "review-agent", 1, []string{"workbuddy", "status:reviewing"})
+	stepStateEntry(t, sm, repo, issue, "status:developing")
+
+	select {
+	case req := <-dispatch:
+		t.Fatalf("dispatch must be blocked at cap, got %+v", req)
+	default:
+	}
+
+	state, err := sm.store.QueryIssueCycleState(repo, issue)
+	if err != nil {
+		t.Fatalf("QueryIssueCycleState: %v", err)
+	}
+	if state == nil {
+		t.Fatalf("issue_cycle_state row missing")
+	}
+	if state.DevReviewCycleCount != 2 {
+		t.Fatalf("dev_review_cycle_count = %d, want 2", state.DevReviewCycleCount)
+	}
+	if state.CapHitAt.IsZero() {
+		t.Fatalf("cap_hit_at not recorded")
+	}
+	if len(rep.calls) != 1 {
+		t.Fatalf("cap-hit reporter calls = %d, want 1", len(rep.calls))
+	}
+	info := rep.calls[0]
+	if info.WorkflowName != "dev-flow" || info.MaxReviewCycles != 2 || info.CycleCount != 2 {
+		t.Fatalf("CycleCapInfo = %+v", info)
+	}
+	if len(rec.find(eventlog.TypeDevReviewCycleCapReached)) != 1 {
+		t.Fatalf("expected dev_review_cycle_cap_reached event")
+	}
+}
+
+// TestCycleCapTouchFirstDispatch: state-entry into developing must record
+// first_dispatch_at on the first encounter so the long-flight stuck
+// detector has a baseline.
+func TestCycleCapTouchFirstDispatch(t *testing.T) {
+	sm, _, dispatch, _, _ := newCapTestSM(t, 3)
+	const repo = "test/repo"
+	const issue = 500
+
+	stepStateEntry(t, sm, repo, issue, "status:developing")
+	<-dispatch
+	sm.MarkAgentCompleted(repo, issue, "t1", "dev-agent", 0, []string{"workbuddy", "status:developing"})
+
+	state, err := sm.store.QueryIssueCycleState(repo, issue)
+	if err != nil {
+		t.Fatalf("QueryIssueCycleState: %v", err)
+	}
+	if state == nil || state.FirstDispatchAt.IsZero() {
+		t.Fatalf("first_dispatch_at not recorded for %+v", state)
+	}
+}

--- a/internal/statemachine/cycle_cap_test.go
+++ b/internal/statemachine/cycle_cap_test.go
@@ -254,6 +254,125 @@ func TestCycleCapHitBlocksDispatchAndPostsComment(t *testing.T) {
 	}
 }
 
+// TestCycleCapResetOnBlockedToDeveloping: after the cap is hit and a human
+// flips status:blocked → status:developing, the cycle counter must reset
+// to 0 and a subsequent review→developing round-trip must increment to 1
+// (not cap+1). This is the Option A semantic from REQ-085 maintainer
+// override: "Counter resets when a human transitions status:blocked →
+// status:developing".
+func TestCycleCapResetOnBlockedToDeveloping(t *testing.T) {
+	sm, rec, dispatch, _, rep := newCapTestSM(t, 2) // cap=2 so we hit it on the second dev re-entry
+	const repo = "test/repo"
+	const issue = 600
+
+	// Drive developing → reviewing → developing → reviewing → developing
+	// up to the cap.
+	stepStateEntry(t, sm, repo, issue, "status:developing")
+	<-dispatch
+	sm.MarkAgentCompleted(repo, issue, "t1", "dev-agent", 0, []string{"workbuddy", "status:developing"})
+
+	stepStateEntry(t, sm, repo, issue, "status:reviewing")
+	<-dispatch
+	sm.MarkAgentCompleted(repo, issue, "t2", "review-agent", 1, []string{"workbuddy", "status:reviewing"})
+
+	// Cycle 1 (count=1).
+	stepStateEntry(t, sm, repo, issue, "status:developing")
+	<-dispatch
+	sm.MarkAgentCompleted(repo, issue, "t3", "dev-agent", 0, []string{"workbuddy", "status:developing"})
+
+	stepStateEntry(t, sm, repo, issue, "status:reviewing")
+	<-dispatch
+	sm.MarkAgentCompleted(repo, issue, "t4", "review-agent", 1, []string{"workbuddy", "status:reviewing"})
+
+	// Cycle 2 — cap-hit, dispatch blocked.
+	stepStateEntry(t, sm, repo, issue, "status:developing")
+	select {
+	case req := <-dispatch:
+		t.Fatalf("dispatch must be blocked at cap, got %+v", req)
+	default:
+	}
+
+	state, err := sm.store.QueryIssueCycleState(repo, issue)
+	if err != nil {
+		t.Fatalf("QueryIssueCycleState pre-reset: %v", err)
+	}
+	if state == nil || state.DevReviewCycleCount != 2 || state.CapHitAt.IsZero() {
+		t.Fatalf("expected cap-hit state pre-reset, got %+v", state)
+	}
+	if len(rep.calls) != 1 {
+		t.Fatalf("expected 1 cap-hit reporter call before reset, got %d", len(rep.calls))
+	}
+
+	// Human flips status:blocked. With the workflow_instance now advancing
+	// through stateless states, this records "blocked" as the new
+	// current_state in workflow_instance.
+	stepStateEntry(t, sm, repo, issue, "status:blocked")
+	select {
+	case req := <-dispatch:
+		t.Fatalf("status:blocked must not dispatch, got %+v", req)
+	default:
+	}
+
+	// Human flips back to status:developing — Option A reset must fire.
+	stepStateEntry(t, sm, repo, issue, "status:developing")
+	select {
+	case req := <-dispatch:
+		if req.AgentName != "dev-agent" {
+			t.Fatalf("expected dev-agent dispatch after reset, got %q", req.AgentName)
+		}
+	default:
+		t.Fatalf("expected dev-agent dispatch after blocked→developing reset")
+	}
+
+	// Counter must be 0 (or row absent) and cap_hit_at must be cleared.
+	state, err = sm.store.QueryIssueCycleState(repo, issue)
+	if err != nil {
+		t.Fatalf("QueryIssueCycleState post-reset: %v", err)
+	}
+	if state != nil {
+		if state.DevReviewCycleCount != 0 {
+			t.Fatalf("dev_review_cycle_count post-reset = %d, want 0", state.DevReviewCycleCount)
+		}
+		if !state.CapHitAt.IsZero() {
+			t.Fatalf("cap_hit_at post-reset = %v, want zero", state.CapHitAt)
+		}
+	}
+
+	// The reset event must have been logged.
+	if len(rec.find(eventlog.TypeDevReviewCycleCountReset)) != 1 {
+		t.Fatalf("expected dev_review_cycle_count_reset event, got %d", len(rec.find(eventlog.TypeDevReviewCycleCountReset)))
+	}
+
+	// A subsequent review→developing round-trip must increment to 1, not cap+1.
+	sm.MarkAgentCompleted(repo, issue, "t5", "dev-agent", 0, []string{"workbuddy", "status:developing"})
+	stepStateEntry(t, sm, repo, issue, "status:reviewing")
+	<-dispatch
+	sm.MarkAgentCompleted(repo, issue, "t6", "review-agent", 1, []string{"workbuddy", "status:reviewing"})
+
+	stepStateEntry(t, sm, repo, issue, "status:developing")
+	select {
+	case req := <-dispatch:
+		if req.AgentName != "dev-agent" {
+			t.Fatalf("expected dev-agent dispatch on first post-reset cycle, got %q", req.AgentName)
+		}
+	default:
+		t.Fatalf("expected dev-agent dispatch on first post-reset cycle")
+	}
+
+	state, err = sm.store.QueryIssueCycleState(repo, issue)
+	if err != nil {
+		t.Fatalf("QueryIssueCycleState post-cycle: %v", err)
+	}
+	if state == nil || state.DevReviewCycleCount != 1 {
+		t.Fatalf("dev_review_cycle_count post-cycle = %+v, want 1", state)
+	}
+
+	// No new cap-hit reporter call: the post-reset cycle is at 1, well below cap=2.
+	if len(rep.calls) != 1 {
+		t.Fatalf("unexpected extra cap-hit reporter calls: %d", len(rep.calls))
+	}
+}
+
 // TestCycleCapTouchFirstDispatch: state-entry into developing must record
 // first_dispatch_at on the first encounter so the long-flight stuck
 // detector has a baseline.

--- a/internal/statemachine/statemachine.go
+++ b/internal/statemachine/statemachine.go
@@ -77,6 +77,7 @@ const DefaultMaxReviewCycles = 3
 const (
 	stateNameDeveloping = "developing"
 	stateNameReviewing  = "reviewing"
+	stateNameBlocked    = "blocked"
 )
 
 // CycleCapReporter is the optional callback used by the StateMachine to post
@@ -356,12 +357,17 @@ func (sm *StateMachine) processWorkflowEvent(ctx context.Context, wf *config.Wor
 		return sm.dispatchStateAgents(ctx, event.Repo, event.IssueNum, wf.Name, currentStateName, currentState)
 	}
 
-	if !stateEntryDetected {
-		_, err := sm.evaluateTransitions(ctx, wf, event, currentStateName, currentState)
-		return err
+	if stateEntryDetected {
+		// Stateless state-entry (e.g. status:blocked, status:done): no agent
+		// dispatch, but still advance the persisted workflow_instance so
+		// subsequent state-aware checks (in particular the dev↔review cycle
+		// counter's blocked→developing reset) see the correct prior state.
+		sm.recordStateEntry(wf.Name, event.Repo, event.IssueNum, currentStateName, currentState)
+		return nil
 	}
 
-	return nil
+	_, err := sm.evaluateTransitions(ctx, wf, event, currentStateName, currentState)
+	return err
 }
 
 func (sm *StateMachine) publishAlert(eventKind string, severity alertbus.Severity, repo string, issueNum int, agentName string, payload map[string]any) {
@@ -475,6 +481,12 @@ func (sm *StateMachine) evaluateTransitions(ctx context.Context, wf *config.Work
 // re-enters the developing state after the workflow_instance's persisted
 // current_state was reviewing. The very first entry into developing is
 // not counted (no prior reviewing state exists).
+//
+// Option A reset (REQ-085 maintainer override): when the prior workflow
+// state is "blocked" — i.e. a human has flipped status:blocked →
+// status:developing to give the issue another shot — the dev↔review cycle
+// counter is reset so the cap re-engages from scratch. The blocked→developing
+// label transition itself does not count as a round-trip.
 func (sm *StateMachine) applyDevReviewCycleCap(ctx context.Context, wf *config.WorkflowConfig, repo string, issueNum int, currentStateName string) (bool, error) {
 	if currentStateName != stateNameDeveloping {
 		return false, nil
@@ -483,6 +495,24 @@ func (sm *StateMachine) applyDevReviewCycleCap(ctx context.Context, wf *config.W
 		return false, nil
 	}
 	priorState := sm.queryPriorWorkflowState(wf.Name, repo, issueNum)
+
+	// Option A counter reset: a human-driven blocked→developing transition
+	// clears the cycle counter and the cap-hit marker so future round-trips
+	// start fresh. We rely on the workflow_instance state advancing through
+	// "blocked" via processWorkflowEvent's stateless state-entry branch.
+	if priorState == stateNameBlocked {
+		if err := sm.store.ResetIssueCycleState(repo, issueNum); err != nil {
+			log.Printf("[statemachine] reset issue cycle state on blocked→developing for %s#%d: %v", repo, issueNum, err)
+			return false, fmt.Errorf("statemachine: reset issue cycle state: %w", err)
+		}
+		sm.eventlog.Log(eventlog.TypeDevReviewCycleCountReset, repo, issueNum, map[string]any{
+			"workflow":    wf.Name,
+			"prior_state": priorState,
+			"reason":      "blocked_to_developing",
+		})
+		return false, nil
+	}
+
 	if priorState != stateNameReviewing {
 		return false, nil
 	}

--- a/internal/statemachine/statemachine.go
+++ b/internal/statemachine/statemachine.go
@@ -67,6 +67,36 @@ const DoneLabel = "status:done"
 // enough to recover from a crashed coordinator.
 const DefaultIssueClaimLease = 30 * time.Minute
 
+// DefaultMaxReviewCycles is the orchestrator-level cap on dev↔review
+// round-trips (developing→reviewing→developing) used when a workflow does
+// not specify max_review_cycles in its frontmatter. See REQ-085.
+const DefaultMaxReviewCycles = 3
+
+// State names recognized by the dev↔review cycle counter. These match the
+// canonical default workflow shipped in `.github/workbuddy/workflows/default.md`.
+const (
+	stateNameDeveloping = "developing"
+	stateNameReviewing  = "reviewing"
+)
+
+// CycleCapReporter is the optional callback used by the StateMachine to post
+// a needs-human comment with the rejection-trail digest when an issue trips
+// the dev↔review cycle cap. The interface is satisfied by *reporter.Reporter
+// in production wiring; tests pass a fake.
+type CycleCapReporter interface {
+	ReportDevReviewCycleCap(ctx context.Context, repo string, issueNum int, info CycleCapInfo) error
+}
+
+// CycleCapInfo carries the data the Reporter needs to assemble the
+// needs-human comment posted on cap-hit. The rejection-trail digest is
+// expected to be assembled by Coordinator Go code (no agent re-invocation).
+type CycleCapInfo struct {
+	WorkflowName    string
+	CycleCount      int
+	MaxReviewCycles int
+	HitAt           time.Time
+}
+
 type dispatchGroup struct {
 	workflow string
 	state    string
@@ -125,6 +155,11 @@ type StateMachine struct {
 
 	workflowManager *workflow.Manager
 
+	// capReporter posts the needs-human comment when an issue trips the
+	// dev↔review cycle cap. Optional; when nil, cap-hit still records an
+	// event + alert but no GitHub comment is written.
+	capReporter CycleCapReporter
+
 	// issueClaim configuration (REQ-057). When claimerID is empty, per-issue
 	// claim acquisition is skipped — useful for tests that don't care and for
 	// backwards compatibility with the existing NewStateMachine signature.
@@ -168,6 +203,13 @@ func NewStateMachine(
 		claimTokens:     make(map[string]string),
 		claimWarned:     make(map[string]struct{}),
 	}
+}
+
+// SetCycleCapReporter installs the callback used to post a needs-human
+// comment when an issue trips the dev↔review cycle cap. Pass nil to disable
+// the comment side-effect (event + alert still fire).
+func (sm *StateMachine) SetCycleCapReporter(r CycleCapReporter) {
+	sm.capReporter = r
 }
 
 // SetIssueClaim enables per-issue dispatch-claim acquisition (REQ-057). When
@@ -289,6 +331,28 @@ func (sm *StateMachine) processWorkflowEvent(ctx context.Context, wf *config.Wor
 		}
 		sm.inflightMu.Unlock()
 
+		// REQ-085: orchestrator-level dev↔review cycle counter and cap.
+		// Production state changes flow through the state-entry branch (agents
+		// flip labels atomically), so this is where we count round-trips.
+		blocked, err := sm.applyDevReviewCycleCap(ctx, wf, event.Repo, event.IssueNum, currentStateName)
+		if err != nil {
+			return err
+		}
+		if blocked {
+			return nil
+		}
+
+		// Persist the new current state so future cycles can compare against it.
+		sm.recordStateEntry(wf.Name, event.Repo, event.IssueNum, currentStateName, currentState)
+
+		// Touch first_dispatch_at so the long-flight stuck detector knows when
+		// the issue first received an agent dispatch.
+		if sm.store != nil {
+			if err := sm.store.TouchIssueFirstDispatch(event.Repo, event.IssueNum); err != nil {
+				log.Printf("[statemachine] touch first dispatch for %s#%d: %v", event.Repo, event.IssueNum, err)
+			}
+		}
+
 		return sm.dispatchStateAgents(ctx, event.Repo, event.IssueNum, wf.Name, currentStateName, currentState)
 	}
 
@@ -400,6 +464,120 @@ func (sm *StateMachine) evaluateTransitions(ctx context.Context, wf *config.Work
 	}
 
 	return true, nil
+}
+
+// applyDevReviewCycleCap detects a developing→reviewing→developing round-trip
+// and enforces the workflow's max_review_cycles cap (REQ-085). Returns
+// (blocked=true) when the cap is hit and dispatch should NOT proceed; the
+// caller is responsible for halting state-entry dispatch in that case.
+//
+// Cycle detection rule: a "round-trip" is recorded each time the issue
+// re-enters the developing state after the workflow_instance's persisted
+// current_state was reviewing. The very first entry into developing is
+// not counted (no prior reviewing state exists).
+func (sm *StateMachine) applyDevReviewCycleCap(ctx context.Context, wf *config.WorkflowConfig, repo string, issueNum int, currentStateName string) (bool, error) {
+	if currentStateName != stateNameDeveloping {
+		return false, nil
+	}
+	if sm.store == nil || sm.workflowManager == nil {
+		return false, nil
+	}
+	priorState := sm.queryPriorWorkflowState(wf.Name, repo, issueNum)
+	if priorState != stateNameReviewing {
+		return false, nil
+	}
+
+	cycleCount, err := sm.store.IncrementDevReviewCycleCount(repo, issueNum)
+	if err != nil {
+		return false, fmt.Errorf("statemachine: increment dev_review_cycle_count: %w", err)
+	}
+
+	maxCycles := wf.MaxReviewCycles
+	if maxCycles <= 0 {
+		maxCycles = DefaultMaxReviewCycles
+	}
+
+	payload := map[string]any{
+		"workflow":          wf.Name,
+		"cycle_count":       cycleCount,
+		"max_review_cycles": maxCycles,
+	}
+	sm.eventlog.Log(eventlog.TypeDevReviewCycleCount, repo, issueNum, payload)
+
+	if cycleCount >= maxCycles {
+		if err := sm.store.MarkIssueCycleCapHit(repo, issueNum); err != nil {
+			log.Printf("[statemachine] mark issue cycle cap hit for %s#%d: %v", repo, issueNum, err)
+		}
+		sm.eventlog.Log(eventlog.TypeDevReviewCycleCapReached, repo, issueNum, payload)
+		sm.publishAlert(alertbus.KindDevReviewCycleCapReached, alertbus.SeverityError, repo, issueNum, "", payload)
+		if sm.capReporter != nil {
+			info := CycleCapInfo{
+				WorkflowName:    wf.Name,
+				CycleCount:      cycleCount,
+				MaxReviewCycles: maxCycles,
+				HitAt:           time.Now().UTC(),
+			}
+			if err := sm.capReporter.ReportDevReviewCycleCap(ctx, repo, issueNum, info); err != nil {
+				log.Printf("[statemachine] report cycle cap for %s#%d: %v", repo, issueNum, err)
+			}
+		}
+		return true, nil
+	}
+
+	if cycleCount == maxCycles-1 {
+		warnPayload := map[string]any{
+			"workflow":          wf.Name,
+			"cycle_count":       cycleCount,
+			"max_review_cycles": maxCycles,
+			"remaining":         maxCycles - cycleCount,
+		}
+		sm.eventlog.Log(eventlog.TypeDevReviewCycleApproaching, repo, issueNum, warnPayload)
+		sm.publishAlert(alertbus.KindDevReviewCycleApproaching, alertbus.SeverityWarn, repo, issueNum, "", warnPayload)
+	}
+	return false, nil
+}
+
+// recordStateEntry advances the persisted workflow_instance current_state
+// when a state-entry causes a real transition. Idempotent for self-entries.
+func (sm *StateMachine) recordStateEntry(workflowName, repo string, issueNum int, currentStateName string, currentState *config.State) {
+	if sm.workflowManager == nil {
+		return
+	}
+	prior := sm.queryPriorWorkflowState(workflowName, repo, issueNum)
+	if prior == "" || prior == currentStateName {
+		return
+	}
+	triggerAgent := ""
+	if currentState != nil {
+		triggerAgent = currentState.Agent
+	}
+	if err := sm.workflowManager.Advance(repo, issueNum, workflowName, prior, currentStateName, triggerAgent); err != nil {
+		log.Printf("[statemachine] advance workflow instance %s#%d %s→%s: %v", repo, issueNum, prior, currentStateName, err)
+		return
+	}
+	if _, err := sm.store.IncrementTransition(repo, issueNum, prior, currentStateName); err != nil {
+		log.Printf("[statemachine] increment transition %s#%d %s→%s: %v", repo, issueNum, prior, currentStateName, err)
+	}
+}
+
+// queryPriorWorkflowState returns the persisted current_state for the issue
+// before the present state-entry. Empty string if the workflow instance does
+// not exist or its persisted state cannot be read.
+func (sm *StateMachine) queryPriorWorkflowState(workflowName, repo string, issueNum int) string {
+	if sm.workflowManager == nil {
+		return ""
+	}
+	instances, err := sm.workflowManager.QueryByRepoIssue(repo, issueNum)
+	if err != nil {
+		log.Printf("[statemachine] query workflow instances %s#%d: %v", repo, issueNum, err)
+		return ""
+	}
+	for _, inst := range instances {
+		if inst.WorkflowName == workflowName {
+			return inst.CurrentState
+		}
+	}
+	return ""
 }
 
 func (sm *StateMachine) ensureWorkflowInstance(workflowName, repo string, issueNum int, currentState string) error {

--- a/internal/store/queries.go
+++ b/internal/store/queries.go
@@ -640,3 +640,110 @@ func (s *Store) QueryWorkflowTransitions(instanceID string) ([]WorkflowTransitio
 	}
 	return out, rows.Err()
 }
+
+// ---------------------------------------------------------------------------
+// Issue cycle state — orchestrator-level dev↔review counter and timing
+// used by the max_review_cycles cap and the long-flight stuck detector.
+// ---------------------------------------------------------------------------
+
+// IncrementDevReviewCycleCount atomically increments the per-issue
+// dev_review_cycle_count and returns the new value. The row is created on
+// first call. updated_at is bumped to CURRENT_TIMESTAMP.
+func (s *Store) IncrementDevReviewCycleCount(repo string, issueNum int) (int, error) {
+	var count int
+	err := s.db.QueryRow(
+		`INSERT INTO issue_cycle_state (repo, issue_num, dev_review_cycle_count, updated_at)
+		 VALUES (?, ?, 1, CURRENT_TIMESTAMP)
+		 ON CONFLICT (repo, issue_num)
+		 DO UPDATE SET dev_review_cycle_count = dev_review_cycle_count + 1,
+		               updated_at = CURRENT_TIMESTAMP
+		 RETURNING dev_review_cycle_count`,
+		repo, issueNum,
+	).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("store: increment dev_review_cycle_count: %w", err)
+	}
+	return count, nil
+}
+
+// TouchIssueFirstDispatch records the first time an agent was dispatched for
+// (repo, issueNum). Subsequent calls are no-ops. Used by the long-flight
+// stuck detector to measure total in-flight time independent of per-state
+// dwell time.
+func (s *Store) TouchIssueFirstDispatch(repo string, issueNum int) error {
+	_, err := s.db.Exec(
+		`INSERT INTO issue_cycle_state (repo, issue_num, first_dispatch_at, updated_at)
+		 VALUES (?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+		 ON CONFLICT (repo, issue_num)
+		 DO UPDATE SET first_dispatch_at = COALESCE(issue_cycle_state.first_dispatch_at, CURRENT_TIMESTAMP),
+		               updated_at = CURRENT_TIMESTAMP`,
+		repo, issueNum,
+	)
+	if err != nil {
+		return fmt.Errorf("store: touch issue first_dispatch_at: %w", err)
+	}
+	return nil
+}
+
+// MarkIssueCycleCapHit records the moment the issue tripped the
+// max_review_cycles cap. Idempotent.
+func (s *Store) MarkIssueCycleCapHit(repo string, issueNum int) error {
+	_, err := s.db.Exec(
+		`INSERT INTO issue_cycle_state (repo, issue_num, cap_hit_at, updated_at)
+		 VALUES (?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+		 ON CONFLICT (repo, issue_num)
+		 DO UPDATE SET cap_hit_at = COALESCE(issue_cycle_state.cap_hit_at, CURRENT_TIMESTAMP),
+		               updated_at = CURRENT_TIMESTAMP`,
+		repo, issueNum,
+	)
+	if err != nil {
+		return fmt.Errorf("store: mark issue cycle cap hit: %w", err)
+	}
+	return nil
+}
+
+// QueryIssueCycleState returns the per-issue cycle counter and timing. Returns
+// (nil, nil) when no row exists for the issue.
+func (s *Store) QueryIssueCycleState(repo string, issueNum int) (*IssueCycleState, error) {
+	row := s.db.QueryRow(
+		`SELECT repo, issue_num, dev_review_cycle_count,
+		        first_dispatch_at, cap_hit_at, updated_at
+		 FROM issue_cycle_state
+		 WHERE repo = ? AND issue_num = ?`,
+		repo, issueNum,
+	)
+	var rec IssueCycleState
+	var firstDispatch, capHit, updated sql.NullString
+	err := row.Scan(&rec.Repo, &rec.IssueNum, &rec.DevReviewCycleCount,
+		&firstDispatch, &capHit, &updated)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("store: query issue cycle state: %w", err)
+	}
+	if firstDispatch.Valid {
+		rec.FirstDispatchAt, _ = ParseTimestamp(firstDispatch.String, "issue_cycle_state.first_dispatch_at")
+	}
+	if capHit.Valid {
+		rec.CapHitAt, _ = ParseTimestamp(capHit.String, "issue_cycle_state.cap_hit_at")
+	}
+	if updated.Valid {
+		rec.UpdatedAt, _ = ParseTimestamp(updated.String, "issue_cycle_state.updated_at")
+	}
+	return &rec, nil
+}
+
+// ResetIssueCycleState removes the per-issue cycle counter row. Used by
+// `workbuddy issue restart` so that an explicit restart clears the cycle
+// counter alongside other recovery state.
+func (s *Store) ResetIssueCycleState(repo string, issueNum int) error {
+	_, err := s.db.Exec(
+		`DELETE FROM issue_cycle_state WHERE repo = ? AND issue_num = ?`,
+		repo, issueNum,
+	)
+	if err != nil {
+		return fmt.Errorf("store: reset issue cycle state: %w", err)
+	}
+	return nil
+}

--- a/internal/store/queries_cycle_state_test.go
+++ b/internal/store/queries_cycle_state_test.go
@@ -1,0 +1,130 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func newCycleTestStore(t *testing.T) *Store {
+	t.Helper()
+	dir := t.TempDir()
+	st, err := NewStore(filepath.Join(dir, "cycle.db"))
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return st
+}
+
+func TestIncrementDevReviewCycleCount(t *testing.T) {
+	st := newCycleTestStore(t)
+	repo := "owner/repo"
+	issue := 1
+
+	for want := 1; want <= 3; want++ {
+		got, err := st.IncrementDevReviewCycleCount(repo, issue)
+		if err != nil {
+			t.Fatalf("IncrementDevReviewCycleCount %d: %v", want, err)
+		}
+		if got != want {
+			t.Fatalf("count = %d, want %d", got, want)
+		}
+	}
+
+	state, err := st.QueryIssueCycleState(repo, issue)
+	if err != nil {
+		t.Fatalf("QueryIssueCycleState: %v", err)
+	}
+	if state == nil || state.DevReviewCycleCount != 3 {
+		t.Fatalf("state = %+v", state)
+	}
+}
+
+func TestQueryIssueCycleStateMissing(t *testing.T) {
+	st := newCycleTestStore(t)
+	state, err := st.QueryIssueCycleState("owner/repo", 99)
+	if err != nil {
+		t.Fatalf("QueryIssueCycleState: %v", err)
+	}
+	if state != nil {
+		t.Fatalf("expected nil state for missing issue, got %+v", state)
+	}
+}
+
+func TestTouchIssueFirstDispatchIsIdempotent(t *testing.T) {
+	st := newCycleTestStore(t)
+	repo := "owner/repo"
+	issue := 2
+
+	if err := st.TouchIssueFirstDispatch(repo, issue); err != nil {
+		t.Fatalf("first touch: %v", err)
+	}
+	first, err := st.QueryIssueCycleState(repo, issue)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if first == nil || first.FirstDispatchAt.IsZero() {
+		t.Fatalf("first_dispatch_at not set: %+v", first)
+	}
+	originalFirst := first.FirstDispatchAt
+
+	if err := st.TouchIssueFirstDispatch(repo, issue); err != nil {
+		t.Fatalf("second touch: %v", err)
+	}
+	second, err := st.QueryIssueCycleState(repo, issue)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if !second.FirstDispatchAt.Equal(originalFirst) {
+		t.Fatalf("first_dispatch_at changed: original=%v second=%v", originalFirst, second.FirstDispatchAt)
+	}
+}
+
+func TestMarkIssueCycleCapHitIsIdempotent(t *testing.T) {
+	st := newCycleTestStore(t)
+	repo := "owner/repo"
+	issue := 3
+
+	if err := st.MarkIssueCycleCapHit(repo, issue); err != nil {
+		t.Fatalf("MarkIssueCycleCapHit: %v", err)
+	}
+	first, err := st.QueryIssueCycleState(repo, issue)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if first == nil || first.CapHitAt.IsZero() {
+		t.Fatalf("cap_hit_at not set: %+v", first)
+	}
+	originalHit := first.CapHitAt
+
+	if err := st.MarkIssueCycleCapHit(repo, issue); err != nil {
+		t.Fatalf("second MarkIssueCycleCapHit: %v", err)
+	}
+	second, err := st.QueryIssueCycleState(repo, issue)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if !second.CapHitAt.Equal(originalHit) {
+		t.Fatalf("cap_hit_at changed: original=%v second=%v", originalHit, second.CapHitAt)
+	}
+}
+
+func TestResetIssueCycleStateRemovesRow(t *testing.T) {
+	st := newCycleTestStore(t)
+	repo := "owner/repo"
+	issue := 4
+
+	if _, err := st.IncrementDevReviewCycleCount(repo, issue); err != nil {
+		t.Fatalf("IncrementDevReviewCycleCount: %v", err)
+	}
+	if err := st.ResetIssueCycleState(repo, issue); err != nil {
+		t.Fatalf("ResetIssueCycleState: %v", err)
+	}
+	state, err := st.QueryIssueCycleState(repo, issue)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if state != nil {
+		t.Fatalf("expected nil after reset, got %+v", state)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -290,6 +290,15 @@ func (s *Store) createTables() error {
 			expires_at DATETIME NOT NULL,
 			PRIMARY KEY (repo, issue_num)
 		)`,
+		`CREATE TABLE IF NOT EXISTS issue_cycle_state (
+			repo TEXT NOT NULL,
+			issue_num INTEGER NOT NULL,
+			dev_review_cycle_count INTEGER NOT NULL DEFAULT 0,
+			first_dispatch_at DATETIME,
+			cap_hit_at DATETIME,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (repo, issue_num)
+		)`,
 	}
 	for _, stmt := range stmts {
 		if _, err := s.db.Exec(stmt); err != nil {

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -113,6 +113,17 @@ const (
 	DependencyVerdictNeedsHuman = "needs_human"
 )
 
+// IssueCycleState tracks per-issue dev↔review cycle counts and timing
+// for the orchestrator-level cycle-cap and long-flight stuck detector.
+type IssueCycleState struct {
+	Repo                string
+	IssueNum            int
+	DevReviewCycleCount int
+	FirstDispatchAt     time.Time
+	CapHitAt            time.Time
+	UpdatedAt           time.Time
+}
+
 type IssueDependency struct {
 	Repo              string
 	IssueNum          int

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -2827,6 +2827,25 @@ requirements:
       and long-flight stuck signals independently. `workbuddy issue restart`
       clears the per-issue cycle state so a human-resolved issue can be
       requeued without manual SQL.
+
+      Per the maintainer override comment on issue #214, the cycle counter
+      uses Option A reset semantics: when a human flips status:blocked →
+      status:developing, the StateMachine clears `dev_review_cycle_count`
+      and `cap_hit_at` so the cap re-engages from zero. The
+      blocked→developing label transition itself does not count as a
+      round-trip. The reset is detected via the persisted
+      workflow_instance.current_state, which now advances through stateless
+      states (e.g. blocked, done) so the prior-state check is reliable.
+
+      Architectural note (deviation from literal AC-085-2): the Coordinator
+      does NOT auto-flip `status:blocked` from Go code, since the project's
+      GH call boundary forbids label writes from Coordinator. Instead, on
+      cap-hit the Coordinator (a) blocks all further dispatch for the issue,
+      (b) records `cap_hit_at`, and (c) posts a needs-human comment with
+      explicit instructions to flip the label or run `workbuddy issue
+      restart`. The dispatch block is enforced at the orchestration layer
+      regardless of label state, so the user-visible effect ("agent stops
+      retrying after the cap") is identical to an auto-flip.
     priority: P1
     version: v0.5.0
     status: tested
@@ -2839,6 +2858,7 @@ requirements:
       - "AC-086-6: Notifier publishes `dev_review_cycle_approaching` at cycles == cap-1 so an operator heads-up notification can fire"
       - "AC-086-7: Tests cover clean issue (no extra cycle), 1-cycle issue, cap-hit issue (auto-block + digest), long-flight issue without cycles"
       - "AC-086-8: `workbuddy issue restart` clears the issue_cycle_state row and reports cycle_state_cleared"
+      - "AC-086-9: Cycle counter resets on a human-driven status:blocked → status:developing label transition (Option A reset), preserving the maintainer-stated 'give the agent another shot' semantic; the blocked→developing transition itself does not count as a round-trip"
     code:
       - internal/config/types.go
       - internal/config/loader.go

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -2800,3 +2800,72 @@ requirements:
       - internal/app/coordinator_test.go
       - cmd/coordinator_audit_test.go
     deps: [REQ-019]
+
+  - id: REQ-086
+    title: Dev↔review cycle counter, cap, and long-flight stuck detector
+    description: >
+      Issue #210 ran 7 dev↔review cycles over ~2h15min with no built-in cap.
+      This requirement adds an orchestrator-level cycle counter, a workflow-
+      configurable cap, a rejection-trail digest comment on cap-hit, a long-
+      flight stuck signal independent of per-state dwell, and operator-visible
+      cycle counts in `workbuddy status` and the dashboard API.
+
+      `dev_review_cycle_count` increments on every developing→reviewing→
+      developing round-trip (detected at state-entry into developing when the
+      persisted workflow_instance.current_state is reviewing). On reaching
+      `max_review_cycles` (workflow frontmatter; default 3) the StateMachine
+      stops dispatching dev-agent / review-agent for the issue, emits
+      `dev_review_cycle_cap_reached` event + alert, and posts a needs-human
+      comment whose rejection-trail digest is assembled from existing
+      `completed` events (no agent re-invocation). At `cycles == cap-1` the
+      Coordinator publishes `dev_review_cycle_approaching` so the notifier
+      can fire a heads-up.
+
+      The audit and auditapi handlers expose `dev_review_cycle_count`,
+      `first_dispatch_at`, and a derived `long_flight` boolean (>4h since
+      first dispatch) so `workbuddy status --stuck` can surface dwell-time
+      and long-flight stuck signals independently. `workbuddy issue restart`
+      clears the per-issue cycle state so a human-resolved issue can be
+      requeued without manual SQL.
+    priority: P1
+    version: v0.5.0
+    status: tested
+    acceptance_criteria:
+      - "AC-086-1: `dev_review_cycle_count` increments per developing→reviewing→developing round-trip and is visible at `/api/v1/issues/<repo>/<num>` and on the local audit /issues/.../state surface"
+      - "AC-086-2: `max_review_cycles` is read from workflow frontmatter (default 3); on cap-hit dispatch is blocked and a needs-human comment is posted with a rejection-trail digest assembled by Coordinator Go code"
+      - "AC-086-3: The needs-human comment uses FormatCycleCapReport and includes cycle count, cap, hit-time, and per-rejection digest entries"
+      - "AC-086-4: The audit IssueStateResponse exposes `long_flight` true when first_dispatch_at is older than 4h and the issue is open in an intermediate state, independent of per-state dwell"
+      - "AC-086-5: `workbuddy status` renders `cycles=N` inline with the CYCLES column for any issue with `dev_review_cycle_count > 0`"
+      - "AC-086-6: Notifier publishes `dev_review_cycle_approaching` at cycles == cap-1 so an operator heads-up notification can fire"
+      - "AC-086-7: Tests cover clean issue (no extra cycle), 1-cycle issue, cap-hit issue (auto-block + digest), long-flight issue without cycles"
+      - "AC-086-8: `workbuddy issue restart` clears the issue_cycle_state row and reports cycle_state_cleared"
+    code:
+      - internal/config/types.go
+      - internal/config/loader.go
+      - internal/store/store.go
+      - internal/store/queries.go
+      - internal/store/types.go
+      - internal/statemachine/statemachine.go
+      - internal/eventlog/eventlog.go
+      - internal/alertbus/alertbus.go
+      - internal/audit/http.go
+      - internal/auditapi/handler.go
+      - internal/reporter/reporter.go
+      - internal/reporter/format.go
+      - internal/app/cycle_cap.go
+      - internal/app/repo_runtime.go
+      - cmd/admin_restart_issue.go
+      - cmd/status.go
+      - .github/workbuddy/workflows/default.md
+      - schemas/workflow.schema.json
+      - CLAUDE.md
+    tests:
+      - internal/statemachine/cycle_cap_test.go
+      - internal/store/queries_cycle_state_test.go
+      - internal/audit/http_long_flight_test.go
+      - internal/reporter/cycle_cap_format_test.go
+      - cmd/admin_restart_issue_test.go
+    related_docs:
+      - .github/workbuddy/workflows/default.md
+      - CLAUDE.md
+    deps: [REQ-021, REQ-085]

--- a/schemas/workflow.schema.json
+++ b/schemas/workflow.schema.json
@@ -33,6 +33,12 @@
       "minimum": 0,
       "default": 3,
       "description": "Upper bound on state revisits before the runtime records retry/failure intent."
+    },
+    "max_review_cycles": {
+      "type": "integer",
+      "minimum": 0,
+      "default": 3,
+      "description": "Orchestrator-level cap on dev↔review round-trips (developing→reviewing→developing). On cap-hit the Coordinator stops dispatching dev-agent and review-agent, posts a needs-human comment with a rejection-trail digest, and emits dev_review_cycle_cap_reached. 0 (or unset) inherits the default of 3."
     }
   }
 }


### PR DESCRIPTION
Fixes #214

## Summary
- Tracks `dev_review_cycle_count` per issue (developing→reviewing→developing round-trips, detected at state-entry).
- Adds workflow-level `max_review_cycles` (default 3); on cap-hit the StateMachine blocks dispatch, marks `cap_hit_at`, and posts a needs-human comment whose rejection-trail digest is assembled by Coordinator Go code from existing `completed` events (no agent re-invocation).
- Publishes `dev_review_cycle_approaching` at `cycles == cap - 1` so the existing notifier pipeline can fire a heads-up.
- Adds an independent **long-flight** stuck signal (`first_dispatch_at` > 4h, default) to the audit + auditapi `IssueState` responses; `workbuddy status --stuck` now surfaces dwell vs long_flight (or both) via `stuck_reason`.
- Renders `cycles=N` inline in the `workbuddy status` table for any issue with `dev_review_cycle_count > 0`.
- `workbuddy issue restart` clears the new `issue_cycle_state` row alongside the existing recovery state.

## Where the change lives
- State machine: `internal/statemachine/statemachine.go` (cap detection at state-entry; `applyDevReviewCycleCap`, `recordStateEntry`).
- Store: new `issue_cycle_state` table + idempotent helpers (`internal/store/store.go`, `queries.go`, `types.go`).
- Audit/dashboard: `internal/audit/http.go`, `internal/auditapi/handler.go`.
- Reporter: `internal/reporter/format.go` (`FormatCycleCapReport`), `reporter.go` (`ReportDevReviewCycleCap`, `CycleCapTrailLoader`).
- Wiring: `internal/app/repo_runtime.go` + new `internal/app/cycle_cap.go` (adapter + trail loader).
- CLI: `cmd/status.go`, `cmd/admin_restart_issue.go`.
- Config: `max_review_cycles` in `internal/config/types.go` + loader default; `.github/workbuddy/workflows/default.md`; `schemas/workflow.schema.json`.
- Docs: REQ-085 in `project-index.yaml`; CLAUDE.md north-star #6 expanded.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/statemachine/... -run TestCycleCap` (clean, 1-cycle, approaching, cap-hit + comment, first_dispatch touch).
- [x] `go test ./internal/store/...` (counter, touch idempotence, cap-hit idempotence, reset).
- [x] `go test ./internal/audit/...` (long-flight surfaced even with fresh dwell event; not surfaced when recent; dev_review_cycle_count exposed).
- [x] `go test ./internal/reporter/...` (digest format, loader wired, loader-error fallback).
- [x] `go test ./cmd/...` including new restart-issue cycle-state test.
- [x] `go run . validate` and `go run . validate-docs --strict` exit 0.
- [x] `python3 ~/.autoharness/scripts/validate_index.py project-index.yaml` passes.

## Notes on the architectural rule
Per the project rule "Go code does not write labels", the cap-hit path does NOT auto-flip `status:blocked`. Instead it (a) stops dispatching dev/review for the issue and (b) posts a needs-human comment whose body explicitly instructs the human reviewer to flip the label or run `workbuddy issue restart` after resolving the disagreement. This honors AC-085-2's intent (no further auto-cycles) without violating the GH call boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)