### PR TITLE
statemachine: distinguish dispatch intent from outcome in logs (#241)

### DIFF
--- a/internal/statemachine/statemachine.go
+++ b/internal/statemachine/statemachine.go
@@ -312,7 +312,7 @@ func (sm *StateMachine) processWorkflowEvent(ctx context.Context, wf *config.Wor
 	stateEntryDetected := (event.Type == poller.EventLabelAdded && event.Detail == currentState.EnterLabel) ||
 		(event.Type == poller.EventIssueCreated)
 	if stateEntryDetected && sm.stateHasAgents(currentState) {
-		log.Printf("[statemachine] state entry detected: %s#%d entered %q, dispatching agents %q",
+		log.Printf("[statemachine] state entry detected: %s#%d entered %q, candidate agents=%q",
 			event.Repo, event.IssueNum, currentStateName, sm.stateAgents(currentState))
 		sm.eventlog.Log(eventlog.TypeStateEntry, event.Repo, event.IssueNum,
 			map[string]interface{}{
@@ -839,6 +839,8 @@ func (sm *StateMachine) isBlockedByDependency(repo string, issueNum int, agentFo
 		return false, fmt.Errorf("statemachine: query dependency state: %w", err)
 	}
 	if depState != nil && (depState.Verdict == store.DependencyVerdictBlocked || depState.Verdict == store.DependencyVerdictNeedsHuman) {
+		log.Printf("[statemachine] dispatch blocked by dependency: %s#%d agent=%s verdict=%s",
+			repo, issueNum, agentForLog, depState.Verdict)
 		sm.eventlog.Log(eventlog.TypeDispatchBlockedByDependency, repo, issueNum, map[string]string{
 			"verdict": depState.Verdict,
 			"agent":   agentForLog,
@@ -890,6 +892,7 @@ func (sm *StateMachine) dispatchSingleAgent(ctx context.Context, repo string, is
 	}
 	select {
 	case sm.dispatch <- req:
+		log.Printf("[statemachine] dispatched %s for %s#%d state=%s", agentName, repo, issueNum, state)
 	case <-ctx.Done():
 		// Context cancelled before dispatch sent. Remove this agent from
 		// the group. If no agents were successfully dispatched, clean up

--- a/internal/statemachine/statemachine_test.go
+++ b/internal/statemachine/statemachine_test.go
@@ -1,10 +1,13 @@
 package statemachine
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -730,6 +733,108 @@ func TestDispatchBlockedByDependencyVerdict(t *testing.T) {
 	case req := <-dispatch:
 		t.Fatalf("unexpected dispatch: %+v", req)
 	default:
+	}
+}
+
+// captureLog redirects the standard logger output to a buffer for the duration
+// of the test. Returns the buffer and a cleanup function.
+func captureLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	prev := log.Writer()
+	prevFlags := log.Flags()
+	log.SetOutput(buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(prev)
+		log.SetFlags(prevFlags)
+	})
+	return buf
+}
+
+// TestStateEntryLogWordingAndDispatchedLog covers issue #241:
+//   - state entry log uses neutral "candidate agents=" wording (intent), not
+//     "dispatching agents" (outcome).
+//   - on the gate-passed path, a "[statemachine] dispatched ..." line is
+//     emitted, proving the agent actually entered the dispatch channel.
+func TestStateEntryLogWordingAndDispatchedLog(t *testing.T) {
+	sm, _, dispatch := newTestSM(t)
+	buf := captureLog(t)
+
+	if err := sm.HandleEvent(context.Background(), ChangeEvent{
+		Type:     poller.EventLabelAdded,
+		Repo:     "test/repo",
+		IssueNum: 241,
+		Labels:   []string{"workbuddy", "status:developing"},
+		Detail:   "status:developing",
+	}); err != nil {
+		t.Fatalf("HandleEvent: %v", err)
+	}
+
+	// Drain dispatch so the goroutine doesn't block.
+	select {
+	case <-dispatch:
+	case <-time.After(time.Second):
+		t.Fatalf("expected dispatch on gate-passed path")
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "candidate agents=") {
+		t.Errorf("expected neutral 'candidate agents=' wording in log, got:\n%s", out)
+	}
+	if strings.Contains(out, "dispatching agents") {
+		t.Errorf("old 'dispatching agents' wording must be removed; got:\n%s", out)
+	}
+	if !strings.Contains(out, "dispatched dev-agent for test/repo#241 state=developing") {
+		t.Errorf("expected '[statemachine] dispatched ...' line on gate-passed path, got:\n%s", out)
+	}
+}
+
+// TestDispatchBlockedByDependencyLogsReason covers issue #241:
+// when the dependency gate blocks dispatch, a human-readable log line should
+// be emitted in addition to the existing dispatch_blocked_by_dependency event,
+// and the "dispatched ..." line must NOT appear (ascend_dispatched=false).
+func TestDispatchBlockedByDependencyLogsReason(t *testing.T) {
+	sm, rec, dispatch := newTestSM(t)
+	if err := sm.store.UpsertIssueDependencyState(store.IssueDependencyState{
+		Repo:     "test/repo",
+		IssueNum: 241,
+		Verdict:  store.DependencyVerdictBlocked,
+	}); err != nil {
+		t.Fatalf("UpsertIssueDependencyState: %v", err)
+	}
+	buf := captureLog(t)
+
+	if err := sm.HandleEvent(context.Background(), ChangeEvent{
+		Type:     poller.EventLabelAdded,
+		Repo:     "test/repo",
+		IssueNum: 241,
+		Labels:   []string{"workbuddy", "status:developing"},
+		Detail:   "status:developing",
+	}); err != nil {
+		t.Fatalf("HandleEvent: %v", err)
+	}
+
+	select {
+	case req := <-dispatch:
+		t.Fatalf("unexpected dispatch on gate-blocked path: %+v", req)
+	default:
+	}
+
+	// The pre-existing event must still be recorded (backward compat).
+	if got := rec.find(eventlog.TypeDispatchBlockedByDependency); len(got) != 1 {
+		t.Fatalf("expected 1 dispatch_blocked_by_dependency event, got %d", len(got))
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "dispatch blocked by dependency") {
+		t.Errorf("expected '[statemachine] dispatch blocked by dependency ...' log, got:\n%s", out)
+	}
+	if !strings.Contains(out, "verdict=blocked") {
+		t.Errorf("expected verdict=blocked in log, got:\n%s", out)
+	}
+	if strings.Contains(out, "[statemachine] dispatched ") {
+		t.Errorf("'dispatched ...' line must not appear on gate-blocked path; got:\n%s", out)
 	}
 }
 

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -277,10 +277,8 @@ documentation:
       notes: Historical drift resolved by the app-server JSON-RPC codex backend; keep only as archive context. Codex is now a single runtime path on the 2-agent catalog rather than a separate agent or a dual-backend choice.
 
 requirements:
-  # ============================================================
-  # Layer 1: Core Engine
-  # ============================================================
-
+  # =====================================================  # Layer 1: Core Engine
+  # =====================================================
   - id: REQ-001
     title: Config Loader
     description: >
@@ -425,10 +423,8 @@ requirements:
     tests: []
     deps: [REQ-004]
 
-  # ============================================================
-  # Layer 2: Agent Runtime
-  # ============================================================
-
+  # =====================================================  # Layer 2: Agent Runtime
+  # =====================================================
   - id: REQ-006
     title: Agent Launcher (Multi-Runtime)
     description: >
@@ -544,10 +540,8 @@ requirements:
       - internal/store/store_test.go
     deps: [REQ-024]
 
-  # ============================================================
-  # Layer 3: Communication (v0.2.0)
-  # ============================================================
-
+  # =====================================================  # Layer 3: Communication (v0.2.0)
+  # =====================================================
   - id: REQ-025
     title: Coordinator HTTP API
     description: >
@@ -603,10 +597,8 @@ requirements:
       - internal/worker/distributed_test.go
     deps: [REQ-025]
 
-  # ============================================================
-  # Layer 4: Observability
-  # ============================================================
-
+  # =====================================================  # Layer 4: Observability
+  # =====================================================
   - id: REQ-009
     title: Event Log
     description: >
@@ -712,10 +704,8 @@ requirements:
       - internal/auditapi/handler_test.go
     deps: [REQ-011]
 
-  # ============================================================
-  # Layer 5: Workflow Orchestration
-  # ============================================================
-
+  # =====================================================  # Layer 5: Workflow Orchestration
+  # =====================================================
   - id: REQ-013
     title: Transition Rules Engine (superseded by transitions map)
     description: >
@@ -810,10 +800,8 @@ requirements:
     tests: []
     deps: [REQ-003]
 
-  # ============================================================
-  # CLI Commands
-  # ============================================================
-
+  # =====================================================  # CLI Commands
+  # =====================================================
   - id: REQ-017
     title: CLI - serve command (single-process wrapper)
     description: >
@@ -961,10 +949,8 @@ requirements:
     tests: [cmd/logs_test.go]
     deps: [REQ-008]
 
-  # ============================================================
-  # New Requirements (Architecture Change)
-  # ============================================================
-
+  # =====================================================  # New Requirements (Architecture Change)
+  # =====================================================
   - id: REQ-023
     title: Worker Registry
     description: >
@@ -1062,10 +1048,8 @@ requirements:
       - cmd/worker_test.go
     deps: [REQ-026, REQ-006]
 
-  # ============================================================
-  # Layer 6: Security & Resilience
-  # ============================================================
-
+  # =====================================================  # Layer 6: Security & Resilience
+  # =====================================================
   - id: REQ-029
     title: Worker Authentication
     description: >
@@ -1100,10 +1084,8 @@ requirements:
       - internal/store/store_test.go
     deps: [REQ-025]
 
-  # ============================================================
-  # Layer 7: Audit & Traceability
-  # ============================================================
-
+  # =====================================================  # Layer 7: Audit & Traceability
+  # =====================================================
   - id: REQ-030
     title: Agent Session Audit
     description: >
@@ -1170,10 +1152,8 @@ requirements:
       - cmd/serve_test.go
     deps: [REQ-002, REQ-003, REQ-004, REQ-024]
 
-  # ============================================================
-  # Layer 8: Pipeline Observability & Diagnosis
-  # ============================================================
-
+  # =====================================================  # Layer 8: Pipeline Observability & Diagnosis
+  # =====================================================
   - id: REQ-033
     title: CLI - status --tasks (task queue view)
     description: >
@@ -3207,4 +3187,34 @@ requirements:
       - .github/workflows/ci.yml
       - scripts/validate_index.py
     related_docs: []
+    deps: []
+
+  - id: REQ-094
+    title: State-machine dispatch logs distinguish intent from outcome (#241)
+    description: >
+      The state-entry log line previously read "dispatching agents %q",
+      which was misleading: dispatch can still be vetoed downstream by the
+      dependency gate (`isBlockedByDependency`) before the task ever enters
+      the dispatch channel. Operators reading `journalctl` saw the issue as
+      "dispatched" when it was actually blocked. Re-word the state-entry
+      line to "candidate agents=%q" (intent only), add a
+      `[statemachine] dispatched %s for %s#%d state=%s` line in
+      `dispatchSingleAgent` immediately after the request enters the
+      dispatch channel (true outcome), and add a
+      `[statemachine] dispatch blocked by dependency: ... verdict=%s` line
+      in `isBlockedByDependency` so blocking reasons surface in the system
+      log next to the existing `dispatch_blocked_by_dependency` event. The
+      event payload is unchanged for backwards compatibility.
+    priority: P2
+    version: v0.6.0
+    status: tested
+    acceptance_criteria:
+      - "AC-094-1: `internal/statemachine/statemachine.go` state-entry log uses neutral wording (`candidate agents=`), not `dispatching agents`."
+      - "AC-094-2: `dispatchSingleAgent` emits `[statemachine] dispatched <agent> for <repo>#<n> state=<state>` after the dispatch request is accepted by the channel."
+      - "AC-094-3: `isBlockedByDependency` emits `[statemachine] dispatch blocked by dependency: <repo>#<n> agent=<a> verdict=<v>` whenever it returns blocked, alongside the existing `dispatch_blocked_by_dependency` event (unchanged payload)."
+      - "AC-094-4: Tests assert that the gate-passed path produces the `dispatched ...` log line and the gate-blocked path does not (and additionally produces the new `dispatch blocked by dependency` line)."
+    code:
+      - internal/statemachine/statemachine.go
+    tests:
+      - internal/statemachine/statemachine_test.go
     deps: []


### PR DESCRIPTION
Fixes #241.

## Summary
- Re-word `[statemachine] state entry detected ...` to use neutral `candidate agents=...` (intent) instead of `dispatching agents` (outcome).
- Add `[statemachine] dispatched <agent> for <repo>#<n> state=<state>` in `dispatchSingleAgent` immediately after the request lands in the dispatch channel — this is the true "dispatched" signal.
- Add `[statemachine] dispatch blocked by dependency: <repo>#<n> agent=<a> verdict=<v>` in `isBlockedByDependency` so `journalctl` shows the blocking reason next to the existing `dispatch_blocked_by_dependency` event.
- Existing event schema unchanged; gate logic untouched (`internal/dependency/gate.go` not modified).

## Tests
- `TestStateEntryLogWordingAndDispatchedLog` — gate-passed path emits `dispatched ...` line and uses `candidate agents=` wording.
- `TestDispatchBlockedByDependencyLogsReason` — gate-blocked path emits the new blocked log, does NOT emit `dispatched ...`, and still records the `dispatch_blocked_by_dependency` event.
- `go build ./...`, `go vet ./...`, `go test ./internal/statemachine/...` all pass.
- `project-index.yaml` updated with REQ-093.