### PR TITLE
Add SPA scaffolding for the web UI (#217)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Cache pnpm store + node_modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            web/node_modules
+            ~/.local/share/pnpm/store
+          key: pnpm-${{ runner.os }}-${{ hashFiles('web/pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-${{ runner.os }}-
+
+      - name: Install web deps
+        run: pnpm -C web install --frozen-lockfile
+
+      - name: Build SPA
+        run: pnpm -C web build
+
+      - name: Sync embed dist
+        run: |
+          rm -rf internal/webui/dist
+          cp -r web/dist internal/webui/dist
+          touch internal/webui/dist/.keep
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go build
+        run: go build ./...
+
+      - name: go test
+        run: go test ./... -count=1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,21 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Build SPA bundle for embed
+        run: |
+          pnpm -C web install --frozen-lockfile
+          pnpm -C web build
+          rm -rf internal/webui/dist
+          cp -r web/dist internal/webui/dist
+          touch internal/webui/dist/.keep
+
       - name: Run tests
         run: go test ./... -count=1
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,16 @@
 # Build output
 /workbuddy
 /dist/
+/bin/
+
+# Front-end build artefacts. The SPA bundle is rebuilt by `make web`;
+# only the placeholder index.html and .keep marker stay in version
+# control so `go build` / `go:embed` keep working on a fresh clone.
+/web/dist/
+/web/node_modules/
+/internal/webui/dist/*
+!/internal/webui/dist/.keep
+!/internal/webui/dist/index.html
 
 # Local state and logs
 .workbuddy/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.PHONY: web build clean test vet
+
+# Build the front-end bundle and copy it into the embed root so
+# `go build` produces a binary with the real SPA. The `.keep` file is
+# written last so a fresh checkout still has a valid embed target.
+web:
+	corepack enable
+	pnpm -C web install --frozen-lockfile
+	pnpm -C web build
+	rm -rf internal/webui/dist
+	cp -r web/dist internal/webui/dist
+	touch internal/webui/dist/.keep
+
+build: web
+	go build -o bin/workbuddy .
+
+test:
+	go test ./... -count=1
+
+vet:
+	go vet ./...
+
+clean:
+	rm -rf web/dist internal/webui/dist web/node_modules bin/

--- a/cmd/coordinator.go
+++ b/cmd/coordinator.go
@@ -593,6 +593,10 @@ func buildCoordinatorMux(api *app.FullCoordinatorServer, st *store.Store, evlog 
 	mux.Handle("/api/v1/workers", api.WrapAuth(dashboardMux))
 	mux.Handle("/api/v1/issues/in-flight", api.WrapAuth(dashboardMux))
 	mux.Handle("/api/v1/issues/", api.WrapAuth(dashboardMux))
+
+	spa := webui.SPAHandler()
+	sessionUI.SetFallback(spa)
+
 	mux.Handle("/sessions", api.WrapAuth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		sessionMux.ServeHTTP(w, r)
 	})))
@@ -613,6 +617,10 @@ func buildCoordinatorMux(api *app.FullCoordinatorServer, st *store.Store, evlog 
 	mux.Handle("/api/v1/config/reload", api.WrapAuth(http.HandlerFunc(api.HandleConfigReload)))
 	mux.Handle("/api/v1/tasks/poll", api.WrapAuth(http.HandlerFunc(api.HandlePollTask)))
 	mux.Handle("/api/v1/tasks/", api.WrapAuth(http.HandlerFunc(api.HandleTaskAction)))
+
+	// SPA catch-all is registered last so any earlier exact/subtree pattern
+	// (login, /api/, /sessions/, etc.) wins over the embedded bundle.
+	mux.Handle("/", api.WrapAuth(spa))
 	return mux
 }
 

--- a/cmd/worker_repos.go
+++ b/cmd/worker_repos.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/Lincyaw/workbuddy/internal/auditapi"
 	"github.com/Lincyaw/workbuddy/internal/store"
-	"github.com/Lincyaw/workbuddy/internal/webui"
 	"github.com/Lincyaw/workbuddy/internal/workerclient"
 	"github.com/spf13/cobra"
 )
@@ -232,14 +231,6 @@ func startWorkerMgmtServer(mgmtAddr, addrFile, authToken string, bindings *worke
 		sessionAPIMux := http.NewServeMux()
 		sessionAPI.RegisterSessionsOnly(sessionAPIMux)
 		mux.Handle("/sessions/", protected(sessionAPIMux))
-
-		sessionUI := webui.NewHandler(st)
-		sessionUI.SetSessionsDir(sessionsDir)
-		sessionUIMux := http.NewServeMux()
-		sessionUI.Register(sessionUIMux)
-		mux.Handle("/sessions", protected(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			sessionUIMux.ServeHTTP(w, r)
-		})))
 	}
 
 	srv := &http.Server{Handler: mux}

--- a/internal/webui/dist/index.html
+++ b/internal/webui/dist/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>workbuddy</title>
+    <style>
+      body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 36rem; margin: 4rem auto; padding: 0 1rem; color: #24292f; }
+      code { background: #f0f3f6; padding: 0.1rem 0.4rem; border-radius: 4px; }
+    </style>
+  </head>
+  <body>
+    <h1>workbuddy webui not built</h1>
+    <p>
+      You are running a binary that was built without the front-end bundle.
+      Run <code>make web</code> (or <code>make build</code>) from the repo root
+      to produce <code>internal/webui/dist/</code> and rebuild
+      <code>workbuddy</code>.
+    </p>
+    <p>
+      API endpoints (<code>/api/v1/...</code>, <code>/health</code>, etc.)
+      continue to work; only the dashboard UI is unavailable.
+    </p>
+  </body>
+</html>

--- a/internal/webui/embed.go
+++ b/internal/webui/embed.go
@@ -1,0 +1,12 @@
+package webui
+
+import "embed"
+
+// distFS holds the production SPA bundle produced by `pnpm -C web build`
+// and copied into internal/webui/dist/ by `make web`. The directory ships
+// with a placeholder index.html so a fresh `go build` succeeds without
+// running the front-end pipeline first; `make web` overwrites it with
+// the real bundle.
+//
+//go:embed dist
+var distFS embed.FS

--- a/internal/webui/handler.go
+++ b/internal/webui/handler.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"html/template"
 	"io"
 	"log"
 	"net/http"
@@ -16,36 +15,23 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Lincyaw/workbuddy/internal/auditapi"
 	"github.com/Lincyaw/workbuddy/internal/store"
 )
 
-// Handler serves the session viewer web UI.
+// Handler serves the session event API (events.json + SSE stream) consumed
+// by the SPA. The legacy HTML list/detail pages have been retired in favour
+// of the embedded SPA bundle; see SetFallback for the bridge to it.
 type Handler struct {
-	store        *store.Store
-	sessionsDir  string
-	basePath     string
-	listTmpl     *template.Template
-	detailTmpl   *template.Template
-	notFoundTmpl *template.Template
+	sessionsDir string
+	basePath    string
+	fallback    http.Handler
 }
 
-// NewHandler creates a Handler backed by the given store.
-func NewHandler(st *store.Store) *Handler {
-	funcMap := template.FuncMap{
-		"truncate": func(s string, n int) string {
-			if len(s) <= n {
-				return s
-			}
-			return s[:n] + "..."
-		},
-	}
-
-	h := &Handler{store: st, basePath: "/sessions"}
-	h.listTmpl = template.Must(template.New("list").Funcs(funcMap).Parse(listHTML))
-	h.detailTmpl = template.Must(template.New("detail").Funcs(funcMap).Parse(detailHTML))
-	h.notFoundTmpl = template.Must(template.New("notfound").Parse(notFoundHTML))
-	return h
+// NewHandler creates a Handler. The store argument is retained for API
+// stability; the events.json and stream endpoints read directly from the
+// per-session events-v1.jsonl files configured via SetSessionsDir.
+func NewHandler(_ *store.Store) *Handler {
+	return &Handler{basePath: "/sessions"}
 }
 
 // SetSessionsDir configures the directory where per-session event logs live,
@@ -55,64 +41,47 @@ func (h *Handler) SetSessionsDir(dir string) {
 	h.sessionsDir = dir
 }
 
-// Register adds the session viewer routes to the given mux.
+// SetFallback installs a handler used when a request under the session base
+// path does not target the events.json or stream endpoint. The SPA scaffold
+// uses this to take over the legacy HTML list/detail routes — clients that
+// land on /sessions or /sessions/{id} get the SPA shell instead of the
+// retired Go-side templates.
+//
+// When fallback is nil, unrecognised subpaths return 404 (the original
+// behaviour minus the deleted list/detail handlers).
+func (h *Handler) SetFallback(fallback http.Handler) {
+	h.fallback = fallback
+}
+
+// Register adds the session API routes (events.json and stream) to the given
+// mux. The legacy HTML list and detail pages are no longer registered — the
+// SPA handler at "/" owns them.
 func (h *Handler) Register(mux *http.ServeMux) {
 	h.RegisterAt(mux, h.basePath)
 }
 
-// RegisterAt mounts the session viewer routes under the given base path.
+// RegisterAt mounts the session API routes under the given base path.
 func (h *Handler) RegisterAt(mux *http.ServeMux, basePath string) {
 	basePath = strings.TrimRight(basePath, "/")
 	if basePath == "" {
 		basePath = "/sessions"
 	}
 	h.basePath = basePath
-	mux.HandleFunc(basePath, h.handleList)
 	mux.HandleFunc(basePath+"/", h.handleSessionSubpath)
-}
-
-// handleList renders the session list page with optional filtering.
-func (h *Handler) handleList(w http.ResponseWriter, r *http.Request) {
-	q := r.URL.Query()
-	filter := store.SessionFilter{
-		Repo:      q.Get("repo"),
-		AgentName: q.Get("agent"),
-	}
-	if issueStr := q.Get("issue"); issueStr != "" {
-		if n, err := strconv.Atoi(issueStr); err == nil {
-			filter.IssueNum = n
-		}
-	}
-
-	sessions, err := h.store.ListAgentSessions(filter)
-	if err != nil {
-		http.Error(w, "Internal server error", http.StatusInternalServerError)
-		return
-	}
-
-	data := listData{Sessions: sessions, Filter: filter}
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := h.listTmpl.Execute(w, data); err != nil {
-		http.Error(w, "Template error", http.StatusInternalServerError)
-	}
 }
 
 // handleSessionSubpath dispatches requests under /sessions/ based on suffix:
 //
-//	/sessions/{id}                → detail HTML
 //	/sessions/{id}/events.json    → paginated JSON events
 //	/sessions/{id}/stream         → SSE tail
+//
+// Anything else (including the empty suffix that used to render the HTML
+// detail page) is delegated to the SPA fallback when one is configured, or
+// returns 404 otherwise.
 func (h *Handler) handleSessionSubpath(w http.ResponseWriter, r *http.Request) {
 	rest := strings.TrimPrefix(r.URL.Path, h.basePath+"/")
-	if rest == "" {
-		http.Redirect(w, r, h.basePath, http.StatusFound)
-		return
-	}
-
 	sessionID, suffix, _ := strings.Cut(rest, "/")
 	switch suffix {
-	case "":
-		h.handleDetail(w, r, sessionID)
 	case "events.json":
 		markDeprecated(w, r,
 			"/sessions/{id}/events.json",
@@ -124,6 +93,12 @@ func (h *Handler) handleSessionSubpath(w http.ResponseWriter, r *http.Request) {
 			"/api/v1/sessions/{id}/stream")
 		h.handleStream(w, r, sessionID)
 	default:
+		// Empty suffix (the legacy detail page) and any other path now
+		// belong to the SPA when a fallback is configured.
+		if h.fallback != nil {
+			h.fallback.ServeHTTP(w, r)
+			return
+		}
 		http.NotFound(w, r)
 	}
 }
@@ -169,61 +144,6 @@ func markDeprecated(w http.ResponseWriter, r *http.Request, oldPath, newPath str
 	w.Header().Set("Sunset", "30 days")
 	w.Header().Set("Link", `<`+newPath+`>; rel="successor-version"`)
 	log.Printf("[deprecated] old path %s accessed (request %s), prefer %s", oldPath, r.URL.Path, newPath)
-}
-
-// handleDetail renders a single session detail page.
-func (h *Handler) handleDetail(w http.ResponseWriter, r *http.Request, sessionID string) {
-	sess, err := h.store.GetAgentSession(sessionID)
-	if err != nil {
-		http.Error(w, "Internal server error", http.StatusInternalServerError)
-		return
-	}
-	if sess == nil {
-		if prefersJSON(r) {
-			writeJSONStatus(w, http.StatusNotFound, map[string]string{"error": "session not found"})
-			return
-		}
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.WriteHeader(http.StatusNotFound)
-		_ = h.notFoundTmpl.Execute(w, sessionID)
-		return
-	}
-
-	if prefersJSON(r) {
-		writeJSONStatus(w, http.StatusOK, auditapi.BuildSessionResponse(sess, h.sessionsDir))
-		return
-	}
-
-	var taskStatus string
-	if sess.TaskID != "" {
-		tasks, err := h.store.QueryTasks("")
-		if err == nil {
-			for _, t := range tasks {
-				if t.ID == sess.TaskID {
-					taskStatus = t.Status
-					break
-				}
-			}
-		}
-	}
-
-	hasEvents := false
-	if p := h.eventsPath(sessionID); p != "" {
-		if _, err := os.Stat(p); err == nil {
-			hasEvents = true
-		}
-	}
-
-	data := detailData{
-		Session:    *sess,
-		TaskStatus: taskStatus,
-		HasEvents:  hasEvents,
-	}
-
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := h.detailTmpl.Execute(w, data); err != nil {
-		http.Error(w, "Template error", http.StatusInternalServerError)
-	}
 }
 
 // handleEventsJSON returns a paginated slice of events from events-v1.jsonl.
@@ -486,20 +406,9 @@ func isValidSessionID(sessionID string) bool {
 	return true
 }
 
-func prefersJSON(r *http.Request) bool {
-	if r.URL.Query().Get("format") == "json" {
-		return true
-	}
-	return strings.Contains(r.Header.Get("Accept"), "application/json")
-}
-
 func writeJSON(w http.ResponseWriter, v any) {
-	writeJSONStatus(w, http.StatusOK, v)
-}
-
-func writeJSONStatus(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
+	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(v)
 }
 
@@ -613,20 +522,7 @@ func truncString(s string, n int) string {
 	return s[:n] + "… [truncated]"
 }
 
-// listData is the template data for the session list page.
-type listData struct {
-	Sessions []store.AgentSession
-	Filter   store.SessionFilter
-}
-
-// detailData is the template data for the session detail page.
-type detailData struct {
-	Session    store.AgentSession
-	TaskStatus string
-	HasEvents  bool
-}
-
-// SessionURL returns the URL path for a session detail page.
+// SessionURL returns the URL path for a session detail page in the SPA.
 func SessionURL(sessionID string) string {
 	return fmt.Sprintf("/sessions/%s", sessionID)
 }

--- a/internal/webui/spa.go
+++ b/internal/webui/spa.go
@@ -1,0 +1,88 @@
+package webui
+
+import (
+	"io/fs"
+	"net/http"
+	"path"
+	"strings"
+)
+
+// SPAHandler returns an http.Handler that serves the embedded SPA bundle.
+//
+// Behaviour:
+//   - Requests whose path resolves to a real file inside dist/ (e.g.
+//     /assets/index-*.js, /favicon.ico, /index.html) are served directly
+//     with sensible Content-Type headers.
+//   - Any other GET/HEAD request falls back to dist/index.html, so client-
+//     side routes deep-linked by the browser hydrate the SPA.
+//   - Non-GET/HEAD requests get 405 — the SPA endpoint is read-only.
+//
+// Auth is intentionally NOT enforced here: callers wrap the handler with
+// their existing auth middleware (e.g. api.WrapAuth).
+func SPAHandler() http.Handler {
+	sub, err := fs.Sub(distFS, "dist")
+	if err != nil {
+		// fs.Sub only fails when the embedded path is wrong, which would be
+		// a build-time bug rather than a runtime condition.
+		panic("webui: embed dist subtree missing: " + err.Error())
+	}
+	fileServer := http.FileServer(http.FS(sub))
+	return &spaHandler{root: sub, files: fileServer}
+}
+
+type spaHandler struct {
+	root  fs.FS
+	files http.Handler
+}
+
+func (h *spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", "GET, HEAD")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	clean := path.Clean("/" + strings.TrimPrefix(r.URL.Path, "/"))
+	if clean == "/" {
+		h.serveIndex(w, r)
+		return
+	}
+
+	rel := strings.TrimPrefix(clean, "/")
+	if rel == "" || strings.Contains(rel, "..") {
+		h.serveIndex(w, r)
+		return
+	}
+
+	if exists, _ := fileExists(h.root, rel); exists {
+		h.files.ServeHTTP(w, r)
+		return
+	}
+	h.serveIndex(w, r)
+}
+
+func (h *spaHandler) serveIndex(w http.ResponseWriter, r *http.Request) {
+	data, err := fs.ReadFile(h.root, "index.html")
+	if err != nil {
+		http.Error(w, "webui not available", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache")
+	if r.Method == http.MethodHead {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	_, _ = w.Write(data)
+}
+
+// fileExists reports whether rel points at a regular file inside fsys.
+// Directories don't count — they should fall back to index.html so the
+// SPA owns the route rather than the file server's auto-index.
+func fileExists(fsys fs.FS, rel string) (bool, error) {
+	info, err := fs.Stat(fsys, rel)
+	if err != nil {
+		return false, err
+	}
+	return !info.IsDir(), nil
+}

--- a/internal/webui/spa_test.go
+++ b/internal/webui/spa_test.go
@@ -1,0 +1,164 @@
+package webui
+
+import (
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestSPAHandler_ServesAssets verifies that real files inside dist/ are
+// streamed back with the right body and an asset-friendly Content-Type so
+// the browser executes JavaScript bundles.
+func TestSPAHandler_ServesAssets(t *testing.T) {
+	t.Parallel()
+	asset := pickAssetFromEmbed(t)
+	srv := httptest.NewServer(SPAHandler())
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + asset.urlPath)
+	if err != nil {
+		t.Fatalf("GET %s: %v", asset.urlPath, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	ct := resp.Header.Get("Content-Type")
+	if !strings.Contains(ct, asset.expectContentType) {
+		t.Fatalf("Content-Type = %q, want it to contain %q", ct, asset.expectContentType)
+	}
+}
+
+// TestSPAHandler_FallbackServesIndex verifies that any unmatched path falls
+// back to dist/index.html so client-side routes hydrate the SPA shell.
+func TestSPAHandler_FallbackServesIndex(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(SPAHandler())
+	t.Cleanup(srv.Close)
+
+	for _, path := range []string{"/", "/some/random/path", "/dashboard", "/sessions/abc-123"} {
+		path := path
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+			resp, err := http.Get(srv.URL + path)
+			if err != nil {
+				t.Fatalf("GET %s: %v", path, err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want 200", resp.StatusCode)
+			}
+			if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "text/html") {
+				t.Fatalf("Content-Type = %q, want text/html", ct)
+			}
+		})
+	}
+}
+
+// TestSPAHandler_DoesNotInterceptAPIRoutes verifies that registering the SPA
+// at "/" alongside an API subtree leaves the API path untouched. This is the
+// invariant that lets `/api/v1/status` keep its original handler when the
+// coordinator mux is wired up.
+func TestSPAHandler_DoesNotInterceptAPIRoutes(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/status", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+	mux.Handle("/", SPAHandler())
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/status")
+	if err != nil {
+		t.Fatalf("GET /api/v1/status: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Fatalf("Content-Type = %q, want application/json — SPA handler intercepted the API route", ct)
+	}
+}
+
+// TestSPAHandler_RejectsNonReadMethods documents the read-only contract:
+// POST to a SPA path must not silently fall back to index.html.
+func TestSPAHandler_RejectsNonReadMethods(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(SPAHandler())
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Post(srv.URL+"/", "application/json", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatalf("POST /: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", resp.StatusCode)
+	}
+}
+
+type spaAsset struct {
+	urlPath           string
+	expectContentType string
+}
+
+// pickAssetFromEmbed walks the embedded dist subtree and picks the first file
+// that is not index.html. This keeps the test independent of whether the
+// placeholder bundle (just index.html) or a real `make web` bundle (index +
+// assets/*.js) is checked in.
+func pickAssetFromEmbed(t *testing.T) spaAsset {
+	t.Helper()
+	sub, err := fs.Sub(distFS, "dist")
+	if err != nil {
+		t.Fatalf("fs.Sub: %v", err)
+	}
+	var found spaAsset
+	walkErr := fs.WalkDir(sub, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		if path == "index.html" || path == ".keep" {
+			return nil
+		}
+		found = spaAsset{
+			urlPath:           "/" + path,
+			expectContentType: contentTypeFor(path),
+		}
+		return fs.SkipAll
+	})
+	if walkErr != nil {
+		t.Fatalf("walk dist: %v", walkErr)
+	}
+	if found.urlPath == "" {
+		// No real asset present in the placeholder bundle. Treat index.html
+		// itself as the asset under test — it is still a real file inside
+		// dist/ and exercises the "path matched a real file" branch.
+		found = spaAsset{urlPath: "/index.html", expectContentType: "text/html"}
+	}
+	return found
+}
+
+func contentTypeFor(path string) string {
+	switch {
+	case strings.HasSuffix(path, ".js"):
+		return "javascript"
+	case strings.HasSuffix(path, ".css"):
+		return "text/css"
+	case strings.HasSuffix(path, ".html"):
+		return "text/html"
+	case strings.HasSuffix(path, ".svg"):
+		return "image/svg"
+	default:
+		return ""
+	}
+}

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -2976,3 +2976,56 @@ requirements:
       - internal/webui/handler_test.go
       - cmd/coordinator_audit_test.go
     deps: [REQ-013, REQ-018, REQ-019, REQ-029]
+
+  - id: REQ-089
+    title: Web UI scaffold - Preact + Vite SPA embedded into the Go binary
+    description: >
+      Stand up the front-end build pipeline that future dashboard, sessions,
+      and issue-detail pages will live inside. A fresh `web/` workspace
+      builds a Preact + Vite single-page app; `make web` copies the bundle
+      into `internal/webui/dist/` and the Go binary embeds that directory
+      via go:embed. A new HTTP handler (`internal/webui.SPAHandler`) serves
+      the bundle and falls back to `index.html` for client-side routes,
+      while the legacy session list/detail HTML pages are retired in favour
+      of the SPA. The `events.json` and SSE `stream` endpoints stay in
+      place because the SPA still consumes them. The dist directory ships
+      with a placeholder `index.html` so a bare `go build` keeps working;
+      `make web` overwrites it with the real bundle. CI runs the SPA build
+      before `go build`/`go test`.
+    priority: P1
+    version: v0.5.0
+    status: tested
+    acceptance_criteria:
+      - "AC-089-1: `pnpm -C web install --frozen-lockfile && pnpm -C web build` succeeds on a clean checkout"
+      - "AC-089-2: `make build` produces `bin/workbuddy` in one shot, embedding the SPA bundle"
+      - "AC-089-3: `internal/webui.SPAHandler` returns the embedded `index.html` for `/` and unmatched paths, serves real files under `/assets/...` directly, and rejects non-GET/HEAD methods with 405"
+      - "AC-089-4: When the SPA handler is registered at `/`, sibling API routes (`/api/v1/...`) keep their original handler — the SPA does not intercept them"
+      - "AC-089-5: Coordinator mux registers the SPA at `/` after every other pattern; `/sessions/{id}/events.json` and `/sessions/{id}/stream` still hit the webui handler, while `/sessions` and `/sessions/{id}` deep-link into the SPA via the fallback"
+      - "AC-089-6: `web/dist/`, `web/node_modules/`, and `internal/webui/dist/*` are gitignored except for the `.keep` marker and the placeholder `index.html`"
+      - "AC-089-7: A CI workflow runs `corepack enable`, caches `web/node_modules` keyed off `web/pnpm-lock.yaml`, builds the SPA, then runs `go build`/`go vet`/`go test`"
+      - "AC-089-8: `internal/webui/spa_test.go` covers the asset-served, API-not-intercepted, and unmatched-path-falls-back-to-index branches"
+    code:
+      - web/package.json
+      - web/pnpm-lock.yaml
+      - web/tsconfig.json
+      - web/vite.config.ts
+      - web/index.html
+      - web/src/main.tsx
+      - web/src/App.tsx
+      - web/src/api/client.ts
+      - web/src/pages/Placeholder.tsx
+      - internal/webui/embed.go
+      - internal/webui/spa.go
+      - internal/webui/dist/index.html
+      - internal/webui/handler.go
+      - cmd/coordinator.go
+      - cmd/worker_repos.go
+      - Makefile
+      - .github/workflows/ci.yml
+      - .github/workflows/release.yml
+      - .gitignore
+    tests:
+      - internal/webui/spa_test.go
+    related_docs:
+      - web/README.md
+    deps: []

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+*.log
+.DS_Store
+*.tsbuildinfo

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,57 @@
+# workbuddy-web
+
+Preact + Vite single-page app served as the workbuddy dashboard. Real
+pages (dashboard, sessions, issue detail) ship in follow-up issues — this
+scaffold renders a placeholder so the build, embed, and proxy plumbing
+can be exercised end-to-end.
+
+## Layout
+
+```
+web/
+├── package.json           # pnpm @ 9.x
+├── tsconfig.json
+├── vite.config.ts         # dev proxy + outDir=dist
+├── index.html
+└── src/
+    ├── main.tsx           # mount <App /> on #root
+    ├── App.tsx            # Router shell + placeholder route
+    ├── api/client.ts      # fetch wrapper (cookies + 401 → /login)
+    └── pages/
+        └── Placeholder.tsx
+```
+
+## Development
+
+Requires Node 22 with corepack enabled (which makes `pnpm@9.x` available).
+
+```bash
+corepack enable
+pnpm -C web install --frozen-lockfile
+pnpm -C web dev
+```
+
+The dev server listens on `http://127.0.0.1:5173`. API requests under
+`/api/`, `/sessions/`, `/health`, `/metrics`, `/events`, `/tasks`,
+`/issues/`, `/workers/`, `/login`, and `/logout` are proxied to the
+coordinator at `http://127.0.0.1:8090` (override with the
+`WORKBUDDY_COORDINATOR_URL` environment variable).
+
+## Building for the Go binary
+
+The Go binary embeds `internal/webui/dist/`. The top-level `Makefile`
+target wires this together:
+
+```bash
+make build   # runs pnpm build, copies web/dist → internal/webui/dist, then go build
+```
+
+If you only need the front-end bundle:
+
+```bash
+pnpm -C web build
+```
+
+`go build ./...` on a fresh clone still succeeds because
+`internal/webui/dist/` ships with a placeholder `index.html` checked into
+the repo. `make build` overwrites it with the real bundle.

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>workbuddy</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "workbuddy-web",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@9.15.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "preact": "^10.25.0",
+    "preact-iso": "^2.9.0",
+    "@preact/signals": "^1.3.0"
+  },
+  "devDependencies": {
+    "vite": "^6.0.0",
+    "typescript": "^5.7.0",
+    "@types/node": "^22.10.0"
+  }
+}

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -1,0 +1,717 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@preact/signals':
+        specifier: ^1.3.0
+        version: 1.3.4(preact@10.29.1)
+      preact:
+        specifier: ^10.25.0
+        version: 10.29.1
+      preact-iso:
+        specifier: ^2.9.0
+        version: 2.11.1(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.17
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.2(@types/node@22.19.17)
+
+packages:
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@preact/signals-core@1.14.1':
+    resolution: {integrity: sha512-vxPpfXqrwUe9lpjqfYNjAF/0RF/eFGeLgdJzdmIIZjpOnTmGmAB4BjWone562mJGMRP4frU6iZ6ei3PDsu52Ng==}
+
+  '@preact/signals@1.3.4':
+    resolution: {integrity: sha512-TPMkStdT0QpSc8FpB63aOwXoSiZyIrPsP9Uj347KopdS6olZdAYeeird/5FZv/M1Yc1ge5qstub2o8VDbvkT4g==}
+    peerDependencies:
+      preact: 10.x
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  preact-iso@2.11.1:
+    resolution: {integrity: sha512-rLy0RmzP/hrDjnFdnEblxFgKtzUj4njkHrpGJBGS7S4QuYw1zv0lA38qsWpeAAB10JAz/hF2CsHrLen9ufCtbw==}
+    peerDependencies:
+      preact: '>=10 || >= 11.0.0-0'
+      preact-render-to-string: '>=6.4.0'
+
+  preact-render-to-string@6.6.7:
+    resolution: {integrity: sha512-3XdbsX3+vn9dQW+jJI/FsI9rlkgl6dbeUpqLsChak6jp3j3auFqBCkno7VChbMFs5Q8ylBj6DrUkKRwtVN3nvw==}
+    peerDependencies:
+      preact: '>=10 || >= 11.0.0-0'
+
+  preact@10.29.1:
+    resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
+
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@preact/signals-core@1.14.1': {}
+
+  '@preact/signals@1.3.4(preact@10.29.1)':
+    dependencies:
+      '@preact/signals-core': 1.14.1
+      preact: 10.29.1
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@22.19.17':
+    dependencies:
+      undici-types: 6.21.0
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.3:
+    optional: true
+
+  nanoid@3.3.11: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.12:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  preact-iso@2.11.1(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1):
+    dependencies:
+      preact: 10.29.1
+      preact-render-to-string: 6.6.7(preact@10.29.1)
+
+  preact-render-to-string@6.6.7(preact@10.29.1):
+    dependencies:
+      preact: 10.29.1
+
+  preact@10.29.1: {}
+
+  rollup@4.60.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
+
+  source-map-js@1.2.1: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  vite@6.4.2(@types/node@22.19.17):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.12
+      rollup: 4.60.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,0 +1,13 @@
+import { LocationProvider, Router, Route } from 'preact-iso';
+import { Placeholder } from './pages/Placeholder';
+
+export function App() {
+  return (
+    <LocationProvider>
+      <Router>
+        <Route path="/" component={Placeholder} />
+        <Route default component={Placeholder} />
+      </Router>
+    </LocationProvider>
+  );
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,0 +1,48 @@
+export interface ApiError extends Error {
+  status: number;
+  body: unknown;
+}
+
+function buildLoginRedirect(): string {
+  const next = encodeURIComponent(
+    window.location.pathname + window.location.search + window.location.hash,
+  );
+  return `/login?next=${next}`;
+}
+
+export async function apiFetch(input: string, init: RequestInit = {}): Promise<Response> {
+  const resp = await fetch(input, {
+    ...init,
+    credentials: 'include',
+    headers: {
+      Accept: 'application/json',
+      ...(init.headers ?? {}),
+    },
+  });
+
+  if (resp.status === 401) {
+    window.location.replace(buildLoginRedirect());
+    return resp;
+  }
+  return resp;
+}
+
+export async function apiJSON<T>(input: string, init: RequestInit = {}): Promise<T> {
+  const resp = await apiFetch(input, init);
+  const text = await resp.text();
+  let body: unknown = null;
+  if (text) {
+    try {
+      body = JSON.parse(text);
+    } catch {
+      body = text;
+    }
+  }
+  if (!resp.ok) {
+    const err = new Error(`request failed: ${resp.status}`) as ApiError;
+    err.status = resp.status;
+    err.body = body;
+    throw err;
+  }
+  return body as T;
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,0 +1,9 @@
+import { render } from 'preact';
+import { App } from './App';
+
+const root = document.getElementById('root');
+if (!root) {
+  throw new Error('#root element missing from index.html');
+}
+
+render(<App />, root);

--- a/web/src/pages/Placeholder.tsx
+++ b/web/src/pages/Placeholder.tsx
@@ -1,0 +1,13 @@
+export function Placeholder() {
+  return (
+    <main style={{ fontFamily: 'system-ui, sans-serif', padding: '2rem' }}>
+      <h1>workbuddy</h1>
+      <p>Hello from the SPA scaffold.</p>
+      <p>
+        Real pages (dashboard, sessions, issue details) ship in follow-up
+        issues. This page exists to prove the scaffold renders, the embed
+        pipeline works, and dev-server proxying reaches the coordinator.
+      </p>
+    </main>
+  );
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "verbatimModuleSyntax": false,
+
+    "types": ["node", "vite/client"],
+
+    "paths": {
+      "react": ["./node_modules/preact/compat/"],
+      "react-dom": ["./node_modules/preact/compat/"]
+    }
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,45 @@
+import { defineConfig } from 'vite';
+
+const COORDINATOR_PROXY = process.env.WORKBUDDY_COORDINATOR_URL || 'http://127.0.0.1:8090';
+
+const proxiedPrefixes = [
+  '/api',
+  '/health',
+  '/metrics',
+  '/events',
+  '/tasks',
+  '/issues',
+  '/sessions',
+  '/workers',
+  '/login',
+  '/logout',
+];
+
+const proxy: Record<string, { target: string; changeOrigin: boolean; ws: boolean }> = {};
+for (const prefix of proxiedPrefixes) {
+  proxy[prefix] = { target: COORDINATOR_PROXY, changeOrigin: true, ws: true };
+}
+
+export default defineConfig({
+  server: {
+    port: 5173,
+    strictPort: true,
+    proxy,
+  },
+  build: {
+    outDir: 'dist',
+    assetsDir: 'assets',
+    emptyOutDir: true,
+    sourcemap: false,
+  },
+  esbuild: {
+    jsx: 'automatic',
+    jsxImportSource: 'preact',
+  },
+  resolve: {
+    alias: {
+      react: 'preact/compat',
+      'react-dom': 'preact/compat',
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Stand up the front-end build pipeline that future dashboard, sessions, and issue-detail pages will live inside (#217).

- `web/` Preact + Vite scaffold rendering a single Hello placeholder, with a fetch wrapper that attaches cookies and redirects to `/login?next=…` on 401.
- `internal/webui.SPAHandler()` embeds `dist/` via `go:embed`, serves real files directly, and falls back to `index.html` for any unmatched path so client-side routes hydrate the SPA. A placeholder `index.html` ships with the repo so a fresh `go build` keeps working.
- Coordinator mux mounts SPA at `/` last; `/sessions/{id}/events.json` and `/sessions/{id}/stream` still hit the webui handler, and `/sessions` / `/sessions/{id}` fall through to the SPA via `Handler.SetFallback`.
- `Makefile` drives `pnpm -C web install/build` and copies `web/dist` into `internal/webui/dist` ahead of `go build`. New `ci.yml` runs corepack + cached pnpm install + SPA build before `go vet/build/test`; `release.yml` gains the same step so goreleaser ships the real bundle.
- `project-index.yaml` gains REQ-085 (status: tested), gated on `internal/webui/spa_test.go` (asset served, fallback, API-not-intercepted, method-not-allowed).

## Test plan
- [x] `pnpm -C web install --frozen-lockfile && pnpm -C web build` on a clean checkout
- [x] `make build` produces `bin/workbuddy`
- [x] `bin/workbuddy serve --listen 127.0.0.1:18217 --auth` returns SPA index.html for `/`, real JS for `/assets/index-*.js`, fallback for `/some/random/path`, and JSON for `/api/v1/status` (auth-required)
- [x] `go test ./... -count=1` (TestConcurrentWrites in eventlog is a pre-existing flake, passes on retry)
- [x] `go vet ./...` clean
- [x] `python3 ~/.autoharness/scripts/validate_index.py project-index.yaml` clean
- [x] `go run . validate-docs --strict` clean

Fixes #217