### PR TITLE
webui: fix /issues/* SPA 404 + transition_counts null crash

### DIFF
--- a/cmd/coordinator.go
+++ b/cmd/coordinator.go
@@ -565,7 +565,10 @@ func buildCoordinatorMux(api *app.FullCoordinatorServer, st *store.Store, evlog 
 	audit.NewHTTPHandler(st).Register(readOnlyAuditMux)
 	mux.Handle("/events", api.WrapAuth(readOnlyAuditMux))
 	mux.Handle("/tasks", api.WrapAuth(readOnlyAuditMux))
-	mux.Handle("/issues/", api.WrapAuth(readOnlyAuditMux))
+	// Legacy /issues/{owner}/{repo}/{num}/state — kept for `workbuddy status`
+	// clients. Use a path-specific pattern so SPA routes like
+	// /issues/{owner}/{repo}/{num} still fall through to the catch-all.
+	mux.Handle("/issues/{owner}/{repo}/{num}/state", api.WrapAuth(readOnlyAuditMux))
 
 	metricsMux := http.NewServeMux()
 	metrics.NewHandler(st).WithEventLogger(evlog).Register(metricsMux)

--- a/internal/auditapi/handler.go
+++ b/internal/auditapi/handler.go
@@ -531,13 +531,14 @@ func (h *Handler) handleAPIIssueDetail(w http.ResponseWriter, r *http.Request) {
 	}
 	labels := decodeLabels(cache.Labels)
 	resp := issueDetailResponse{
-		Repo:         cache.Repo,
-		IssueNum:     cache.IssueNum,
-		Title:        firstLine(cache.Body),
-		CurrentState: labelToState(currentLabel(labels)),
-		Labels:       labels,
-		Transitions:  []issueTransitionResponse{},
-		Sessions:     []issueSessionRefResponse{},
+		Repo:             cache.Repo,
+		IssueNum:         cache.IssueNum,
+		Title:            firstLine(cache.Body),
+		CurrentState:     labelToState(currentLabel(labels)),
+		Labels:           labels,
+		Transitions:      []issueTransitionResponse{},
+		TransitionCounts: []transitionCountResponse{},
+		Sessions:         []issueSessionRefResponse{},
 	}
 	transitions, err := h.store.QueryIssueTransitions(repo, issueNum)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Restrict the legacy `/issues/{owner}/{repo}/{num}/state` audit handler to its specific path so SPA routes like `/issues/Lincyaw/workbuddy/231` fall through to the embedded SPA bundle (was 404 on direct nav / refresh)
- Initialise `transition_counts` to `[]` in the issue-detail JSON response so the SPA's `detail.transition_counts.length` access does not crash on issues that have not yet recorded any state transition

## How I found these
While dispatching the v0.5.0 Phase 1.1 supervisor sub-issue (#231) end-to-end through the dev-agent pipeline I drove the SPA via browser-harness:
- direct nav to `/issues/Lincyaw/workbuddy/231` → 404 (server-side)
- click-through from the dashboard in-flight table → blank page; console showed `TypeError: Cannot read properties of null (reading 'length')`

After the fix, both routes render the full IssueDetail (state badge, labels, cycle counts, transitions, sessions).

## Test plan
- [x] `go test ./internal/auditapi/... ./cmd/...` — pass
- [x] `go vet ./...` — clean
- [x] `make build` — clean
- [x] manual: redeploy, hit `/issues/Lincyaw/workbuddy/231` directly → 200 + IssueDetail rendered
- [x] manual: legacy `/issues/Lincyaw/workbuddy/231/state` (used by `workbuddy status`) still returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)