### PR TITLE
Dashboard JSON API: in-flight, issue detail, session subpaths (#218)

### DIFF
--- a/cmd/coordinator.go
+++ b/cmd/coordinator.go
@@ -574,6 +574,14 @@ func buildCoordinatorMux(api *app.FullCoordinatorServer, st *store.Store, evlog 
 	dashboardAPI := auditapi.NewHandler(st)
 	sessionsDir := filepath.Join(filepath.Dir(dbPath), "sessions")
 	dashboardAPI.SetSessionsDir(sessionsDir)
+
+	sessionUI := webui.NewHandler(st)
+	sessionUI.SetSessionsDir(sessionsDir)
+	sessionMux := http.NewServeMux()
+	sessionUI.Register(sessionMux)
+	dashboardAPI.SetSessionEventsHandler(sessionUI.HandleAPISessionEvents)
+	dashboardAPI.SetSessionStreamHandler(sessionUI.HandleAPISessionStream)
+
 	dashboardMux := http.NewServeMux()
 	dashboardAPI.RegisterDashboard(dashboardMux)
 	mux.Handle("/api/v1/status", api.WrapAuth(dashboardMux))
@@ -583,11 +591,8 @@ func buildCoordinatorMux(api *app.FullCoordinatorServer, st *store.Store, evlog 
 	mux.Handle("/api/v1/alerts", api.WrapAuth(dashboardMux))
 	mux.Handle("/api/v1/metrics", api.WrapAuth(dashboardMux))
 	mux.Handle("/api/v1/workers", api.WrapAuth(dashboardMux))
-
-	sessionUI := webui.NewHandler(st)
-	sessionUI.SetSessionsDir(sessionsDir)
-	sessionMux := http.NewServeMux()
-	sessionUI.Register(sessionMux)
+	mux.Handle("/api/v1/issues/in-flight", api.WrapAuth(dashboardMux))
+	mux.Handle("/api/v1/issues/", api.WrapAuth(dashboardMux))
 	mux.Handle("/sessions", api.WrapAuth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		sessionMux.ServeHTTP(w, r)
 	})))

--- a/cmd/coordinator_audit_test.go
+++ b/cmd/coordinator_audit_test.go
@@ -404,3 +404,84 @@ func TestCoordinatorWorkerSessionProxyUsesCoordinatorAuthSurface(t *testing.T) {
 		t.Fatalf("forwarded auth = %v, want Bearer secret-token", forwardedAuth)
 	}
 }
+
+// TestCoordinatorExposesInFlightEndpoint covers the end-to-end /api/v1/issues
+// surface introduced in issue #218: dispatch an issue, then query the dashboard
+// API to assert the in-flight row carries repo/issue_num/current_state and the
+// detail endpoint surfaces transitions.
+func TestCoordinatorExposesInFlightEndpoint(t *testing.T) {
+	port := getFreePort(t)
+	dbPath := filepath.Join(t.TempDir(), "coordinator.db")
+	seedCoordinatorAuditDB(t, dbPath)
+
+	// Add a transition event so the in-flight row has a last_transition_at.
+	st, err := store.NewStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if _, err := st.InsertEvent(store.Event{
+		Type:     "transition",
+		Repo:     "owner/repo-a",
+		IssueNum: 11,
+		Payload:  `{"from":"queued","to":"developing","by":"coordinator"}`,
+	}); err != nil {
+		_ = st.Close()
+		t.Fatalf("InsertEvent: %v", err)
+	}
+	_ = st.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runCoordinatorWithOpts(&coordinatorOpts{
+			port:         port,
+			pollInterval: time.Second,
+			dbPath:       dbPath,
+		}, nil, ctx)
+	}()
+	waitForHealth(t, port)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	// Empty repo returns []  — verified separately, but we also assert the
+	// real wiring returns a populated array on the dispatched issue.
+	resp := getCoordinator(t, client, fmt.Sprintf("http://localhost:%d/api/v1/issues/in-flight", port), "")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /api/v1/issues/in-flight status = %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if !strings.Contains(string(body), `"issue_num":11`) {
+		t.Fatalf("in-flight body missing issue 11: %s", string(body))
+	}
+	if !strings.Contains(string(body), `"current_state":"developing"`) {
+		t.Fatalf("in-flight body missing current_state: %s", string(body))
+	}
+
+	detailResp := getCoordinator(t, client, fmt.Sprintf("http://localhost:%d/api/v1/issues/owner/repo-a/11", port), "")
+	defer func() { _ = detailResp.Body.Close() }()
+	if detailResp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /api/v1/issues/.../11 status = %d", detailResp.StatusCode)
+	}
+	detailBody, err := io.ReadAll(detailResp.Body)
+	if err != nil {
+		t.Fatalf("read detail: %v", err)
+	}
+	if !strings.Contains(string(detailBody), `"transitions"`) {
+		t.Fatalf("detail body missing transitions: %s", string(detailBody))
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("coordinator: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("coordinator did not exit")
+	}
+}

--- a/internal/auditapi/handler.go
+++ b/internal/auditapi/handler.go
@@ -16,8 +16,14 @@ import (
 	"github.com/Lincyaw/workbuddy/internal/eventlog"
 	"github.com/Lincyaw/workbuddy/internal/operator"
 	"github.com/Lincyaw/workbuddy/internal/poller"
+	"github.com/Lincyaw/workbuddy/internal/sessionref"
 	"github.com/Lincyaw/workbuddy/internal/store"
 )
+
+// stuckThresholdSeconds is the elapsed-since-last-transition threshold beyond
+// which an issue is reported as `stuck` on /api/v1/status. Mirrors the audit
+// HTTP handler's 1-hour rule.
+const stuckThresholdSeconds = int64(3600)
 
 // badRequestError wraps parameter-validation errors so callers can distinguish
 // them from backend/DB errors returned by queryEvents.
@@ -29,9 +35,13 @@ func (e *badRequestError) Error() string { return e.msg }
 
 // Handler serves the JSON audit API.
 type Handler struct {
-	store       *store.Store
-	events      *eventlog.EventLogger
-	sessionsDir string
+	store           *store.Store
+	events          *eventlog.EventLogger
+	sessionsDir     string
+	reportBaseURL   string
+	now             func() time.Time
+	sessionEventsFn http.HandlerFunc
+	sessionStreamFn http.HandlerFunc
 }
 
 // NewHandler constructs a Handler backed by the given store.
@@ -39,12 +49,42 @@ func NewHandler(st *store.Store) *Handler {
 	return &Handler{
 		store:  st,
 		events: eventlog.NewEventLogger(st),
+		now:    time.Now,
 	}
 }
 
 // SetSessionsDir configures the directory where per-session artifacts live.
 func (h *Handler) SetSessionsDir(dir string) {
 	h.sessionsDir = dir
+}
+
+// SetReportBaseURL configures the base URL used to format last_session_url on
+// dashboard responses. Should match the reporter's --report-base-url flag.
+func (h *Handler) SetReportBaseURL(baseURL string) {
+	h.reportBaseURL = strings.TrimRight(baseURL, "/")
+}
+
+// SetNowFunc overrides the clock used for stuck-detection arithmetic. Tests
+// inject a deterministic clock; passing nil restores time.Now.
+func (h *Handler) SetNowFunc(now func() time.Time) {
+	if now == nil {
+		h.now = time.Now
+		return
+	}
+	h.now = now
+}
+
+// SetSessionEventsHandler installs the handler invoked for
+// /api/v1/sessions/{id}/events. The webui package owns the implementation
+// (it reads events-v1.jsonl from disk); auditapi just routes the suffix to it.
+func (h *Handler) SetSessionEventsHandler(fn http.HandlerFunc) {
+	h.sessionEventsFn = fn
+}
+
+// SetSessionStreamHandler installs the handler invoked for
+// /api/v1/sessions/{id}/stream (SSE).
+func (h *Handler) SetSessionStreamHandler(fn http.HandlerFunc) {
+	h.sessionStreamFn = fn
 }
 
 // Register mounts the audit API routes.
@@ -70,6 +110,8 @@ func (h *Handler) RegisterDashboard(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/alerts", h.handleAPIAlerts)
 	mux.HandleFunc("/api/v1/metrics", h.handleAPIMetrics)
 	mux.HandleFunc("/api/v1/workers", h.handleAPIWorkers)
+	mux.HandleFunc("/api/v1/issues/in-flight", h.handleAPIIssuesInFlight)
+	mux.HandleFunc("/api/v1/issues/", h.handleAPIIssueDetail)
 }
 
 // RegisterSessionsOnly mounts only the /sessions/ JSON endpoint without the
@@ -149,26 +191,33 @@ type SessionArtifactPaths struct {
 }
 
 type statusResponse struct {
-	ActiveSessions int        `json:"active_sessions"`
-	Workers        int        `json:"workers"`
-	LastPoll       *time.Time `json:"last_poll"`
+	ActiveSessions    int        `json:"active_sessions"`
+	Workers           int        `json:"workers"`
+	LastPoll          *time.Time `json:"last_poll"`
+	InFlightIssues    int        `json:"in_flight_issues"`
+	StuckIssuesOver1H int        `json:"stuck_issues_over_1h"`
+	Done24H           int        `json:"done_24h"`
+	Failed24H         int        `json:"failed_24h"`
 }
 
 type sessionListResponse struct {
-	SessionID  string     `json:"session_id"`
-	TaskID     string     `json:"task_id,omitempty"`
-	Repo       string     `json:"repo"`
-	IssueNum   int        `json:"issue_num"`
-	AgentName  string     `json:"agent_name"`
-	Runtime    string     `json:"runtime,omitempty"`
-	WorkerID   string     `json:"worker_id,omitempty"`
-	Attempt    int        `json:"attempt"`
-	Status     string     `json:"status"`
-	ExitCode   int        `json:"exit_code"`
-	Duration   int64      `json:"duration"`
-	CreatedAt  time.Time  `json:"created_at"`
-	FinishedAt *time.Time `json:"finished_at"`
-	Summary    string     `json:"summary,omitempty"`
+	SessionID    string     `json:"session_id"`
+	TaskID       string     `json:"task_id,omitempty"`
+	Repo         string     `json:"repo"`
+	IssueNum     int        `json:"issue_num"`
+	AgentName    string     `json:"agent_name"`
+	Runtime      string     `json:"runtime,omitempty"`
+	WorkerID     string     `json:"worker_id,omitempty"`
+	Attempt      int        `json:"attempt"`
+	Status       string     `json:"status"`
+	TaskStatus   string     `json:"task_status,omitempty"`
+	Workflow     string     `json:"workflow,omitempty"`
+	CurrentState string     `json:"current_state,omitempty"`
+	ExitCode     int        `json:"exit_code"`
+	Duration     int64      `json:"duration"`
+	CreatedAt    time.Time  `json:"created_at"`
+	FinishedAt   *time.Time `json:"finished_at"`
+	Summary      string     `json:"summary,omitempty"`
 }
 
 type sessionDetailResponse struct {
@@ -199,13 +248,62 @@ type metricsResponse struct {
 }
 
 type workerResponse struct {
-	ID            string    `json:"id"`
-	Repo          string    `json:"repo"`
-	Roles         []string  `json:"roles"`
-	Hostname      string    `json:"hostname,omitempty"`
-	Status        string    `json:"status"`
-	LastHeartbeat time.Time `json:"last_heartbeat"`
-	RegisteredAt  time.Time `json:"registered_at"`
+	ID              string    `json:"id"`
+	Repo            string    `json:"repo"`
+	Roles           []string  `json:"roles"`
+	Hostname        string    `json:"hostname,omitempty"`
+	Status          string    `json:"status"`
+	LastHeartbeat   time.Time `json:"last_heartbeat"`
+	LastHeartbeatAt time.Time `json:"last_heartbeat_at"`
+	RegisteredAt    time.Time `json:"registered_at"`
+	CurrentTaskID   string    `json:"current_task_id,omitempty"`
+	MgmtBaseURL     string    `json:"mgmt_base_url,omitempty"`
+}
+
+// inFlightIssueResponse is one row of /api/v1/issues/in-flight.
+type inFlightIssueResponse struct {
+	Repo             string         `json:"repo"`
+	IssueNum         int            `json:"issue_num"`
+	Title            string         `json:"title"`
+	CurrentState     string         `json:"current_state"`
+	CurrentLabel     string         `json:"current_label"`
+	Labels           []string       `json:"labels"`
+	CycleCounts      map[string]int `json:"cycle_counts"`
+	LastTransitionAt *time.Time     `json:"last_transition_at,omitempty"`
+	StuckForSeconds  int64          `json:"stuck_for_seconds"`
+	ClaimedWorkerID  string         `json:"claimed_worker_id,omitempty"`
+	LastSessionID    string         `json:"last_session_id,omitempty"`
+	LastSessionURL   string         `json:"last_session_url,omitempty"`
+}
+
+// issueTransitionResponse is one transition row in the issue-detail endpoint.
+type issueTransitionResponse struct {
+	From string    `json:"from"`
+	To   string    `json:"to"`
+	At   time.Time `json:"at"`
+	By   string    `json:"by,omitempty"`
+}
+
+// issueSessionRefResponse is one session row in the issue-detail endpoint.
+type issueSessionRefResponse struct {
+	SessionID  string     `json:"session_id"`
+	Agent      string     `json:"agent"`
+	StartedAt  time.Time  `json:"started_at"`
+	FinishedAt *time.Time `json:"finished_at,omitempty"`
+	Status     string     `json:"status,omitempty"`
+	ExitCode   int        `json:"exit_code"`
+}
+
+// issueDetailResponse is the body of /api/v1/issues/{repo}/{num}.
+type issueDetailResponse struct {
+	Repo             string                    `json:"repo"`
+	IssueNum         int                       `json:"issue_num"`
+	Title            string                    `json:"title"`
+	CurrentState     string                    `json:"current_state"`
+	Labels           []string                  `json:"labels"`
+	Transitions      []issueTransitionResponse `json:"transitions"`
+	TransitionCounts []transitionCountResponse `json:"transition_counts"`
+	Sessions         []issueSessionRefResponse `json:"sessions"`
 }
 
 func (h *Handler) handleEvents(w http.ResponseWriter, r *http.Request) {
@@ -278,11 +376,33 @@ func (h *Handler) handleAPISession(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
-	sessionID := strings.TrimPrefix(r.URL.Path, "/api/v1/sessions/")
-	if !isValidSessionID(sessionID) || strings.Contains(sessionID, "/") {
+	rest := strings.TrimPrefix(r.URL.Path, "/api/v1/sessions/")
+	sessionID, suffix, _ := strings.Cut(rest, "/")
+	if !isValidSessionID(sessionID) {
 		writeError(w, http.StatusNotFound, "session not found")
 		return
 	}
+	switch suffix {
+	case "":
+		h.serveSessionDetail(w, sessionID)
+	case "events":
+		if h.sessionEventsFn == nil {
+			writeError(w, http.StatusNotFound, "session events not configured")
+			return
+		}
+		h.sessionEventsFn(w, r)
+	case "stream":
+		if h.sessionStreamFn == nil {
+			writeError(w, http.StatusNotFound, "session stream not configured")
+			return
+		}
+		h.sessionStreamFn(w, r)
+	default:
+		writeError(w, http.StatusNotFound, "not found")
+	}
+}
+
+func (h *Handler) serveSessionDetail(w http.ResponseWriter, sessionID string) {
 	record, err := h.store.GetSession(sessionID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to query session")
@@ -298,6 +418,180 @@ func (h *Handler) handleAPISession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, resp)
+}
+
+func (h *Handler) handleAPIIssuesInFlight(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	caches, err := h.collectInFlightIssues()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to collect in-flight issues")
+		return
+	}
+	now := h.now().UTC()
+	out := make([]inFlightIssueResponse, 0, len(caches))
+	for _, ic := range caches {
+		row, err := h.buildInFlightRow(ic, now)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to build in-flight row")
+			return
+		}
+		out = append(out, row)
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (h *Handler) buildInFlightRow(ic store.IssueCache, now time.Time) (inFlightIssueResponse, error) {
+	labels := decodeLabels(ic.Labels)
+	cur := currentLabel(labels)
+	row := inFlightIssueResponse{
+		Repo:         ic.Repo,
+		IssueNum:     ic.IssueNum,
+		Title:        firstLine(ic.Body),
+		CurrentState: labelToState(cur),
+		CurrentLabel: cur,
+		Labels:       labels,
+		CycleCounts:  map[string]int{},
+	}
+	counts, err := h.store.QueryTransitionCounts(ic.Repo, ic.IssueNum)
+	if err != nil {
+		return row, fmt.Errorf("transition counts: %w", err)
+	}
+	for _, tc := range counts {
+		row.CycleCounts[tc.FromState+"->"+tc.ToState] = tc.Count
+	}
+	last, err := h.store.LatestIssueTransition(ic.Repo, ic.IssueNum)
+	if err != nil {
+		return row, fmt.Errorf("latest transition: %w", err)
+	}
+	if last != nil {
+		ts := last.At
+		row.LastTransitionAt = &ts
+		if !ts.IsZero() {
+			seconds := int64(now.Sub(ts).Seconds())
+			if seconds < 0 {
+				seconds = 0
+			}
+			row.StuckForSeconds = seconds
+		}
+	}
+	if claim, err := h.store.QueryIssueClaim(ic.Repo, ic.IssueNum); err == nil && claim != nil {
+		row.ClaimedWorkerID = claim.WorkerID
+	}
+	if session, err := h.store.LatestSessionForIssue(ic.Repo, ic.IssueNum); err == nil && session != nil {
+		row.LastSessionID = session.SessionID
+		row.LastSessionURL = sessionref.BuildURL(h.reportBaseURL, session.WorkerID, session.SessionID)
+	}
+	return row, nil
+}
+
+func (h *Handler) handleAPIIssueDetail(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	rest := strings.TrimPrefix(r.URL.Path, "/api/v1/issues/")
+	if rest == "" || rest == "in-flight" {
+		// The in-flight handler is registered at the more-specific path, so
+		// reaching here means a malformed request.
+		writeError(w, http.StatusNotFound, "not found")
+		return
+	}
+	repo, issueNum, ok := splitRepoIssue(rest)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "invalid issue path; expect /api/v1/issues/<owner>/<repo>/<num>")
+		return
+	}
+	cache, err := h.store.QueryIssueCache(repo, issueNum)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to query issue cache")
+		return
+	}
+	if cache == nil {
+		writeError(w, http.StatusNotFound, "issue not found")
+		return
+	}
+	labels := decodeLabels(cache.Labels)
+	resp := issueDetailResponse{
+		Repo:         cache.Repo,
+		IssueNum:     cache.IssueNum,
+		Title:        firstLine(cache.Body),
+		CurrentState: labelToState(currentLabel(labels)),
+		Labels:       labels,
+		Transitions:  []issueTransitionResponse{},
+		Sessions:     []issueSessionRefResponse{},
+	}
+	transitions, err := h.store.QueryIssueTransitions(repo, issueNum)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to query transitions")
+		return
+	}
+	for _, t := range transitions {
+		resp.Transitions = append(resp.Transitions, issueTransitionResponse{
+			From: t.From,
+			To:   t.To,
+			At:   t.At,
+			By:   t.By,
+		})
+	}
+	counts, err := h.store.QueryTransitionCounts(repo, issueNum)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to query transition counts")
+		return
+	}
+	for _, c := range counts {
+		resp.TransitionCounts = append(resp.TransitionCounts, transitionCountResponse{
+			FromState: c.FromState,
+			ToState:   c.ToState,
+			Count:     c.Count,
+		})
+	}
+	sessions, err := h.store.ListSessions(store.SessionFilter{Repo: repo, IssueNum: issueNum})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list sessions")
+		return
+	}
+	for _, sess := range sessions {
+		exitCode, _, finishedAt, _ := h.sessionTaskStats(sess)
+		resp.Sessions = append(resp.Sessions, issueSessionRefResponse{
+			SessionID:  sess.SessionID,
+			Agent:      sess.AgentName,
+			StartedAt:  sess.CreatedAt,
+			FinishedAt: finishedAt,
+			Status:     sess.Status,
+			ExitCode:   exitCode,
+		})
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func splitRepoIssue(trimmed string) (string, int, bool) {
+	parts := strings.Split(trimmed, "/")
+	if len(parts) < 2 {
+		return "", 0, false
+	}
+	tail := parts[len(parts)-1]
+	issueNum, err := strconv.Atoi(tail)
+	if err != nil || issueNum <= 0 {
+		return "", 0, false
+	}
+	repo := strings.Join(parts[:len(parts)-1], "/")
+	if repo == "" {
+		return "", 0, false
+	}
+	return repo, issueNum, true
+}
+
+func firstLine(s string) string {
+	if s == "" {
+		return ""
+	}
+	if i := strings.IndexAny(s, "\r\n"); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return strings.TrimSpace(s)
 }
 
 func (h *Handler) handleAPIEvents(w http.ResponseWriter, r *http.Request) {
@@ -372,14 +666,18 @@ func (h *Handler) handleAPIWorkers(w http.ResponseWriter, r *http.Request) {
 	}
 	resp := make([]workerResponse, 0, len(workers))
 	for _, worker := range workers {
+		currentTask, _ := h.store.WorkerCurrentTaskID(worker.ID)
 		resp = append(resp, workerResponse{
-			ID:            worker.ID,
-			Repo:          worker.Repo,
-			Roles:         decodeRoles(worker.Roles),
-			Hostname:      worker.Hostname,
-			Status:        worker.Status,
-			LastHeartbeat: worker.LastHeartbeat,
-			RegisteredAt:  worker.RegisteredAt,
+			ID:              worker.ID,
+			Repo:            worker.Repo,
+			Roles:           decodeRoles(worker.Roles),
+			Hostname:        worker.Hostname,
+			Status:          worker.Status,
+			LastHeartbeat:   worker.LastHeartbeat,
+			LastHeartbeatAt: worker.LastHeartbeat,
+			RegisteredAt:    worker.RegisteredAt,
+			CurrentTaskID:   currentTask,
+			MgmtBaseURL:     worker.MgmtBaseURL,
 		})
 	}
 	writeJSON(w, http.StatusOK, resp)
@@ -586,7 +884,97 @@ func (h *Handler) queryStatus() (statusResponse, error) {
 		return resp, fmt.Errorf("query last poll: %w", err)
 	}
 	resp.LastPoll = lastPoll
+
+	now := h.now().UTC()
+	inFlight, stuck, err := h.summariseInFlight(now)
+	if err != nil {
+		return resp, fmt.Errorf("summarise in-flight: %w", err)
+	}
+	resp.InFlightIssues = inFlight
+	resp.StuckIssuesOver1H = stuck
+
+	since := now.Add(-24 * time.Hour)
+	if done, err := h.store.CountTerminalSessionsSince(store.TaskStatusCompleted, since); err == nil {
+		resp.Done24H = done
+	}
+	if failed, err := h.store.CountTerminalSessionsSince(store.TaskStatusFailed, since); err == nil {
+		resp.Failed24H = failed
+	}
 	return resp, nil
+}
+
+// summariseInFlight returns the in-flight issue count and how many of those
+// have been stuck longer than the 1-hour threshold (no transition since).
+func (h *Handler) summariseInFlight(now time.Time) (int, int, error) {
+	caches, err := h.collectInFlightIssues()
+	if err != nil {
+		return 0, 0, err
+	}
+	stuck := 0
+	for _, ic := range caches {
+		last, err := h.store.LatestIssueTransition(ic.Repo, ic.IssueNum)
+		if err != nil {
+			return 0, 0, err
+		}
+		if last == nil {
+			continue
+		}
+		if int64(now.Sub(last.At).Seconds()) > stuckThresholdSeconds {
+			stuck++
+		}
+	}
+	return len(caches), stuck, nil
+}
+
+// collectInFlightIssues returns all open issue caches that are not in a
+// terminal status (status:done / status:failed / status:blocked dependent on
+// dep state). Used by both the in-flight endpoint and the status summary.
+func (h *Handler) collectInFlightIssues() ([]store.IssueCache, error) {
+	all, err := h.store.ListIssueCaches("")
+	if err != nil {
+		return nil, fmt.Errorf("list issue caches: %w", err)
+	}
+	out := make([]store.IssueCache, 0, len(all))
+	for _, ic := range all {
+		if !isInFlight(ic) {
+			continue
+		}
+		out = append(out, ic)
+	}
+	return out, nil
+}
+
+func isInFlight(ic store.IssueCache) bool {
+	state := strings.ToLower(strings.TrimSpace(ic.State))
+	if state == "closed" {
+		return false
+	}
+	labels := decodeLabels(ic.Labels)
+	for _, label := range labels {
+		switch label {
+		case "status:done", "status:failed":
+			return false
+		}
+	}
+	return true
+}
+
+func currentLabel(labels []string) string {
+	for _, label := range labels {
+		if strings.HasPrefix(label, "status:") {
+			return label
+		}
+	}
+	return ""
+}
+
+// labelToState maps "status:developing" -> "developing"; returns "" when the
+// label is not a workbuddy state label.
+func labelToState(label string) string {
+	if strings.HasPrefix(label, "status:") {
+		return strings.TrimPrefix(label, "status:")
+	}
+	return label
 }
 
 func (h *Handler) listSessions(repo string, limit, offset int) ([]sessionListResponse, error) {
@@ -606,7 +994,7 @@ func (h *Handler) listSessions(repo string, limit, offset int) ([]sessionListRes
 		if err != nil {
 			return nil, err
 		}
-		out = append(out, sessionListResponse{
+		row := sessionListResponse{
 			SessionID:  record.SessionID,
 			TaskID:     record.TaskID,
 			Repo:       record.Repo,
@@ -621,7 +1009,20 @@ func (h *Handler) listSessions(repo string, limit, offset int) ([]sessionListRes
 			CreatedAt:  record.CreatedAt,
 			FinishedAt: finishedAt,
 			Summary:    record.Summary,
-		})
+		}
+		if record.TaskID != "" {
+			if task, err := h.store.GetTask(record.TaskID); err == nil && task != nil {
+				row.TaskStatus = task.Status
+				row.Workflow = task.Workflow
+				row.CurrentState = task.State
+			}
+		}
+		if row.CurrentState == "" {
+			if cache, err := h.store.QueryIssueCache(record.Repo, record.IssueNum); err == nil && cache != nil {
+				row.CurrentState = labelToState(currentLabel(decodeLabels(cache.Labels)))
+			}
+		}
+		out = append(out, row)
 	}
 	return out, nil
 }

--- a/internal/auditapi/handler_test.go
+++ b/internal/auditapi/handler_test.go
@@ -1,7 +1,9 @@
 package auditapi
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -664,4 +666,471 @@ func TestDashboardWorkersEndpoint(t *testing.T) {
 	if len(body[0].Roles) != 2 {
 		t.Fatalf("worker[0].roles = %#v", body[0].Roles)
 	}
+	// New fields added in #218.
+	if body[0].LastHeartbeatAt.IsZero() {
+		t.Fatalf("worker[0].last_heartbeat_at = zero, want timestamp")
+	}
+	// CurrentTaskID is "" for both seeded workers (active session for worker-1
+	// is task-active but its status is "running", so it should populate).
+	foundCurrent := false
+	for _, w := range body {
+		if w.CurrentTaskID != "" {
+			foundCurrent = true
+			break
+		}
+	}
+	if !foundCurrent {
+		t.Fatalf("expected at least one worker.current_task_id to be populated, got %#v", body)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Issue #218: in-flight, issue detail, sessions subpath, status field tests.
+// ---------------------------------------------------------------------------
+
+func newInFlightFixture(t *testing.T) *dashboardFixture {
+	t.Helper()
+	st := newTestStore(t)
+	sessionsDir := filepath.Join(t.TempDir(), "sessions")
+	seedDashboardData(t, st, sessionsDir)
+	seedInFlightExtras(t, st)
+
+	h := NewHandler(st)
+	h.SetSessionsDir(sessionsDir)
+	h.SetReportBaseURL("http://coord.example.com")
+	// Pin "now" so stuck_for_seconds is deterministic. Issue 40's last
+	// transition is 30 minutes before this; issue 41 is 2h before.
+	fixed := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	h.SetNowFunc(func() time.Time { return fixed })
+
+	mux := http.NewServeMux()
+	h.RegisterDashboard(mux)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return &dashboardFixture{server: server, sessionsDir: sessionsDir}
+}
+
+func seedInFlightExtras(t *testing.T, st *store.Store) {
+	t.Helper()
+	// Issue 40 is already seeded as "open" with status:reviewing label.
+	// Issue 41 needs an open in-flight cache too.
+	if err := st.UpsertIssueCache(store.IssueCache{
+		Repo:     "owner/repo",
+		IssueNum: 41,
+		Labels:   `["status:developing"]`,
+		Body:     "Add cycle cap to dev/review loop\n\nFull body here",
+		State:    "open",
+	}); err != nil {
+		t.Fatalf("UpsertIssueCache 41: %v", err)
+	}
+	// Closed issue (must NOT appear in in-flight).
+	if err := st.UpsertIssueCache(store.IssueCache{
+		Repo:     "owner/repo",
+		IssueNum: 99,
+		Labels:   `["status:done"]`,
+		Body:     "Already done",
+		State:    "open",
+	}); err != nil {
+		t.Fatalf("UpsertIssueCache 99: %v", err)
+	}
+	// Set issue 40's body to give the title field something to render.
+	if err := st.UpsertIssueCache(store.IssueCache{
+		Repo:     "owner/repo",
+		IssueNum: 40,
+		Labels:   `["status:reviewing","type:feature"]`,
+		Body:     "API endpoints for dashboard\n\ndetails",
+		State:    "open",
+	}); err != nil {
+		t.Fatalf("UpsertIssueCache 40 reseed: %v", err)
+	}
+	// Insert the two transitions with explicit, ordered timestamps so the
+	// dashboard's ORDER BY ts ASC matches the insertion sequence and
+	// stuck_for_seconds can be asserted deterministically.
+	if _, err := st.DB().Exec(
+		`INSERT INTO events (ts, type, repo, issue_num, payload) VALUES
+		 ('2026-04-17 10:00:00','transition','owner/repo',40,'{"from":"developing","to":"reviewing","by":"dev-agent"}'),
+		 ('2026-04-17 11:30:00','transition','owner/repo',40,'{"from":"reviewing","to":"developing","by":"review-agent"}')`,
+	); err != nil {
+		t.Fatalf("insert transitions: %v", err)
+	}
+	// Add an issue-claim row so claimed_worker_id is populated.
+	if _, err := st.AcquireIssueClaim("owner/repo", 40, "worker-1", time.Hour); err != nil {
+		t.Fatalf("AcquireIssueClaim: %v", err)
+	}
+}
+
+func TestHandleIssuesInFlight_Happy(t *testing.T) {
+	fixture := newInFlightFixture(t)
+
+	resp, err := http.Get(fixture.server.URL + "/api/v1/issues/in-flight")
+	if err != nil {
+		t.Fatalf("GET /api/v1/issues/in-flight: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Content-Type"); !strings.HasPrefix(got, "application/json") {
+		t.Fatalf("content-type = %q", got)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	// Structurally-empty data must serialize as `[]` (not `null`).
+	if strings.TrimSpace(string(body)) == "null" {
+		t.Fatal("body decoded as JSON null, want array")
+	}
+	var rows []inFlightIssueResponse
+	if err := json.Unmarshal(body, &rows); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2 (issues 40 and 41); body=%s", len(rows), string(body))
+	}
+	byNum := map[int]inFlightIssueResponse{}
+	for _, r := range rows {
+		byNum[r.IssueNum] = r
+	}
+	row40, ok := byNum[40]
+	if !ok {
+		t.Fatalf("missing issue 40: %+v", byNum)
+	}
+	if row40.CurrentLabel != "status:reviewing" || row40.CurrentState != "reviewing" {
+		t.Fatalf("issue 40 state = %q/%q", row40.CurrentLabel, row40.CurrentState)
+	}
+	if row40.Title != "API endpoints for dashboard" {
+		t.Fatalf("issue 40 title = %q", row40.Title)
+	}
+	if row40.CycleCounts["developing->reviewing"] != 1 {
+		t.Fatalf("issue 40 cycle counts = %#v", row40.CycleCounts)
+	}
+	if row40.LastTransitionAt == nil || row40.LastTransitionAt.IsZero() {
+		t.Fatalf("issue 40 last_transition_at = %v", row40.LastTransitionAt)
+	}
+	if row40.StuckForSeconds < 1500 || row40.StuckForSeconds > 1900 {
+		t.Fatalf("issue 40 stuck_for_seconds = %d, want ≈1800", row40.StuckForSeconds)
+	}
+	if row40.ClaimedWorkerID != "worker-1" {
+		t.Fatalf("issue 40 claimed_worker_id = %q", row40.ClaimedWorkerID)
+	}
+	if row40.LastSessionID != "session-40" {
+		t.Fatalf("issue 40 last_session_id = %q", row40.LastSessionID)
+	}
+	wantURL := "http://coord.example.com/workers/worker-1/sessions/session-40"
+	if row40.LastSessionURL != wantURL {
+		t.Fatalf("issue 40 last_session_url = %q, want %q", row40.LastSessionURL, wantURL)
+	}
+}
+
+func TestHandleIssuesInFlight_EmptyReturnsArray(t *testing.T) {
+	st := newTestStore(t)
+	h := NewHandler(st)
+	mux := http.NewServeMux()
+	h.RegisterDashboard(mux)
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	resp, err := http.Get(server.URL + "/api/v1/issues/in-flight")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if strings.TrimSpace(string(body)) != "[]" {
+		t.Fatalf("body = %q, want \"[]\"", string(body))
+	}
+}
+
+func TestHandleIssueDetail_Happy(t *testing.T) {
+	fixture := newInFlightFixture(t)
+
+	resp, err := http.Get(fixture.server.URL + "/api/v1/issues/owner/repo/40")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	var body issueDetailResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Repo != "owner/repo" || body.IssueNum != 40 {
+		t.Fatalf("repo/issue = %q/%d", body.Repo, body.IssueNum)
+	}
+	if body.CurrentState != "reviewing" {
+		t.Fatalf("current_state = %q", body.CurrentState)
+	}
+	if len(body.Transitions) < 2 {
+		t.Fatalf("transitions = %d, want ≥2", len(body.Transitions))
+	}
+	first := body.Transitions[0]
+	last := body.Transitions[len(body.Transitions)-1]
+	if first.From != "developing" || first.To != "reviewing" {
+		t.Fatalf("transitions[0] = %+v", first)
+	}
+	if first.By != "dev-agent" {
+		t.Fatalf("transitions[0].by = %q", first.By)
+	}
+	if last.From != "reviewing" || last.To != "developing" {
+		t.Fatalf("transitions[last] = %+v", last)
+	}
+	if len(body.TransitionCounts) < 2 {
+		t.Fatalf("transition_counts = %d, want ≥2", len(body.TransitionCounts))
+	}
+	if len(body.Sessions) == 0 {
+		t.Fatal("sessions empty, expected at least session-40")
+	}
+}
+
+func TestHandleIssueDetail_NotFound(t *testing.T) {
+	fixture := newInFlightFixture(t)
+
+	resp, err := http.Get(fixture.server.URL + "/api/v1/issues/owner/repo/9999")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestHandleIssueDetail_Malformed(t *testing.T) {
+	fixture := newInFlightFixture(t)
+
+	resp, err := http.Get(fixture.server.URL + "/api/v1/issues/not-a-path")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestDashboardSessionEvents_Delegates(t *testing.T) {
+	st := newTestStore(t)
+	h := NewHandler(st)
+
+	// Stub the events handler.
+	called := false
+	h.SetSessionEventsHandler(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		if !strings.HasPrefix(r.URL.Path, "/api/v1/sessions/") {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"events":[]}`))
+	})
+
+	mux := http.NewServeMux()
+	h.RegisterDashboard(mux)
+
+	req := httptest.NewRequest("GET", "/api/v1/sessions/session-x/events", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if !called {
+		t.Fatal("events handler not invoked")
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("code = %d", rec.Code)
+	}
+}
+
+func TestDashboardSessionEvents_NoHandler404(t *testing.T) {
+	st := newTestStore(t)
+	h := NewHandler(st)
+	mux := http.NewServeMux()
+	h.RegisterDashboard(mux)
+
+	req := httptest.NewRequest("GET", "/api/v1/sessions/session-x/events", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("code = %d, want 404", rec.Code)
+	}
+}
+
+func TestDashboardSessionsEndpoint_AddedFields(t *testing.T) {
+	st := newTestStore(t)
+	sessionsDir := filepath.Join(t.TempDir(), "sessions")
+	seedDashboardData(t, st, sessionsDir)
+	// Add task workflow + state so the new session-list fields populate.
+	if _, err := st.DB().Exec(`UPDATE task_queue SET workflow = 'default', state = 'reviewing' WHERE id = ?`, "task-40"); err != nil {
+		t.Fatalf("update task workflow: %v", err)
+	}
+
+	h := NewHandler(st)
+	h.SetSessionsDir(sessionsDir)
+	mux := http.NewServeMux()
+	h.RegisterDashboard(mux)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	resp, err := http.Get(server.URL + "/api/v1/sessions?repo=owner/repo&limit=10")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var rows []sessionListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rows); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	var s40 *sessionListResponse
+	for i := range rows {
+		if rows[i].SessionID == "session-40" {
+			s40 = &rows[i]
+		}
+	}
+	if s40 == nil {
+		t.Fatal("missing session-40")
+	}
+	if s40.Workflow != "default" {
+		t.Fatalf("workflow = %q", s40.Workflow)
+	}
+	if s40.CurrentState != "reviewing" {
+		t.Fatalf("current_state = %q", s40.CurrentState)
+	}
+	if s40.TaskStatus == "" {
+		t.Fatalf("task_status = %q", s40.TaskStatus)
+	}
+}
+
+func TestDashboardStatusEndpoint_AddedFields(t *testing.T) {
+	fixture := newInFlightFixture(t)
+
+	resp, err := http.Get(fixture.server.URL + "/api/v1/status")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var body statusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.InFlightIssues != 2 {
+		t.Fatalf("in_flight_issues = %d, want 2", body.InFlightIssues)
+	}
+	// Issue 40's last transition is 30m before fixed-now, so 0 stuck. Issue 41
+	// has no transitions at all (not stuck). Both done/failed counters are
+	// computed from sessions that closed in the last 24h.
+	if body.StuckIssuesOver1H < 0 {
+		t.Fatalf("stuck_issues_over_1h = %d", body.StuckIssuesOver1H)
+	}
+}
+
+func TestDeprecatedSessionPath_AddsHeaderAndKeepsBody(t *testing.T) {
+	st := newTestStore(t)
+	sessionsDir := filepath.Join(t.TempDir(), "sessions")
+	seedDashboardData(t, st, sessionsDir)
+
+	// Build a webui handler so the deprecation alias paths under /sessions/
+	// are registered. This mirrors the coordinator wiring.
+	uiCalled := false
+	stubEvents := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		uiCalled = true
+		writeJSONStatus(w, http.StatusOK, map[string]any{"events": []any{}, "total": 0})
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/sessions/", func(w http.ResponseWriter, r *http.Request) {
+		// Mimic the deprecation header that the real webui handler attaches.
+		if strings.HasSuffix(r.URL.Path, "/events.json") {
+			w.Header().Set("Deprecation", "true")
+			stubEvents(w, r)
+			return
+		}
+		http.NotFound(w, r)
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	resp, err := http.Get(server.URL + "/sessions/session-40/events.json")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if !uiCalled {
+		t.Fatal("expected legacy events handler to be called")
+	}
+	if got := resp.Header.Get("Deprecation"); got != "true" {
+		t.Fatalf("Deprecation header = %q, want \"true\"", got)
+	}
+}
+
+func writeJSONStatus(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// TestHandleIssuesInFlight_Golden snapshots the canonical /api/v1/issues/
+// in-flight payload so any future drift in the field names/shape is caught
+// at PR-review time rather than in production. Pattern mirrors
+// internal/reporter/format_golden_test.go.
+func TestHandleIssuesInFlight_Golden(t *testing.T) {
+	fixture := newInFlightFixture(t)
+
+	resp, err := http.Get(fixture.server.URL + "/api/v1/issues/in-flight")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+
+	var rows []inFlightIssueResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rows); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// Re-marshal indented for stable snapshot (and to filter the issue 41 row,
+	// which has no transitions and no deterministic data to assert).
+	for i := range rows {
+		if rows[i].IssueNum == 40 {
+			var buf bytes.Buffer
+			enc := json.NewEncoder(&buf)
+			enc.SetIndent("", "  ")
+			enc.SetEscapeHTML(false)
+			if err := enc.Encode(rows[i]); err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			got := strings.TrimRight(buf.String(), "\n")
+			want := `{
+  "repo": "owner/repo",
+  "issue_num": 40,
+  "title": "API endpoints for dashboard",
+  "current_state": "reviewing",
+  "current_label": "status:reviewing",
+  "labels": [
+    "status:reviewing",
+    "type:feature"
+  ],
+  "cycle_counts": {
+    "developing->reviewing": 1,
+    "reviewing->developing": 1
+  },
+  "last_transition_at": "2026-04-17T11:30:00Z",
+  "stuck_for_seconds": 1800,
+  "claimed_worker_id": "worker-1",
+  "last_session_id": "session-40",
+  "last_session_url": "http://coord.example.com/workers/worker-1/sessions/session-40"
+}`
+			if got != want {
+				t.Fatalf("issue 40 row drift.\n--- got ---\n%s\n--- want ---\n%s", got, want)
+			}
+			return
+		}
+	}
+	t.Fatal("issue 40 row not found in response")
 }

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -3,7 +3,6 @@ package reporter
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,6 +16,7 @@ import (
 	"github.com/Lincyaw/workbuddy/internal/ghadapter"
 	"github.com/Lincyaw/workbuddy/internal/ghutil"
 	runtimepkg "github.com/Lincyaw/workbuddy/internal/runtime"
+	"github.com/Lincyaw/workbuddy/internal/sessionref"
 )
 
 // ReactionConfused is the GitHub reaction content used to signal that an
@@ -179,10 +179,7 @@ func (r *Reporter) SetBaseURL(baseURL string) {
 }
 
 func (r *Reporter) sessionURL(sessionID, workerID string) string {
-	if r.baseURL == "" || sessionID == "" || workerID == "" {
-		return ""
-	}
-	return r.baseURL + "/workers/" + url.PathEscape(workerID) + "/sessions/" + url.PathEscape(sessionID)
+	return sessionref.BuildURL(r.baseURL, workerID, sessionID)
 }
 
 // SetVerifier sets the claim verifier used to check agent side-effects.

--- a/internal/sessionref/url.go
+++ b/internal/sessionref/url.go
@@ -1,0 +1,15 @@
+// Package sessionref centralises URL formatting for "view session" links so
+// the reporter (which posts the URL into GitHub comments) and the dashboard
+// JSON API (which surfaces the URL on issue/session listings) cannot drift.
+package sessionref
+
+import "net/url"
+
+// BuildURL returns the canonical workers/<workerID>/sessions/<sessionID> URL
+// rooted at baseURL, or an empty string when any required input is missing.
+func BuildURL(baseURL, workerID, sessionID string) string {
+	if baseURL == "" || sessionID == "" || workerID == "" {
+		return ""
+	}
+	return baseURL + "/workers/" + url.PathEscape(workerID) + "/sessions/" + url.PathEscape(sessionID)
+}

--- a/internal/store/queries.go
+++ b/internal/store/queries.go
@@ -7,6 +7,7 @@ package store
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -124,6 +125,152 @@ func (s *Store) LatestIssueEvent(repo string, issueNum int) (*IssueEventMeta, er
 		return nil, nil
 	}
 	return &IssueEventMeta{Type: eventType, TS: ts.UTC()}, nil
+}
+
+// IssueTransitionEvent captures the {from,to,at,by} fields stored on a
+// `transition` event payload. Used by the dashboard issue-detail endpoint.
+type IssueTransitionEvent struct {
+	From string
+	To   string
+	At   time.Time
+	By   string
+}
+
+// LatestIssueTransition returns the most recent `transition` event for the
+// given issue, or nil if none exists. Used for last_transition_at on the
+// in-flight dashboard.
+func (s *Store) LatestIssueTransition(repo string, issueNum int) (*IssueTransitionEvent, error) {
+	var rawTS, payload string
+	err := s.db.QueryRow(
+		`SELECT ts, payload FROM events
+		 WHERE repo = ? AND issue_num = ? AND type = 'transition'
+		 ORDER BY ts DESC, id DESC LIMIT 1`,
+		repo, issueNum,
+	).Scan(&rawTS, &payload)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("store: latest issue transition: %w", err)
+	}
+	ts, ok := ParseTimestamp(rawTS, "event.ts")
+	if !ok {
+		return nil, nil
+	}
+	out := &IssueTransitionEvent{At: ts.UTC()}
+	parseTransitionPayload(payload, out)
+	return out, nil
+}
+
+// QueryIssueTransitions returns every `transition` event for the issue in
+// chronological order. Used by the issue-detail endpoint.
+func (s *Store) QueryIssueTransitions(repo string, issueNum int) ([]IssueTransitionEvent, error) {
+	rows, err := s.db.Query(
+		`SELECT ts, payload FROM events
+		 WHERE repo = ? AND issue_num = ? AND type = 'transition'
+		 ORDER BY ts ASC, id ASC`,
+		repo, issueNum,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("store: query issue transitions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []IssueTransitionEvent
+	for rows.Next() {
+		var rawTS, payload string
+		if err := rows.Scan(&rawTS, &payload); err != nil {
+			return nil, fmt.Errorf("store: scan issue transition: %w", err)
+		}
+		ts, ok := ParseTimestamp(rawTS, "event.ts")
+		if !ok {
+			continue
+		}
+		ev := IssueTransitionEvent{At: ts.UTC()}
+		parseTransitionPayload(payload, &ev)
+		out = append(out, ev)
+	}
+	return out, rows.Err()
+}
+
+// LatestSessionForIssue returns the newest session row for the (repo,issue)
+// pair, or nil when no session has been created. Used to populate
+// last_session_id / last_session_url on the in-flight dashboard.
+func (s *Store) LatestSessionForIssue(repo string, issueNum int) (*SessionRecord, error) {
+	row := s.db.QueryRow(
+		`SELECT s.id, s.session_id, s.task_id, s.repo, s.issue_num, s.agent_name, s.runtime, s.worker_id, s.attempt,
+		        COALESCE(t.status, s.status),
+		        s.dir, s.stdout_path, s.stderr_path, s.tool_calls_path, s.metadata_path, s.summary, s.raw_path, s.created_at, s.closed_at
+		 FROM sessions s
+		 LEFT JOIN task_queue t ON t.id = s.task_id
+		 WHERE s.repo = ? AND s.issue_num = ?
+		 ORDER BY s.id DESC LIMIT 1`,
+		repo, issueNum,
+	)
+	record, err := scanSessionRecordForAPI(row.Scan)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("store: latest session for issue: %w", err)
+	}
+	return record, nil
+}
+
+// CountTerminalSessionsSince counts sessions that have transitioned into the
+// given terminal status since the cutoff time. Used for done_24h / failed_24h
+// summary fields on /api/v1/status.
+func (s *Store) CountTerminalSessionsSince(status string, since time.Time) (int, error) {
+	var n int
+	err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM sessions s
+		 LEFT JOIN task_queue t ON t.id = s.task_id
+		 WHERE COALESCE(t.status, s.status) = ?
+		   AND s.closed_at IS NOT NULL
+		   AND s.closed_at >= ?`,
+		status, since.UTC().Format("2006-01-02 15:04:05"),
+	).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("store: count terminal sessions: %w", err)
+	}
+	return n, nil
+}
+
+// WorkerCurrentTaskID returns the running task ID currently owned by the
+// worker, or "" when the worker has nothing in flight.
+func (s *Store) WorkerCurrentTaskID(workerID string) (string, error) {
+	var taskID sql.NullString
+	err := s.db.QueryRow(
+		`SELECT id FROM task_queue WHERE worker_id = ? AND status = ? ORDER BY updated_at DESC LIMIT 1`,
+		workerID, TaskStatusRunning,
+	).Scan(&taskID)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("store: worker current task: %w", err)
+	}
+	if !taskID.Valid {
+		return "", nil
+	}
+	return taskID.String, nil
+}
+
+func parseTransitionPayload(payload string, ev *IssueTransitionEvent) {
+	type rawTransition struct {
+		From string `json:"from"`
+		To   string `json:"to"`
+		By   string `json:"by"`
+	}
+	if payload == "" {
+		return
+	}
+	var raw rawTransition
+	if err := json.Unmarshal([]byte(payload), &raw); err != nil {
+		return
+	}
+	ev.From = raw.From
+	ev.To = raw.To
+	ev.By = raw.By
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1408,15 +1408,29 @@ func (s *Store) QueryIssueCache(repo string, issueNum int) (*IssueCache, error) 
 	return &ic, nil
 }
 
-// ListIssueCaches returns all non-PR cached issues for a repo.
+// ListIssueCaches returns all non-PR cached issues. Pass "" for repo to fan
+// out across every repo recorded in the cache.
 func (s *Store) ListIssueCaches(repo string) ([]IssueCache, error) {
-	rows, err := s.db.Query(
-		`SELECT repo, issue_num, labels, body, state, updated_at
-		 FROM issue_cache
-		 WHERE repo = ? AND (state IS NULL OR state NOT LIKE 'pr:%')
-		 ORDER BY issue_num`,
-		repo,
+	var (
+		rows *sql.Rows
+		err  error
 	)
+	if repo == "" {
+		rows, err = s.db.Query(
+			`SELECT repo, issue_num, labels, body, state, updated_at
+			 FROM issue_cache
+			 WHERE state IS NULL OR state NOT LIKE 'pr:%'
+			 ORDER BY repo, issue_num`,
+		)
+	} else {
+		rows, err = s.db.Query(
+			`SELECT repo, issue_num, labels, body, state, updated_at
+			 FROM issue_cache
+			 WHERE repo = ? AND (state IS NULL OR state NOT LIKE 'pr:%')
+			 ORDER BY issue_num`,
+			repo,
+		)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("store: list issue caches: %w", err)
 	}

--- a/internal/webui/handler.go
+++ b/internal/webui/handler.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -113,12 +114,61 @@ func (h *Handler) handleSessionSubpath(w http.ResponseWriter, r *http.Request) {
 	case "":
 		h.handleDetail(w, r, sessionID)
 	case "events.json":
+		markDeprecated(w, r,
+			"/sessions/{id}/events.json",
+			"/api/v1/sessions/{id}/events")
 		h.handleEventsJSON(w, r, sessionID)
 	case "stream":
+		markDeprecated(w, r,
+			"/sessions/{id}/stream",
+			"/api/v1/sessions/{id}/stream")
 		h.handleStream(w, r, sessionID)
 	default:
 		http.NotFound(w, r)
 	}
+}
+
+// HandleAPISessionEvents serves /api/v1/sessions/{id}/events. The new path
+// reuses the existing on-disk events-v1.jsonl reader; the legacy
+// /sessions/{id}/events.json route is preserved as a 30-day deprecation alias.
+func (h *Handler) HandleAPISessionEvents(w http.ResponseWriter, r *http.Request) {
+	sessionID, ok := apiSessionID(r.URL.Path)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	h.handleEventsJSON(w, r, sessionID)
+}
+
+// HandleAPISessionStream serves /api/v1/sessions/{id}/stream (SSE).
+func (h *Handler) HandleAPISessionStream(w http.ResponseWriter, r *http.Request) {
+	sessionID, ok := apiSessionID(r.URL.Path)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	h.handleStream(w, r, sessionID)
+}
+
+func apiSessionID(path string) (string, bool) {
+	rest := strings.TrimPrefix(path, "/api/v1/sessions/")
+	id, _, _ := strings.Cut(rest, "/")
+	if !isValidSessionID(id) {
+		return "", false
+	}
+	return id, true
+}
+
+// markDeprecated tags responses to legacy /sessions/{id}/events.json and
+// /sessions/{id}/stream paths. Operators get a `Deprecation: true` header
+// (per RFC 8594 the value would be a date, but the issue spec asks for a
+// boolean shape) and a stdout log line so log-scrapers can spot lingering
+// callers before the alias is removed.
+func markDeprecated(w http.ResponseWriter, r *http.Request, oldPath, newPath string) {
+	w.Header().Set("Deprecation", "true")
+	w.Header().Set("Sunset", "30 days")
+	w.Header().Set("Link", `<`+newPath+`>; rel="successor-version"`)
+	log.Printf("[deprecated] old path %s accessed (request %s), prefer %s", oldPath, r.URL.Path, newPath)
 }
 
 // handleDetail renders a single session detail page.

--- a/internal/webui/handler_test.go
+++ b/internal/webui/handler_test.go
@@ -1,0 +1,153 @@
+package webui
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Lincyaw/workbuddy/internal/store"
+)
+
+// seedSession writes a session row + an events-v1.jsonl file so the events.json
+// and stream paths have something to read.
+func seedSession(t *testing.T, st *store.Store, sessionsDir, sessionID string) {
+	t.Helper()
+	dir := filepath.Join(sessionsDir, sessionID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "events-v1.jsonl"),
+		[]byte("{\"kind\":\"a\",\"seq\":1}\n{\"kind\":\"b\",\"seq\":2}\n"),
+		0o644,
+	); err != nil {
+		t.Fatalf("write events: %v", err)
+	}
+	if _, err := st.CreateSession(store.SessionRecord{
+		SessionID: sessionID,
+		Repo:      "owner/repo",
+		IssueNum:  214,
+		AgentName: "dev-agent",
+		Status:    store.TaskStatusRunning,
+		Dir:       dir,
+	}); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+}
+
+func TestDeprecatedEventsAndStreamPaths(t *testing.T) {
+	st, err := store.NewStore(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	sessionsDir := filepath.Join(t.TempDir(), "sessions")
+	seedSession(t, st, sessionsDir, "session-218")
+
+	h := NewHandler(st)
+	h.SetSessionsDir(sessionsDir)
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	var logBuf bytes.Buffer
+	originalOut := log.Writer()
+	originalFlags := log.Flags()
+	log.SetOutput(&logBuf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(originalOut)
+		log.SetFlags(originalFlags)
+	})
+
+	resp, err := http.Get(server.URL + "/sessions/session-218/events.json")
+	if err != nil {
+		t.Fatalf("GET legacy events: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Deprecation"); got != "true" {
+		t.Fatalf("Deprecation header = %q, want \"true\"", got)
+	}
+	if got := resp.Header.Get("Sunset"); got == "" {
+		t.Fatalf("Sunset header missing")
+	}
+	if !strings.Contains(logBuf.String(), "[deprecated]") {
+		t.Fatalf("expected [deprecated] log line, got %q", logBuf.String())
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(body), `"kind":"a"`) {
+		t.Fatalf("body missing event content: %s", string(body))
+	}
+}
+
+// TestAPISessionEventsParity ensures the new /api/v1/sessions/{id}/events path
+// returns byte-for-byte the same JSON body as the legacy /sessions/{id}/
+// events.json alias. This is the AC contract from #218: "diff 逐字节验".
+func TestAPISessionEventsParity(t *testing.T) {
+	st, err := store.NewStore(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	sessionsDir := filepath.Join(t.TempDir(), "sessions")
+	seedSession(t, st, sessionsDir, "session-218")
+
+	h := NewHandler(st)
+	h.SetSessionsDir(sessionsDir)
+	mux := http.NewServeMux()
+	h.Register(mux)
+	mux.HandleFunc("/api/v1/sessions/", func(w http.ResponseWriter, r *http.Request) {
+		// Mirror the coordinator wiring: dispatch suffix to the right method.
+		rest := strings.TrimPrefix(r.URL.Path, "/api/v1/sessions/")
+		_, suffix, _ := strings.Cut(rest, "/")
+		switch suffix {
+		case "events":
+			h.HandleAPISessionEvents(w, r)
+		case "stream":
+			h.HandleAPISessionStream(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	legacy, err := http.Get(server.URL + "/sessions/session-218/events.json?limit=50&offset=0")
+	if err != nil {
+		t.Fatalf("legacy GET: %v", err)
+	}
+	defer func() { _ = legacy.Body.Close() }()
+	legacyBody, _ := io.ReadAll(legacy.Body)
+
+	modern, err := http.Get(server.URL + "/api/v1/sessions/session-218/events?limit=50&offset=0")
+	if err != nil {
+		t.Fatalf("modern GET: %v", err)
+	}
+	defer func() { _ = modern.Body.Close() }()
+	modernBody, _ := io.ReadAll(modern.Body)
+
+	if !bytes.Equal(legacyBody, modernBody) {
+		t.Fatalf("response bodies differ.\nlegacy=%s\nmodern=%s", string(legacyBody), string(modernBody))
+	}
+	// Modern path must NOT carry the deprecation header.
+	if got := modern.Header.Get("Deprecation"); got != "" {
+		t.Fatalf("modern path Deprecation = %q, want empty", got)
+	}
+}

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -2936,3 +2936,43 @@ requirements:
     related_docs:
       - docs/implemented/distributed-topology-and-cli.md
     deps: [REQ-027, REQ-028, REQ-029, REQ-051]
+
+  - id: REQ-088
+    title: Dashboard JSON API surface (in-flight, issue detail, session subpaths)
+    description: >
+      The dashboard SPA planned in #215 needs a single JSON contract: an
+      "in-flight" panorama listing every non-terminal issue with its
+      current_state, cycle_counts, last_transition_at, stuck_for_seconds,
+      claimed_worker_id and last_session_id/url; a per-issue detail endpoint
+      with the full transitions and sessions history; and the events/stream
+      session subpaths moved under /api/v1/* with a 30-day deprecation alias
+      under /sessions/. /api/v1/status, /api/v1/sessions, and /api/v1/workers
+      gain summary fields (in_flight_issues, stuck_issues_over_1h, done_24h,
+      failed_24h, task_status, workflow, current_state, current_task_id,
+      mgmt_base_url) without removing existing fields. last_session_url reuses
+      the reporter URL formatter via internal/sessionref so the dashboard and
+      GitHub comments cannot drift.
+    priority: P0
+    version: v0.5.0
+    status: tested
+    acceptance_criteria:
+      - "AC-088-1: GET /api/v1/issues/in-flight returns a JSON array (never null) of every non-done/non-closed issue with repo, issue_num, title, current_state, current_label, cycle_counts, last_transition_at, stuck_for_seconds, claimed_worker_id, last_session_id, last_session_url"
+      - "AC-088-2: GET /api/v1/issues/{owner}/{repo}/{num} returns the cached issue with its full transitions list (from/to/at/by), transition_counts and sessions history"
+      - "AC-088-3: GET /api/v1/sessions/{id}/events serves the same body as the legacy /sessions/{id}/events.json (byte-for-byte parity); GET /api/v1/sessions/{id}/stream proxies to the SSE handler with no Deprecation header"
+      - "AC-088-4: Legacy /sessions/{id}/events.json and /sessions/{id}/stream paths still respond OK but emit Deprecation: true and a stdout [deprecated] log line"
+      - "AC-088-5: /api/v1/status response adds in_flight_issues, stuck_issues_over_1h, done_24h, failed_24h; /api/v1/sessions adds task_status, workflow, current_state; /api/v1/workers adds last_heartbeat_at, current_task_id, mgmt_base_url; existing fields remain unchanged"
+      - "AC-088-6: A golden snapshot test in internal/auditapi locks the in-flight row JSON shape so accidental field renames fail at PR-review time"
+      - "AC-088-7: go build ./... && go vet ./... && go test ./internal/auditapi/... ./internal/webui/... ./internal/store/... ./cmd/... -count=1 are green"
+    code:
+      - internal/auditapi/handler.go
+      - internal/webui/handler.go
+      - internal/store/queries.go
+      - internal/store/store.go
+      - internal/sessionref/url.go
+      - internal/reporter/reporter.go
+      - cmd/coordinator.go
+    tests:
+      - internal/auditapi/handler_test.go
+      - internal/webui/handler_test.go
+      - cmd/coordinator_audit_test.go
+    deps: [REQ-013, REQ-018, REQ-019, REQ-029]


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/issues/in-flight` — every non-terminal issue with `current_state`, `cycle_counts`, `last_transition_at`, `stuck_for_seconds`, `claimed_worker_id`, `last_session_id`, `last_session_url`. Empty result returns `[]`, never `null`.
- Adds `GET /api/v1/issues/{owner}/{repo}/{num}` — cached issue with full transitions list, transition_counts, and sessions history.
- Migrates session subpaths to `/api/v1/sessions/{id}/events` and `/api/v1/sessions/{id}/stream` while keeping the legacy `/sessions/{id}/events.json` and `/sessions/{id}/stream` paths as 30-day aliases that emit `Deprecation: true` plus a stdout `[deprecated]` log line. Body parity with the legacy path is byte-for-byte.
- Appends summary fields to existing endpoints without removing any: `/api/v1/status` gains `in_flight_issues`, `stuck_issues_over_1h`, `done_24h`, `failed_24h`; `/api/v1/sessions` gains `task_status`, `workflow`, `current_state`; `/api/v1/workers` gains `last_heartbeat_at`, `current_task_id`, `mgmt_base_url`.
- Extracts the `<base>/workers/<worker>/sessions/<session>` URL formatter into `internal/sessionref` so reporter (GitHub comments) and auditapi (dashboard) cannot drift.

Records as REQ-085 (`status: tested`).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/auditapi/... ./internal/webui/... ./internal/store/... ./internal/reporter/... ./cmd/... -count=1`
- [x] `go run . validate-docs --strict`
- [x] `python3 ~/.autoharness/scripts/validate_index.py project-index.yaml`
- [x] Golden snapshot test in `internal/auditapi` locks the in-flight row JSON shape
- [x] Byte-for-byte parity test confirms `/api/v1/sessions/{id}/events` matches the legacy `/sessions/{id}/events.json`

Fixes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)