### PR TITLE
deploy: add deploy watch pull-based release watcher + rollback

### DIFF
--- a/cmd/deploy_watch.go
+++ b/cmd/deploy_watch.go
@@ -1,0 +1,590 @@
+package cmd
+
+import (
+	"archive/tar"
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	defaultWatchInterval        = 5 * time.Minute
+	defaultUpdaterBinaryPath    = "/usr/local/bin/workbuddy"
+	defaultUpdaterSystemctlMode = "user"
+	updaterCurrentVersionFile   = "current-version"
+	updaterPreviousBinaryFile   = "previous-binary"
+	updaterChecksumName         = "checksums.txt"
+)
+
+// deployWatchSleep blocks for d or until ctx is cancelled. Overridable in tests.
+var deployWatchSleep = func(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+type deployWatchOpts struct {
+	repository     string
+	interval       time.Duration
+	restartUnits   []string
+	stateDir       string
+	binaryPath     string
+	systemctlScope string
+	dryRun         bool
+	once           bool
+}
+
+type deployRollbackOpts struct {
+	stateDir       string
+	restartUnits   []string
+	binaryPath     string
+	systemctlScope string
+	dryRun         bool
+}
+
+var deployWatchCmd = &cobra.Command{
+	Use:   "watch",
+	Short: "Poll GitHub Releases and upgrade the deployed binary in place",
+	Long: strings.TrimSpace(`
+Poll the configured GitHub repository for the latest release on a fixed
+interval. When a newer release is found, download its linux-${ARCH} archive,
+verify its SHA256 against the release checksums file, atomically replace the
+target binary (default /usr/local/bin/workbuddy), back up the previous
+binary, and restart the listed systemd units.
+
+The previous binary is preserved in <state-dir>/previous-binary so that
+"workbuddy deploy rollback" can restore it. The current installed version
+is tracked in <state-dir>/current-version. On any failure the existing
+binary is left untouched and the error is logged; the loop retries on the
+next interval.
+`),
+	Example: strings.TrimSpace(`
+  # One-shot dry run:
+  workbuddy deploy watch --repo Lincyaw/workbuddy --once --dry-run
+
+  # Recurring updater (typical systemd user service ExecStart):
+  workbuddy deploy watch \
+    --repo Lincyaw/workbuddy \
+    --interval 5m \
+    --restart-units workbuddy-coordinator.service \
+    --restart-units workbuddy-worker.service
+`),
+	RunE: runDeployWatchCmd,
+}
+
+var deployRollbackCmd = &cobra.Command{
+	Use:   "rollback",
+	Short: "Swap the previous binary back into place and restart units",
+	Long: strings.TrimSpace(`
+Swap <state-dir>/previous-binary back into the target binary path (default
+/usr/local/bin/workbuddy), then restart the listed systemd units. The
+displaced binary is moved into <state-dir>/previous-binary so that running
+rollback twice toggles between the two versions.
+`),
+	RunE: runDeployRollbackCmd,
+}
+
+func init() {
+	deployWatchCmd.Flags().String("repo", "", "GitHub repository in OWNER/NAME form (required)")
+	deployWatchCmd.Flags().Duration("interval", defaultWatchInterval, "Poll interval between release checks")
+	deployWatchCmd.Flags().StringSlice("restart-units", nil, "systemd unit name(s) to restart after a successful upgrade (repeatable)")
+	deployWatchCmd.Flags().String("state-dir", "", "Directory used to track the current version and previous binary backup (default: $XDG_STATE_HOME/workbuddy/updater or ~/.local/state/workbuddy/updater)")
+	deployWatchCmd.Flags().String("binary", defaultUpdaterBinaryPath, "Path to the workbuddy binary to upgrade")
+	deployWatchCmd.Flags().String("systemctl-scope", defaultUpdaterSystemctlMode, "systemctl scope used to restart units: user or system")
+	deployWatchCmd.Flags().Bool("dry-run", false, "Run a check but do not download, replace, or restart anything")
+	deployWatchCmd.Flags().Bool("once", false, "Run a single check and exit instead of looping")
+
+	deployRollbackCmd.Flags().String("state-dir", "", "Directory holding the previous-binary backup (default: $XDG_STATE_HOME/workbuddy/updater or ~/.local/state/workbuddy/updater)")
+	deployRollbackCmd.Flags().StringSlice("restart-units", nil, "systemd unit name(s) to restart after rollback (repeatable)")
+	deployRollbackCmd.Flags().String("binary", defaultUpdaterBinaryPath, "Path to the workbuddy binary to roll back")
+	deployRollbackCmd.Flags().String("systemctl-scope", defaultUpdaterSystemctlMode, "systemctl scope used to restart units: user or system")
+	deployRollbackCmd.Flags().Bool("dry-run", false, "Print the actions that would be taken without executing them")
+
+	deployCmd.AddCommand(deployWatchCmd, deployRollbackCmd)
+}
+
+func runDeployWatchCmd(cmd *cobra.Command, _ []string) error {
+	opts, err := parseDeployWatchFlags(cmd)
+	if err != nil {
+		return err
+	}
+	if !opts.dryRun {
+		if err := requireWritable(cmd, "deploy watch"); err != nil {
+			return err
+		}
+	}
+	return runDeployWatchLoop(cmd.Context(), opts, cmdStdout(cmd))
+}
+
+func runDeployRollbackCmd(cmd *cobra.Command, _ []string) error {
+	opts, err := parseDeployRollbackFlags(cmd)
+	if err != nil {
+		return err
+	}
+	if !opts.dryRun {
+		if err := requireWritable(cmd, "deploy rollback"); err != nil {
+			return err
+		}
+	}
+	return runDeployRollback(cmd.Context(), opts, cmdStdout(cmd))
+}
+
+func parseDeployWatchFlags(cmd *cobra.Command) (*deployWatchOpts, error) {
+	repo, _ := cmd.Flags().GetString("repo")
+	interval, _ := cmd.Flags().GetDuration("interval")
+	units, _ := cmd.Flags().GetStringSlice("restart-units")
+	stateDir, _ := cmd.Flags().GetString("state-dir")
+	binary, _ := cmd.Flags().GetString("binary")
+	scope, _ := cmd.Flags().GetString("systemctl-scope")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	once, _ := cmd.Flags().GetBool("once")
+
+	repo = strings.TrimSpace(repo)
+	if repo == "" {
+		return nil, fmt.Errorf("deploy watch: --repo is required (owner/name)")
+	}
+	if !strings.Contains(repo, "/") {
+		return nil, fmt.Errorf("deploy watch: --repo must be owner/name, got %q", repo)
+	}
+	if interval <= 0 {
+		return nil, fmt.Errorf("deploy watch: --interval must be positive")
+	}
+	scope = strings.ToLower(strings.TrimSpace(scope))
+	if scope != "user" && scope != "system" {
+		return nil, fmt.Errorf("deploy watch: --systemctl-scope must be user or system")
+	}
+	binary = strings.TrimSpace(binary)
+	if binary == "" {
+		return nil, fmt.Errorf("deploy watch: --binary is required")
+	}
+	resolvedStateDir, err := resolveUpdaterStateDir(stateDir)
+	if err != nil {
+		return nil, fmt.Errorf("deploy watch: %w", err)
+	}
+	return &deployWatchOpts{
+		repository:     repo,
+		interval:       interval,
+		restartUnits:   trimStringSlice(units),
+		stateDir:       resolvedStateDir,
+		binaryPath:     binary,
+		systemctlScope: scope,
+		dryRun:         dryRun,
+		once:           once,
+	}, nil
+}
+
+func parseDeployRollbackFlags(cmd *cobra.Command) (*deployRollbackOpts, error) {
+	stateDir, _ := cmd.Flags().GetString("state-dir")
+	units, _ := cmd.Flags().GetStringSlice("restart-units")
+	binary, _ := cmd.Flags().GetString("binary")
+	scope, _ := cmd.Flags().GetString("systemctl-scope")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+	scope = strings.ToLower(strings.TrimSpace(scope))
+	if scope != "user" && scope != "system" {
+		return nil, fmt.Errorf("deploy rollback: --systemctl-scope must be user or system")
+	}
+	binary = strings.TrimSpace(binary)
+	if binary == "" {
+		return nil, fmt.Errorf("deploy rollback: --binary is required")
+	}
+	resolvedStateDir, err := resolveUpdaterStateDir(stateDir)
+	if err != nil {
+		return nil, fmt.Errorf("deploy rollback: %w", err)
+	}
+	return &deployRollbackOpts{
+		stateDir:       resolvedStateDir,
+		restartUnits:   trimStringSlice(units),
+		binaryPath:     binary,
+		systemctlScope: scope,
+		dryRun:         dryRun,
+	}, nil
+}
+
+func resolveUpdaterStateDir(requested string) (string, error) {
+	if dir := strings.TrimSpace(requested); dir != "" {
+		return filepath.Abs(dir)
+	}
+	if v := strings.TrimSpace(os.Getenv("XDG_STATE_HOME")); v != "" {
+		return filepath.Join(v, "workbuddy", "updater"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user home: %w", err)
+	}
+	return filepath.Join(home, ".local", "state", "workbuddy", "updater"), nil
+}
+
+func runDeployWatchLoop(ctx context.Context, opts *deployWatchOpts, stdout io.Writer) error {
+	if opts == nil {
+		return fmt.Errorf("deploy watch: options are required")
+	}
+	for {
+		if err := runDeployWatchOnce(ctx, opts, stdout); err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return err
+			}
+			fmt.Fprintf(stdout, "watch: error: %v\n", err)
+		}
+		if opts.once {
+			return nil
+		}
+		if err := deployWatchSleep(ctx, opts.interval); err != nil {
+			return err
+		}
+	}
+}
+
+func runDeployWatchOnce(ctx context.Context, opts *deployWatchOpts, stdout io.Writer) error {
+	current, err := readCurrentVersion(opts.stateDir)
+	if err != nil {
+		return fmt.Errorf("read current version: %w", err)
+	}
+	latest, err := resolveReleaseVersion(ctx, opts.repository, "latest")
+	if err != nil {
+		return fmt.Errorf("resolve latest release: %w", err)
+	}
+	currentLabel := current
+	if currentLabel == "" {
+		currentLabel = "<none>"
+	}
+	if !semverGreater(latest, current) {
+		fmt.Fprintf(stdout, "watch: up-to-date (current=%s, latest=v%s)\n", currentLabel, latest)
+		return nil
+	}
+	fmt.Fprintf(stdout, "watch: upgrade available (current=%s, latest=v%s)\n", currentLabel, latest)
+	if opts.dryRun {
+		fmt.Fprintf(stdout, "watch: dry-run, skipping download and restart\n")
+		return nil
+	}
+	if err := performUpgrade(ctx, opts, latest, stdout); err != nil {
+		return err
+	}
+	return nil
+}
+
+func performUpgrade(ctx context.Context, opts *deployWatchOpts, version string, stdout io.Writer) error {
+	if err := os.MkdirAll(opts.stateDir, 0o755); err != nil {
+		return fmt.Errorf("create state dir: %w", err)
+	}
+	archiveName := releaseArchiveName(version)
+	archiveBytes, err := downloadReleaseAsset(ctx, opts.repository, version, archiveName)
+	if err != nil {
+		return fmt.Errorf("download archive: %w", err)
+	}
+	checksumBytes, err := downloadReleaseAsset(ctx, opts.repository, version, updaterChecksumName)
+	if err != nil {
+		return fmt.Errorf("download checksums: %w", err)
+	}
+	expected, err := lookupChecksum(checksumBytes, archiveName)
+	if err != nil {
+		return fmt.Errorf("locate checksum: %w", err)
+	}
+	got := sha256Hex(archiveBytes)
+	if got != expected {
+		return fmt.Errorf("checksum mismatch for %s: expected %s, got %s", archiveName, expected, got)
+	}
+	binaryBytes, err := extractBinaryFromArchive(bytes.NewReader(archiveBytes))
+	if err != nil {
+		return fmt.Errorf("extract binary: %w", err)
+	}
+
+	previousBinary := filepath.Join(opts.stateDir, updaterPreviousBinaryFile)
+	if err := backupBinary(opts.binaryPath, previousBinary); err != nil {
+		return fmt.Errorf("backup previous binary: %w", err)
+	}
+	if err := writeBytesAtomic(opts.binaryPath, binaryBytes, 0o755); err != nil {
+		return fmt.Errorf("install new binary: %w", err)
+	}
+	if err := writeCurrentVersion(opts.stateDir, "v"+version); err != nil {
+		return fmt.Errorf("write current-version: %w", err)
+	}
+	fmt.Fprintf(stdout, "watch: installed v%s to %s (previous backed up to %s)\n", version, opts.binaryPath, previousBinary)
+	if err := restartUnits(ctx, opts.systemctlScope, opts.restartUnits); err != nil {
+		return fmt.Errorf("restart units: %w", err)
+	}
+	for _, unit := range opts.restartUnits {
+		fmt.Fprintf(stdout, "watch: restarted %s\n", unit)
+	}
+	return nil
+}
+
+func runDeployRollback(ctx context.Context, opts *deployRollbackOpts, stdout io.Writer) error {
+	if opts == nil {
+		return fmt.Errorf("deploy rollback: options are required")
+	}
+	previousBinary := filepath.Join(opts.stateDir, updaterPreviousBinaryFile)
+	info, err := os.Stat(previousBinary)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("deploy rollback: no previous binary at %s", previousBinary)
+		}
+		return fmt.Errorf("deploy rollback: stat previous binary: %w", err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("deploy rollback: previous binary path %s is a directory", previousBinary)
+	}
+	if opts.dryRun {
+		fmt.Fprintf(stdout, "dry-run: would swap %s into %s\n", previousBinary, opts.binaryPath)
+		for _, unit := range opts.restartUnits {
+			fmt.Fprintf(stdout, "dry-run: would restart %s (scope=%s)\n", unit, opts.systemctlScope)
+		}
+		return nil
+	}
+
+	prevBytes, err := os.ReadFile(previousBinary)
+	if err != nil {
+		return fmt.Errorf("deploy rollback: read previous binary: %w", err)
+	}
+	tmpPrev := previousBinary + ".rollback-tmp"
+	defer os.Remove(tmpPrev)
+	if currentBytes, err := os.ReadFile(opts.binaryPath); err == nil {
+		if err := writeBytesAtomic(tmpPrev, currentBytes, 0o755); err != nil {
+			return fmt.Errorf("deploy rollback: stash current binary: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("deploy rollback: read current binary: %w", err)
+	}
+	if err := writeBytesAtomic(opts.binaryPath, prevBytes, 0o755); err != nil {
+		return fmt.Errorf("deploy rollback: install previous binary: %w", err)
+	}
+	// Move tmpPrev → previousBinary so rollback toggles between versions.
+	if _, err := os.Stat(tmpPrev); err == nil {
+		if err := os.Rename(tmpPrev, previousBinary); err != nil {
+			return fmt.Errorf("deploy rollback: rotate previous-binary: %w", err)
+		}
+	} else {
+		_ = os.Remove(previousBinary)
+	}
+	fmt.Fprintf(stdout, "rollback: swapped %s into %s\n", previousBinary, opts.binaryPath)
+	if err := restartUnits(ctx, opts.systemctlScope, opts.restartUnits); err != nil {
+		return fmt.Errorf("deploy rollback: %w", err)
+	}
+	for _, unit := range opts.restartUnits {
+		fmt.Fprintf(stdout, "rollback: restarted %s\n", unit)
+	}
+	return nil
+}
+
+func backupBinary(src, dst string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// First-time install: nothing to back up.
+			_ = os.Remove(dst)
+			return nil
+		}
+		return err
+	}
+	return writeBytesAtomic(dst, data, 0o755)
+}
+
+func readCurrentVersion(stateDir string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(stateDir, updaterCurrentVersionFile))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func writeCurrentVersion(stateDir, version string) error {
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		return err
+	}
+	return writeBytesAtomic(filepath.Join(stateDir, updaterCurrentVersionFile), []byte(version+"\n"), 0o644)
+}
+
+func downloadReleaseAsset(ctx context.Context, repository, version, name string) ([]byte, error) {
+	url := fmt.Sprintf("%s/%s/releases/download/v%s/%s",
+		strings.TrimRight(deployGitHubDownloadBase, "/"), repository, version, name)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request for %s: %w", name, err)
+	}
+	applyGitHubAuth(req)
+	resp, err := deployHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("download %s: %w", name, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("download %s: unexpected status %s", name, resp.Status)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read %s body: %w", name, err)
+	}
+	return body, nil
+}
+
+func lookupChecksum(checksumFile []byte, target string) (string, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(checksumFile))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		// goreleaser format: "<sha>  <name>" — the name may have a leading "*".
+		name := strings.TrimPrefix(fields[len(fields)-1], "*")
+		if name == target {
+			return strings.ToLower(fields[0]), nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return "", fmt.Errorf("no checksum entry for %s", target)
+}
+
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func extractBinaryFromArchive(reader io.Reader) ([]byte, error) {
+	gzipReader, err := gzip.NewReader(reader)
+	if err != nil {
+		return nil, fmt.Errorf("open gzip: %w", err)
+	}
+	defer gzipReader.Close()
+	tarReader := tar.NewReader(gzipReader)
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read tar: %w", err)
+		}
+		if header == nil || header.Typeflag != tar.TypeReg {
+			continue
+		}
+		if filepath.Base(header.Name) != "workbuddy" {
+			continue
+		}
+		return io.ReadAll(tarReader)
+	}
+	return nil, fmt.Errorf("archive did not contain a workbuddy binary")
+}
+
+func restartUnits(ctx context.Context, scope string, units []string) error {
+	for _, unit := range units {
+		if strings.TrimSpace(unit) == "" {
+			continue
+		}
+		if err := deployRunSystemctl(ctx, scope, "restart", unit); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// semverGreater reports whether `latest` (e.g. "1.2.3") is strictly greater
+// than `current` (e.g. "v1.2.2", "1.2.2", or "" for unset). Non-numeric
+// segments are compared lexically so prerelease tags like "1.2.3-rc1" still
+// produce a stable ordering.
+func semverGreater(latest, current string) bool {
+	if strings.TrimSpace(current) == "" {
+		return true
+	}
+	return compareSemver(latest, current) > 0
+}
+
+func compareSemver(a, b string) int {
+	aCore, aPre := splitSemver(a)
+	bCore, bPre := splitSemver(b)
+	max := len(aCore)
+	if len(bCore) > max {
+		max = len(bCore)
+	}
+	for i := 0; i < max; i++ {
+		ax := "0"
+		bx := "0"
+		if i < len(aCore) {
+			ax = aCore[i]
+		}
+		if i < len(bCore) {
+			bx = bCore[i]
+		}
+		ai, aErr := strconv.Atoi(ax)
+		bi, bErr := strconv.Atoi(bx)
+		if aErr == nil && bErr == nil {
+			if ai != bi {
+				if ai > bi {
+					return 1
+				}
+				return -1
+			}
+			continue
+		}
+		if ax != bx {
+			if ax > bx {
+				return 1
+			}
+			return -1
+		}
+	}
+	// Per semver: a release version > the same version with a prerelease tag.
+	if aPre == "" && bPre != "" {
+		return 1
+	}
+	if aPre != "" && bPre == "" {
+		return -1
+	}
+	if aPre == bPre {
+		return 0
+	}
+	if aPre > bPre {
+		return 1
+	}
+	return -1
+}
+
+func splitSemver(v string) (core []string, prerelease string) {
+	v = strings.TrimSpace(v)
+	v = strings.TrimPrefix(v, "v")
+	if v == "" {
+		return nil, ""
+	}
+	body := v
+	if idx := strings.Index(body, "+"); idx >= 0 {
+		body = body[:idx] // drop build metadata
+	}
+	if idx := strings.Index(body, "-"); idx >= 0 {
+		prerelease = body[idx+1:]
+		body = body[:idx]
+	}
+	core = strings.Split(body, ".")
+	return core, prerelease
+}
+

--- a/cmd/deploy_watch_test.go
+++ b/cmd/deploy_watch_test.go
@@ -1,0 +1,373 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func writeChecksums(entries map[string][]byte) []byte {
+	var b strings.Builder
+	for name, data := range entries {
+		sum := sha256.Sum256(data)
+		fmt.Fprintf(&b, "%s  %s\n", hex.EncodeToString(sum[:]), name)
+	}
+	return []byte(b.String())
+}
+
+func newReleaseServer(t *testing.T, repo, version string, archive, checksums []byte) *httptest.Server {
+	t.Helper()
+	archiveName := releaseArchiveName(version)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/" + repo + "/releases/latest":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"tag_name":"v%s"}`, version)
+		case "/" + repo + "/releases/download/v" + version + "/" + archiveName:
+			w.Header().Set("Content-Type", "application/gzip")
+			_, _ = w.Write(archive)
+		case "/" + repo + "/releases/download/v" + version + "/" + updaterChecksumName:
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write(checksums)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	return server
+}
+
+func setupWatchTestEnv(t *testing.T, server *httptest.Server) func() {
+	t.Helper()
+	oldClient := deployHTTPClient
+	oldAPI := deployGitHubAPIBaseURL
+	oldDownload := deployGitHubDownloadBase
+	oldSystemctl := deployRunSystemctl
+	deployHTTPClient = server.Client()
+	deployGitHubAPIBaseURL = server.URL
+	deployGitHubDownloadBase = server.URL
+	return func() {
+		deployHTTPClient = oldClient
+		deployGitHubAPIBaseURL = oldAPI
+		deployGitHubDownloadBase = oldDownload
+		deployRunSystemctl = oldSystemctl
+	}
+}
+
+func TestSemverGreater(t *testing.T) {
+	cases := []struct {
+		latest, current string
+		want            bool
+	}{
+		{"1.2.3", "", true},
+		{"1.2.3", "v1.2.2", true},
+		{"1.2.3", "v1.2.3", false},
+		{"1.2.3", "v1.3.0", false},
+		{"1.10.0", "v1.9.9", true},
+		{"2.0.0", "v1.99.99", true},
+		{"1.2.3-rc1", "v1.2.3", false},
+	}
+	for _, c := range cases {
+		if got := semverGreater(c.latest, c.current); got != c.want {
+			t.Errorf("semverGreater(%q,%q)=%v want %v", c.latest, c.current, got, c.want)
+		}
+	}
+}
+
+func TestLookupChecksum(t *testing.T) {
+	data := []byte("aabbcc  workbuddy_1.2.3_linux_amd64.tar.gz\n" +
+		"ffeedd  *workbuddy_1.2.3_linux_arm64.tar.gz\n" +
+		"\n" +
+		"# comment\n")
+	if sum, err := lookupChecksum(data, "workbuddy_1.2.3_linux_amd64.tar.gz"); err != nil || sum != "aabbcc" {
+		t.Fatalf("amd64: sum=%q err=%v", sum, err)
+	}
+	if sum, err := lookupChecksum(data, "workbuddy_1.2.3_linux_arm64.tar.gz"); err != nil || sum != "ffeedd" {
+		t.Fatalf("arm64: sum=%q err=%v", sum, err)
+	}
+	if _, err := lookupChecksum(data, "missing.tar.gz"); err == nil {
+		t.Fatalf("expected error for missing entry")
+	}
+}
+
+func TestRunDeployWatchOnce_NoOpWhenAtLatest(t *testing.T) {
+	tempDir := t.TempDir()
+	stateDir := filepath.Join(tempDir, "updater")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, updaterCurrentVersionFile), []byte("v1.2.3\n"), 0o644); err != nil {
+		t.Fatalf("write current: %v", err)
+	}
+
+	archive := buildReleaseArchive(t, "ignored")
+	server := newReleaseServer(t, "acme/workbuddy", "1.2.3", archive,
+		writeChecksums(map[string][]byte{releaseArchiveName("1.2.3"): archive}))
+	defer server.Close()
+	defer setupWatchTestEnv(t, server)()
+
+	deployRunSystemctl = func(_ context.Context, _ string, _ ...string) error {
+		t.Fatal("systemctl should not be invoked when up-to-date")
+		return nil
+	}
+
+	binaryPath := filepath.Join(tempDir, "bin", "workbuddy")
+	if err := os.MkdirAll(filepath.Dir(binaryPath), 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	if err := os.WriteFile(binaryPath, []byte("old"), 0o755); err != nil {
+		t.Fatalf("write old: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	err := runDeployWatchOnce(context.Background(), &deployWatchOpts{
+		repository:     "acme/workbuddy",
+		stateDir:       stateDir,
+		binaryPath:     binaryPath,
+		systemctlScope: "user",
+	}, &stdout)
+	if err != nil {
+		t.Fatalf("runDeployWatchOnce: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "up-to-date") {
+		t.Fatalf("expected up-to-date message, got %q", stdout.String())
+	}
+	if got, _ := os.ReadFile(binaryPath); string(got) != "old" {
+		t.Fatalf("binary unexpectedly modified: %q", got)
+	}
+}
+
+func TestRunDeployWatchOnce_DownloadsAndRestarts(t *testing.T) {
+	tempDir := t.TempDir()
+	stateDir := filepath.Join(tempDir, "updater")
+	binaryPath := filepath.Join(tempDir, "bin", "workbuddy")
+	if err := os.MkdirAll(filepath.Dir(binaryPath), 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	if err := os.WriteFile(binaryPath, []byte("old-binary"), 0o755); err != nil {
+		t.Fatalf("write old: %v", err)
+	}
+
+	archive := buildReleaseArchive(t, "release-binary")
+	server := newReleaseServer(t, "acme/workbuddy", "1.2.3", archive,
+		writeChecksums(map[string][]byte{releaseArchiveName("1.2.3"): archive}))
+	defer server.Close()
+	defer setupWatchTestEnv(t, server)()
+
+	var systemctlCalls []string
+	deployRunSystemctl = func(_ context.Context, scope string, args ...string) error {
+		systemctlCalls = append(systemctlCalls, scope+":"+strings.Join(args, " "))
+		return nil
+	}
+
+	var stdout bytes.Buffer
+	err := runDeployWatchOnce(context.Background(), &deployWatchOpts{
+		repository:     "acme/workbuddy",
+		stateDir:       stateDir,
+		binaryPath:     binaryPath,
+		systemctlScope: "user",
+		restartUnits:   []string{"workbuddy-coordinator.service", "workbuddy-worker.service"},
+	}, &stdout)
+	if err != nil {
+		t.Fatalf("runDeployWatchOnce: %v", err)
+	}
+
+	if got, _ := os.ReadFile(binaryPath); string(got) != "release-binary" {
+		t.Fatalf("binary not upgraded: %q", got)
+	}
+	if got, _ := os.ReadFile(filepath.Join(stateDir, updaterPreviousBinaryFile)); string(got) != "old-binary" {
+		t.Fatalf("previous-binary backup wrong: %q", got)
+	}
+	if got, _ := os.ReadFile(filepath.Join(stateDir, updaterCurrentVersionFile)); strings.TrimSpace(string(got)) != "v1.2.3" {
+		t.Fatalf("current-version not updated: %q", got)
+	}
+	want := "user:restart workbuddy-coordinator.service | user:restart workbuddy-worker.service"
+	if got := strings.Join(systemctlCalls, " | "); got != want {
+		t.Fatalf("systemctl calls = %q, want %q", got, want)
+	}
+}
+
+func TestRunDeployWatchOnce_ChecksumMismatchPreservesBinary(t *testing.T) {
+	tempDir := t.TempDir()
+	stateDir := filepath.Join(tempDir, "updater")
+	binaryPath := filepath.Join(tempDir, "bin", "workbuddy")
+	if err := os.MkdirAll(filepath.Dir(binaryPath), 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	if err := os.WriteFile(binaryPath, []byte("old-binary"), 0o755); err != nil {
+		t.Fatalf("write old: %v", err)
+	}
+
+	archive := buildReleaseArchive(t, "release-binary")
+	bogus := []byte(strings.Repeat("00", 32) + "  " + releaseArchiveName("1.2.3") + "\n")
+	server := newReleaseServer(t, "acme/workbuddy", "1.2.3", archive, bogus)
+	defer server.Close()
+	defer setupWatchTestEnv(t, server)()
+
+	deployRunSystemctl = func(_ context.Context, _ string, _ ...string) error {
+		t.Fatal("systemctl should not run on checksum mismatch")
+		return nil
+	}
+
+	var stdout bytes.Buffer
+	err := runDeployWatchOnce(context.Background(), &deployWatchOpts{
+		repository:     "acme/workbuddy",
+		stateDir:       stateDir,
+		binaryPath:     binaryPath,
+		systemctlScope: "user",
+	}, &stdout)
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("expected checksum mismatch error, got %v", err)
+	}
+	if got, _ := os.ReadFile(binaryPath); string(got) != "old-binary" {
+		t.Fatalf("binary should be untouched, got %q", got)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, updaterCurrentVersionFile)); !os.IsNotExist(err) {
+		t.Fatalf("current-version should not be written on failure: err=%v", err)
+	}
+}
+
+func TestRunDeployWatchOnce_DryRun(t *testing.T) {
+	tempDir := t.TempDir()
+	stateDir := filepath.Join(tempDir, "updater")
+	binaryPath := filepath.Join(tempDir, "bin", "workbuddy")
+	if err := os.MkdirAll(filepath.Dir(binaryPath), 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	if err := os.WriteFile(binaryPath, []byte("old-binary"), 0o755); err != nil {
+		t.Fatalf("write old: %v", err)
+	}
+
+	archive := buildReleaseArchive(t, "release-binary")
+	server := newReleaseServer(t, "acme/workbuddy", "1.2.3", archive,
+		writeChecksums(map[string][]byte{releaseArchiveName("1.2.3"): archive}))
+	defer server.Close()
+	defer setupWatchTestEnv(t, server)()
+
+	deployRunSystemctl = func(_ context.Context, _ string, _ ...string) error {
+		t.Fatal("dry-run must not invoke systemctl")
+		return nil
+	}
+
+	var stdout bytes.Buffer
+	err := runDeployWatchOnce(context.Background(), &deployWatchOpts{
+		repository:     "acme/workbuddy",
+		stateDir:       stateDir,
+		binaryPath:     binaryPath,
+		systemctlScope: "user",
+		dryRun:         true,
+	}, &stdout)
+	if err != nil {
+		t.Fatalf("runDeployWatchOnce: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "dry-run") {
+		t.Fatalf("expected dry-run log, got %q", stdout.String())
+	}
+	if got, _ := os.ReadFile(binaryPath); string(got) != "old-binary" {
+		t.Fatalf("binary should be untouched in dry-run, got %q", got)
+	}
+}
+
+func TestRunDeployRollback_SwapsBinaryAndRestarts(t *testing.T) {
+	tempDir := t.TempDir()
+	stateDir := filepath.Join(tempDir, "updater")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	binaryPath := filepath.Join(tempDir, "bin", "workbuddy")
+	if err := os.MkdirAll(filepath.Dir(binaryPath), 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	if err := os.WriteFile(binaryPath, []byte("current-binary"), 0o755); err != nil {
+		t.Fatalf("write current: %v", err)
+	}
+	previous := filepath.Join(stateDir, updaterPreviousBinaryFile)
+	if err := os.WriteFile(previous, []byte("previous-binary"), 0o755); err != nil {
+		t.Fatalf("write previous: %v", err)
+	}
+
+	oldSystemctl := deployRunSystemctl
+	t.Cleanup(func() { deployRunSystemctl = oldSystemctl })
+	var calls []string
+	deployRunSystemctl = func(_ context.Context, scope string, args ...string) error {
+		calls = append(calls, scope+":"+strings.Join(args, " "))
+		return nil
+	}
+
+	var stdout bytes.Buffer
+	err := runDeployRollback(context.Background(), &deployRollbackOpts{
+		stateDir:       stateDir,
+		binaryPath:     binaryPath,
+		systemctlScope: "user",
+		restartUnits:   []string{"workbuddy-coordinator.service"},
+	}, &stdout)
+	if err != nil {
+		t.Fatalf("runDeployRollback: %v", err)
+	}
+	if got, _ := os.ReadFile(binaryPath); string(got) != "previous-binary" {
+		t.Fatalf("binary should hold previous-binary after rollback, got %q", got)
+	}
+	if got, _ := os.ReadFile(previous); string(got) != "current-binary" {
+		t.Fatalf("previous-binary should now hold prior current, got %q", got)
+	}
+	want := "user:restart workbuddy-coordinator.service"
+	if got := strings.Join(calls, " | "); got != want {
+		t.Fatalf("systemctl calls = %q, want %q", got, want)
+	}
+}
+
+func TestRunDeployRollback_NoBackup(t *testing.T) {
+	tempDir := t.TempDir()
+	stateDir := filepath.Join(tempDir, "updater")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	err := runDeployRollback(context.Background(), &deployRollbackOpts{
+		stateDir:       stateDir,
+		binaryPath:     filepath.Join(tempDir, "bin", "workbuddy"),
+		systemctlScope: "user",
+	}, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "no previous binary") {
+		t.Fatalf("expected no previous binary error, got %v", err)
+	}
+}
+
+func TestParseDeployWatchFlags_Validation(t *testing.T) {
+	cmd := deployWatchCmd
+	// Restore flag values after the subtest.
+	t.Cleanup(func() {
+		_ = cmd.Flags().Set("repo", "")
+		_ = cmd.Flags().Set("interval", defaultWatchInterval.String())
+	})
+	_ = cmd.Flags().Set("repo", "")
+	if _, err := parseDeployWatchFlags(cmd); err == nil {
+		t.Fatalf("expected --repo required error")
+	}
+	_ = cmd.Flags().Set("repo", "no-slash")
+	if _, err := parseDeployWatchFlags(cmd); err == nil {
+		t.Fatalf("expected owner/name error")
+	}
+	_ = cmd.Flags().Set("repo", "acme/workbuddy")
+	_ = cmd.Flags().Set("interval", "0s")
+	if _, err := parseDeployWatchFlags(cmd); err == nil {
+		t.Fatalf("expected positive interval error")
+	}
+}
+
+// Sanity: assert releaseArchiveName follows the expected layout the watcher
+// computes URLs from. If goreleaser config diverges, this guards us.
+func TestReleaseArchiveNameLayout(t *testing.T) {
+	want := fmt.Sprintf("workbuddy_1.2.3_%s_%s.tar.gz", runtime.GOOS, runtime.GOARCH)
+	if got := releaseArchiveName("1.2.3"); got != want {
+		t.Fatalf("releaseArchiveName = %q, want %q", got, want)
+	}
+}

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -3218,3 +3218,38 @@ requirements:
     tests:
       - internal/statemachine/statemachine_test.go
     deps: []
+
+  - id: REQ-095
+    title: Pull-based release watcher (`workbuddy deploy watch` + rollback) — Phase 2 step 2 of #224
+    description: >
+      Add `workbuddy deploy watch`, a long-running poller that periodically
+      checks the configured GitHub repository for the newest release and, on a
+      newer tag, downloads the matching `linux-${ARCH}` archive, verifies the
+      SHA256 entry from `checksums.txt`, atomically replaces the deployed
+      `workbuddy` binary (default `/usr/local/bin/workbuddy`), backs up the
+      previous binary into `<state-dir>/previous-binary`, and `systemctl
+      restart`s the listed units. State (current installed tag, previous
+      binary) lives under `$XDG_STATE_HOME/workbuddy/updater` so a NAT-bound
+      deployment can pull updates without exposing inbound CICD. A companion
+      `workbuddy deploy rollback` swaps the previous binary back into place.
+      `--dry-run` performs a check without download/replace/restart;
+      checksum mismatches leave the existing binary untouched and surface as
+      logged errors that the loop retries on the next interval.
+    priority: P1
+    version: v0.5.0
+    status: tested
+    acceptance_criteria:
+      - "AC-095-1: `workbuddy deploy watch --repo owner/name` polls every --interval (default 5m) and compares the latest GitHub release tag against `<state-dir>/current-version`."
+      - "AC-095-2: When a newer tag is found, the command downloads the linux-${ARCH} archive plus checksums.txt, verifies SHA256, atomically replaces the target binary, and writes the previous binary to `<state-dir>/previous-binary`."
+      - "AC-095-3: After a successful upgrade the command runs `systemctl --<scope> restart` for each `--restart-units` entry; supervisor units are NOT restarted by default."
+      - "AC-095-4: SHA256 mismatches do not touch the deployed binary; the error is reported and the next interval retries."
+      - "AC-095-5: When the deployed version already matches latest the command logs a no-op and exits the iteration without download or restart."
+      - "AC-095-6: `--dry-run` performs the latest-release check but never downloads, never replaces, and never restarts."
+      - "AC-095-7: `workbuddy deploy rollback` swaps `<state-dir>/previous-binary` back into the target binary path and restarts the listed units."
+      - "AC-095-8: `workbuddy deploy watch --help` documents every flag (--repo, --interval, --restart-units, --state-dir, --binary, --systemctl-scope, --dry-run, --once)."
+    code:
+      - cmd/deploy_watch.go
+      - cmd/deploy.go
+    tests:
+      - cmd/deploy_watch_test.go
+    deps: [REQ-062]


### PR DESCRIPTION
Fixes #237. Phase 2 step 2 of #224.

## Summary

- `workbuddy deploy watch --repo OWNER/NAME` polls GitHub Releases on `--interval` (default 5m). When the latest tag is greater than the locally-tracked version it downloads `workbuddy_<ver>_linux_<arch>.tar.gz` + `checksums.txt`, verifies SHA256, atomically replaces the deployed binary (default `/usr/local/bin/workbuddy`), saves the prior binary to `<state-dir>/previous-binary`, writes `<state-dir>/current-version`, and `systemctl restart`s the units listed in `--restart-units`. SHA mismatch / network failure leaves the existing binary untouched and the loop retries on the next tick.
- `workbuddy deploy rollback` swaps `<state-dir>/previous-binary` back into the target binary and restarts the same units; the displaced binary becomes the new previous-binary so two rollbacks toggle versions.
- `--dry-run` performs the latest-release check but never downloads, replaces, or restarts.
- `--once` runs a single check (used by tests / cron-style invocations).
- State dir defaults to `$XDG_STATE_HOME/workbuddy/updater` (falls back to `~/.local/state/workbuddy/updater`).
- supervisor binary is intentionally **not** restarted — that path is deferred to a later milestone per #224.
- Adds `REQ-093` (`status: tested`) to `project-index.yaml`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1`
- [x] `go test ./cmd/ -run 'Watch|Rollback|Semver|Checksum|ReleaseArchive'` covers: noop when up-to-date, full upgrade path with restart, SHA256 mismatch leaves binary untouched, dry-run, rollback swap, missing-backup error, flag validation, archive name layout.
- [x] `workbuddy deploy watch --help` documents every flag.
- [x] `python3 ~/.autoharness/scripts/validate_index.py project-index.yaml` passes.