### PR TITLE
deploy: workbuddy-updater.service + CICD docs (#238)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,3 +14,4 @@
 ## Compatibility
 
 - [ ] schema/API 兼容（只加列、加端点，不删/不改字段）
+- [ ] 涉及 systemd unit / deploy 命令的改动已更新对应文档

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -46,17 +46,22 @@ var (
 )
 
 type deployInstallOpts struct {
-	name             string
-	scope            string
-	binaryPath       string
-	workingDirectory string
-	systemd          bool
-	description      string
-	env              []string
-	envFiles         []string
-	enable           bool
-	start            bool
-	commandArgs      []string
+	name                string
+	scope               string
+	binaryPath          string
+	workingDirectory    string
+	systemd             bool
+	description         string
+	env                 []string
+	envFiles            []string
+	enable              bool
+	start               bool
+	commandArgs         []string
+	enableUpdater       bool
+	updaterRepo         string
+	updaterInterval     string
+	updaterRestartUnits []string
+	updaterName         string
 }
 
 type deployLookupOpts struct {
@@ -209,6 +214,11 @@ func init() {
 	deployInstallCmd.Flags().StringArray("env-file", nil, "Environment file for the service (repeatable)")
 	deployInstallCmd.Flags().Bool("enable", true, "Enable the systemd unit after writing it")
 	deployInstallCmd.Flags().Bool("start", true, "Start the systemd unit after writing it")
+	deployInstallCmd.Flags().Bool("enable-updater", false, "Also install and enable the workbuddy-updater.service systemd user unit that runs `deploy watch` to pull releases from GitHub")
+	deployInstallCmd.Flags().String("updater-repo", defaultUpgradeRepo, "GitHub repository in OWNER/NAME form used by the updater unit (only consulted with --enable-updater)")
+	deployInstallCmd.Flags().String("updater-interval", "5m", "Poll interval used by the updater unit (only consulted with --enable-updater)")
+	deployInstallCmd.Flags().StringSlice("updater-restart-units", []string{"workbuddy-coordinator.service", "workbuddy-worker.service"}, "systemd unit name(s) the updater should restart after a successful upgrade (only consulted with --enable-updater)")
+	deployInstallCmd.Flags().String("updater-name", "workbuddy-updater", "Service name used for the updater unit (only consulted with --enable-updater)")
 
 	deployListCmd.Flags().String("scope", defaultDeployListScope, "Deployment scope: all, user, or system")
 	addOutputFormatFlag(deployListCmd)
@@ -352,19 +362,29 @@ func parseDeployInstallFlags(cmd *cobra.Command, args []string) (*deployInstallO
 	envFiles, _ := cmd.Flags().GetStringArray("env-file")
 	enable, _ := cmd.Flags().GetBool("enable")
 	start, _ := cmd.Flags().GetBool("start")
+	enableUpdater, _ := cmd.Flags().GetBool("enable-updater")
+	updaterRepo, _ := cmd.Flags().GetString("updater-repo")
+	updaterInterval, _ := cmd.Flags().GetString("updater-interval")
+	updaterRestartUnits, _ := cmd.Flags().GetStringSlice("updater-restart-units")
+	updaterName, _ := cmd.Flags().GetString("updater-name")
 
 	return &deployInstallOpts{
-		name:             strings.TrimSpace(name),
-		scope:            strings.TrimSpace(scope),
-		binaryPath:       strings.TrimSpace(binaryPath),
-		workingDirectory: strings.TrimSpace(workingDir),
-		systemd:          systemd,
-		description:      strings.TrimSpace(description),
-		env:              envVars,
-		envFiles:         trimStringSlice(envFiles),
-		enable:           enable,
-		start:            start,
-		commandArgs:      append([]string(nil), args...),
+		name:                strings.TrimSpace(name),
+		scope:               strings.TrimSpace(scope),
+		binaryPath:          strings.TrimSpace(binaryPath),
+		workingDirectory:    strings.TrimSpace(workingDir),
+		systemd:             systemd,
+		description:         strings.TrimSpace(description),
+		env:                 envVars,
+		envFiles:            trimStringSlice(envFiles),
+		enable:              enable,
+		start:               start,
+		commandArgs:         append([]string(nil), args...),
+		enableUpdater:       enableUpdater,
+		updaterRepo:         strings.TrimSpace(updaterRepo),
+		updaterInterval:     strings.TrimSpace(updaterInterval),
+		updaterRestartUnits: trimStringSlice(updaterRestartUnits),
+		updaterName:         strings.TrimSpace(updaterName),
 	}, nil
 }
 
@@ -476,6 +496,11 @@ func runDeployInstallWithOpts(ctx context.Context, opts *deployInstallOpts, stdo
 	}
 
 	if manifest.Systemd == nil {
+		if opts.enableUpdater {
+			if err := installUpdaterUnit(ctx, opts, scope, scopePaths, binaryPath, workingDir, stdout); err != nil {
+				return err
+			}
+		}
 		return nil
 	}
 
@@ -501,6 +526,113 @@ func runDeployInstallWithOpts(ctx context.Context, opts *deployInstallOpts, stdo
 		if _, err := fmt.Fprintf(stdout, "started %s\n", serviceName); err != nil {
 			return fmt.Errorf("deploy install: write output: %w", err)
 		}
+	}
+	if opts.enableUpdater {
+		if err := installUpdaterUnit(ctx, opts, scope, scopePaths, binaryPath, workingDir, stdout); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// installUpdaterUnit writes the workbuddy-updater.service systemd unit, runs
+// daemon-reload, and enables + starts it. The updater runs `workbuddy deploy
+// watch` so it pulls new releases on a schedule (Phase 2.3 of #224). It
+// reuses the same scope/EnvironmentFile as the main install so the user can
+// keep a single env file containing the GitHub token used for release reads.
+func installUpdaterUnit(
+	ctx context.Context,
+	opts *deployInstallOpts,
+	scope string,
+	scopePaths *deployScopePaths,
+	binaryPath, workingDir string,
+	stdout io.Writer,
+) error {
+	if runtime.GOOS != "linux" {
+		return fmt.Errorf("deploy install: --enable-updater requires Linux")
+	}
+	updaterName := opts.updaterName
+	if updaterName == "" {
+		updaterName = "workbuddy-updater"
+	}
+	if !deployNamePattern.MatchString(updaterName) {
+		return fmt.Errorf("deploy install: invalid --updater-name %q", updaterName)
+	}
+	repo := opts.updaterRepo
+	if repo == "" {
+		repo = defaultUpgradeRepo
+	}
+	if !strings.Contains(repo, "/") {
+		return fmt.Errorf("deploy install: --updater-repo must be owner/name, got %q", repo)
+	}
+	interval := opts.updaterInterval
+	if interval == "" {
+		interval = "5m"
+	}
+	if _, err := time.ParseDuration(interval); err != nil {
+		return fmt.Errorf("deploy install: invalid --updater-interval %q: %w", interval, err)
+	}
+	restartUnits := trimStringSlice(opts.updaterRestartUnits)
+
+	watchArgs := []string{
+		"deploy", "watch",
+		"--repo", repo,
+		"--interval", interval,
+		"--systemctl-scope", scope,
+	}
+	if len(restartUnits) > 0 {
+		watchArgs = append(watchArgs, "--restart-units", strings.Join(restartUnits, ","))
+	}
+	execArgs := append([]string{binaryPath}, watchArgs...)
+	for _, arg := range execArgs {
+		if strings.ContainsRune(arg, '\n') {
+			return fmt.Errorf("deploy install: updater command arguments may not contain newlines")
+		}
+	}
+
+	unitPath := filepath.Join(scopePaths.unitDir, updaterName+".service")
+	description := fmt.Sprintf("Workbuddy %s (deploy watch)", updaterName)
+
+	var b strings.Builder
+	b.WriteString("[Unit]\n")
+	fmt.Fprintf(&b, "Description=%s\n", escapeUnitValue(description))
+	b.WriteString("After=network-online.target\n")
+	b.WriteString("Wants=network-online.target\n\n")
+
+	b.WriteString("[Service]\n")
+	b.WriteString("Type=simple\n")
+	fmt.Fprintf(&b, "WorkingDirectory=%s\n", systemdSingleValue(workingDir))
+	fmt.Fprintf(&b, "ExecStart=%s\n", joinSystemdCommand(execArgs))
+	b.WriteString("Restart=always\n")
+	b.WriteString("RestartSec=30s\n")
+	for _, envFile := range trimStringSlice(opts.envFiles) {
+		fmt.Fprintf(&b, "EnvironmentFile=%s\n", systemdSingleValue(envFile))
+	}
+
+	b.WriteString("\n[Install]\n")
+	fmt.Fprintf(&b, "WantedBy=%s\n", scopePaths.wantedBy)
+
+	if err := writeTextFileAtomic(unitPath, b.String(), 0o644); err != nil {
+		return fmt.Errorf("deploy install: write updater unit: %w", err)
+	}
+	if _, err := fmt.Fprintf(stdout, "wrote updater unit %s\n", unitPath); err != nil {
+		return fmt.Errorf("deploy install: write output: %w", err)
+	}
+	if err := deployRunSystemctl(ctx, scope, "daemon-reload"); err != nil {
+		return fmt.Errorf("deploy install: %w", err)
+	}
+	updaterServiceName := updaterName + ".service"
+	if err := deployRunSystemctl(ctx, scope, "enable", updaterServiceName); err != nil {
+		return fmt.Errorf("deploy install: %w", err)
+	}
+	if _, err := fmt.Fprintf(stdout, "enabled %s\n", updaterServiceName); err != nil {
+		return fmt.Errorf("deploy install: write output: %w", err)
+	}
+	if err := deployRunSystemctl(ctx, scope, "start", updaterServiceName); err != nil {
+		return fmt.Errorf("deploy install: %w", err)
+	}
+	if _, err := fmt.Fprintf(stdout, "started %s\n", updaterServiceName); err != nil {
+		return fmt.Errorf("deploy install: write output: %w", err)
 	}
 	return nil
 }

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -1616,4 +1617,140 @@ func buildReleaseArchive(t *testing.T, binaryContent string) []byte {
 		t.Fatalf("close gzip writer: %v", err)
 	}
 	return archive.Bytes()
+}
+
+func TestRunDeployInstallEnableUpdaterWritesUnitAndEnables(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("systemd deployment is only supported on Linux")
+	}
+
+	tempDir := t.TempDir()
+	homeDir := filepath.Join(tempDir, "home")
+	configDir := filepath.Join(tempDir, "xdg")
+	repoDir := filepath.Join(tempDir, "repo")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	t.Setenv("HOME", homeDir)
+	t.Setenv("XDG_CONFIG_HOME", configDir)
+	t.Chdir(repoDir)
+
+	sourceBinary := filepath.Join(tempDir, "current-workbuddy")
+	if err := os.WriteFile(sourceBinary, []byte("binary-v1"), 0o755); err != nil {
+		t.Fatalf("write source binary: %v", err)
+	}
+
+	restore := overrideDeployGlobals(t, sourceBinary)
+	defer restore()
+
+	var systemctlCalls []string
+	deployRunSystemctl = func(_ context.Context, scope string, args ...string) error {
+		systemctlCalls = append(systemctlCalls, scope+":"+strings.Join(args, " "))
+		return nil
+	}
+
+	var stdout bytes.Buffer
+	err := runDeployInstallWithOpts(context.Background(), &deployInstallOpts{
+		name:                "workbuddy",
+		scope:               "user",
+		systemd:             false,
+		envFiles:            []string{"/home/ddq/.config/workbuddy/worker.env"},
+		enableUpdater:       true,
+		updaterRepo:         "Lincyaw/workbuddy",
+		updaterInterval:     "5m",
+		updaterRestartUnits: []string{"workbuddy-coordinator.service", "workbuddy-worker.service"},
+		updaterName:         "workbuddy-updater",
+	}, &stdout)
+	if err != nil {
+		t.Fatalf("runDeployInstallWithOpts: %v", err)
+	}
+
+	updaterPath := filepath.Join(configDir, "systemd", "user", "workbuddy-updater.service")
+	unitBytes, err := os.ReadFile(updaterPath)
+	if err != nil {
+		t.Fatalf("read updater unit: %v", err)
+	}
+	unit := string(unitBytes)
+	for _, want := range []string{
+		"Type=simple\n",
+		"Restart=always\n",
+		"RestartSec=30s\n",
+		"WantedBy=default.target\n",
+		"EnvironmentFile=/home/ddq/.config/workbuddy/worker.env\n",
+		`"deploy" "watch" "--repo" "Lincyaw/workbuddy" "--interval" "5m" "--systemctl-scope" "user" "--restart-units" "workbuddy-coordinator.service,workbuddy-worker.service"`,
+	} {
+		if !strings.Contains(unit, want) {
+			t.Fatalf("updater unit missing %q:\n%s", want, unit)
+		}
+	}
+
+	gotCalls := strings.Join(systemctlCalls, " | ")
+	wantCalls := "user:daemon-reload | user:enable workbuddy-updater.service | user:start workbuddy-updater.service"
+	if gotCalls != wantCalls {
+		t.Fatalf("systemctl calls = %q, want %q", gotCalls, wantCalls)
+	}
+	if !strings.Contains(stdout.String(), "wrote updater unit ") {
+		t.Fatalf("stdout missing updater unit message: %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "enabled workbuddy-updater.service") {
+		t.Fatalf("stdout missing enabled message: %q", stdout.String())
+	}
+}
+
+func TestParseDeployInstallFlagsEnableUpdaterDefaults(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().AddFlagSet(deployInstallCmd.Flags())
+	if err := cmd.ParseFlags([]string{"--enable-updater"}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	opts, err := parseDeployInstallFlags(cmd, nil)
+	if err != nil {
+		t.Fatalf("parseDeployInstallFlags: %v", err)
+	}
+	if !opts.enableUpdater {
+		t.Fatal("expected enableUpdater true")
+	}
+	if got, want := opts.updaterRepo, "Lincyaw/workbuddy"; got != want {
+		t.Fatalf("updaterRepo = %q, want %q", got, want)
+	}
+	if got, want := opts.updaterInterval, "5m"; got != want {
+		t.Fatalf("updaterInterval = %q, want %q", got, want)
+	}
+	wantUnits := []string{"workbuddy-coordinator.service", "workbuddy-worker.service"}
+	if !reflect.DeepEqual(opts.updaterRestartUnits, wantUnits) {
+		t.Fatalf("updaterRestartUnits = %v, want %v", opts.updaterRestartUnits, wantUnits)
+	}
+	if got, want := opts.updaterName, "workbuddy-updater"; got != want {
+		t.Fatalf("updaterName = %q, want %q", got, want)
+	}
+}
+
+func TestRunDeployInstallEnableUpdaterRejectsBadInterval(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("systemd deployment is only supported on Linux")
+	}
+	tempDir := t.TempDir()
+	t.Setenv("HOME", filepath.Join(tempDir, "home"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tempDir, "xdg"))
+	t.Chdir(tempDir)
+
+	sourceBinary := filepath.Join(tempDir, "current-workbuddy")
+	if err := os.WriteFile(sourceBinary, []byte("x"), 0o755); err != nil {
+		t.Fatalf("write source binary: %v", err)
+	}
+	restore := overrideDeployGlobals(t, sourceBinary)
+	defer restore()
+	deployRunSystemctl = func(_ context.Context, _ string, _ ...string) error { return nil }
+
+	err := runDeployInstallWithOpts(context.Background(), &deployInstallOpts{
+		name:            "workbuddy",
+		scope:           "user",
+		enableUpdater:   true,
+		updaterRepo:     "Lincyaw/workbuddy",
+		updaterInterval: "bogus",
+		updaterName:     "workbuddy-updater",
+	}, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "invalid --updater-interval") {
+		t.Fatalf("expected invalid --updater-interval error, got %v", err)
+	}
 }

--- a/docs/deploy-cicd.md
+++ b/docs/deploy-cicd.md
@@ -1,0 +1,189 @@
+# Pull-based CICD: `deploy watch` + `workbuddy-updater.service`
+
+This page covers the operator side of the Phase 2 CICD loop introduced in
+issues #224 / #237 / #238: how a NAT-bound deployment pulls new releases
+from GitHub on a schedule, how to pause it, and how to roll back.
+
+The pipeline has three pieces:
+
+1. `release.yml` — produces the `vX.Y.Z` tarballs + `checksums.txt` on
+   GitHub Releases (Phase 2.1, REQ-093).
+2. `workbuddy deploy watch` — long-running poller that downloads the
+   newest release, verifies the SHA256 against the published
+   checksums file, atomically swaps the binary in place, and restarts
+   listed systemd units (Phase 2.2, REQ-095).
+3. `workbuddy-updater.service` — the systemd user unit that wraps
+   `deploy watch` so the loop survives reboots and crashes (this page,
+   Phase 2.3, REQ-097).
+
+## One-shot bootstrap
+
+After a fresh box has the binary installed once (manually or via
+`workbuddy deploy install`), you can wire up the updater with a single
+command:
+
+```
+workbuddy deploy install \
+  --enable-updater \
+  --updater-repo Lincyaw/workbuddy \
+  --env-file /home/ddq/.config/workbuddy/worker.env
+```
+
+That call does the usual install (binary + manifest, optionally a
+systemd unit) and additionally writes
+`~/.config/systemd/user/workbuddy-updater.service`, runs `systemctl
+--user daemon-reload`, and `enable --now`s the updater.
+
+`--enable-updater` is **off by default**. The first deploy never silently
+enables the auto-update loop. You opt in explicitly per host.
+
+The updater unit itself looks like:
+
+```ini
+[Unit]
+Description=Workbuddy workbuddy-updater (deploy watch)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/ddq
+ExecStart="/usr/local/bin/workbuddy" "deploy" "watch" "--repo" "Lincyaw/workbuddy" "--interval" "5m" "--systemctl-scope" "user" "--restart-units" "workbuddy-coordinator.service,workbuddy-worker.service"
+Restart=always
+RestartSec=30s
+EnvironmentFile=/home/ddq/.config/workbuddy/worker.env
+
+[Install]
+WantedBy=default.target
+```
+
+Defaults (override with the matching install flag):
+
+| Flag | Default |
+|------|---------|
+| `--updater-repo` | `Lincyaw/workbuddy` |
+| `--updater-interval` | `5m` |
+| `--updater-restart-units` | `workbuddy-coordinator.service,workbuddy-worker.service` |
+| `--updater-name` | `workbuddy-updater` |
+
+The updater inherits the install's `--scope` (so a `--scope user`
+install writes the updater under `~/.config/systemd/user/`; a
+`--scope system` install writes it under `/etc/systemd/system/`). The
+updater reuses every `--env-file` you passed to install — that is how
+you supply a GitHub PAT.
+
+## GitHub token: scope, location, why
+
+`deploy watch` reads the GitHub Releases API and downloads release
+assets. For a **public** repo no token is needed. For a **private** repo,
+or if you want to avoid the 60 req/h unauthenticated rate limit, set:
+
+```
+GH_TOKEN=ghp_xxx       # preferred
+# or GITHUB_TOKEN, GITHUB_OAUTH — any one is picked up
+```
+
+Required scope: **`Releases: read`** (GitHub fine-grained PAT) or the
+classic `repo` scope's read-only subset. Nothing else. The updater never
+writes to GitHub.
+
+Where to put it: the file you point `--env-file` at. Example:
+
+```
+# /home/ddq/.config/workbuddy/worker.env
+GH_TOKEN=ghp_xxx
+```
+
+That file is also typically the home of the worker's runtime
+credentials (e.g. `CRS_OAI_KEY` for codex), so reusing it keeps the
+operator surface flat. `chmod 600`.
+
+## Pause the updater (don't auto-upgrade right now)
+
+```
+systemctl --user stop workbuddy-updater
+```
+
+This stops the running watcher but leaves the unit enabled. The next
+`daemon-reload` or boot brings it back. To keep it stopped across
+reboots:
+
+```
+systemctl --user disable --now workbuddy-updater
+```
+
+## Manual upgrade (skip the watcher)
+
+Two equivalent paths:
+
+1. Use the existing one-shot upgrade command (resolves the latest
+   release synchronously, downloads, replaces the binary, restarts the
+   service that the install manifest knows about):
+
+   ```
+   workbuddy deploy upgrade --name workbuddy --scope user
+   workbuddy deploy upgrade --name workbuddy-coordinator --scope system --version v0.5.1
+   ```
+
+2. Trigger one cycle of the watcher without the loop:
+
+   ```
+   workbuddy deploy watch --repo Lincyaw/workbuddy --once
+   ```
+
+   Add `--dry-run` to see what *would* happen without downloading or
+   restarting anything.
+
+## Rollback
+
+`deploy watch` always backs the previous binary up to
+`<state-dir>/previous-binary` (default
+`~/.local/state/workbuddy/updater/previous-binary`) before swapping
+the new one in. To revert:
+
+```
+systemctl --user stop workbuddy-updater          # don't fight the watcher
+workbuddy deploy rollback \
+  --restart-units workbuddy-coordinator.service \
+  --restart-units workbuddy-worker.service
+```
+
+Rollback toggles between the two binaries: running it twice puts you
+back on the new release. After a successful rollback you usually want
+the updater to stay stopped until the upstream issue is fixed:
+
+```
+systemctl --user disable --now workbuddy-updater
+```
+
+When the fix lands, re-enable:
+
+```
+systemctl --user enable --now workbuddy-updater
+```
+
+## What the watcher does NOT do
+
+- It does not restart itself. If a release breaks `deploy watch`'s own
+  flags, you have to roll back manually.
+- It does not page anyone. The unit relies on `Restart=always` to
+  recover from transient failures (network blips, GitHub 5xx). Real
+  alerting is out of scope for v0.5; see #224 for the v0.6 plan.
+- It does not coordinate across hosts. Each box runs its own updater
+  independently. A botched release upgrades every host on its next tick;
+  stage rollouts by version-pinning `--updater-repo` to a fork or by
+  toggling the unit on subsets of hosts.
+
+## Files & paths summary
+
+| Path | Owner | Purpose |
+|------|-------|---------|
+| `~/.config/systemd/user/workbuddy-updater.service` | this issue | unit that runs `deploy watch` |
+| `~/.local/state/workbuddy/updater/current-version` | `deploy watch` | last successfully installed version (`vX.Y.Z`) |
+| `~/.local/state/workbuddy/updater/previous-binary` | `deploy watch` | backup used by `deploy rollback` |
+| `/usr/local/bin/workbuddy` (default) | `deploy watch`, `deploy install` | the binary itself |
+| `~/.config/workbuddy/worker.env` (typical) | operator | `GH_TOKEN`, runtime creds |
+
+For the watcher's own flags (`--repo`, `--interval`, `--restart-units`,
+`--state-dir`, `--binary`, `--systemctl-scope`, `--dry-run`, `--once`)
+see `workbuddy deploy watch --help`.

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -3292,3 +3292,41 @@ requirements:
       - internal/store/store_supervisor_agent_id_test.go
     deps:
       - REQ-092
+
+  - id: REQ-097
+    title: workbuddy-updater.service systemd unit + deploy CICD docs (#238)
+    description: >
+      Phase 2 step 3 of #224. Wraps the Phase 2.2 `workbuddy deploy
+      watch` command into a systemd user service so a NAT-bound
+      deployment automatically pulls new releases without operator
+      intervention. `workbuddy deploy install` gains an opt-in
+      `--enable-updater` flag (off by default to avoid surprising
+      first-time installs); when set, install writes a separate
+      `workbuddy-updater.service` unit alongside the main install,
+      runs `daemon-reload`, then `enable --now`s the updater. The
+      generated unit uses `Type=simple`, `Restart=always`,
+      `RestartSec=30s`, reuses the install's `--env-file` (so a
+      single env file can carry the GitHub PAT used for release
+      reads), and `WantedBy=default.target` (or the system scope's
+      multi-user.target). Operator docs land in
+      `docs/deploy-cicd.md` covering token scope/placement, pause,
+      manual upgrade, and rollback. The PR template gains a
+      compatibility checkbox covering systemd unit / deploy command
+      changes.
+    priority: P1
+    version: v0.5.0
+    status: tested
+    acceptance_criteria:
+      - "AC-097-1: `workbuddy deploy install --enable-updater` writes <unit-dir>/workbuddy-updater.service with Type=simple, Restart=always, RestartSec=30s, WantedBy matching the install scope, and an ExecStart that invokes `<binary> deploy watch --repo <updater-repo> --interval <updater-interval> --systemctl-scope <scope> --restart-units <units,...>`."
+      - "AC-097-2: `--enable-updater` is off by default; a plain `workbuddy deploy install` does not write or enable the updater unit."
+      - "AC-097-3: When the updater is enabled, install runs systemctl daemon-reload then enable + start for `workbuddy-updater.service` in the install scope; --updater-interval is parsed as a Go duration and rejected if invalid."
+      - "AC-097-4: The updater unit reuses every `--env-file` passed to install, so the GitHub PAT can live in the same env file as the worker runtime credentials."
+      - "AC-097-5: docs/deploy-cicd.md documents token scope (Releases: read), placement (the env-file pointed at by --env-file), pausing (`systemctl --user stop workbuddy-updater`), manual upgrade (`workbuddy deploy upgrade` or `workbuddy deploy watch --once`), and rollback (`workbuddy deploy rollback` plus disable to keep it stopped)."
+      - "AC-097-6: `.github/pull_request_template.md` contains the checkbox `- [ ] 涉及 systemd unit / deploy 命令的改动已更新对应文档`."
+    code:
+      - cmd/deploy.go
+      - docs/deploy-cicd.md
+      - .github/pull_request_template.md
+    tests:
+      - cmd/deploy_test.go
+    deps: [REQ-095]


### PR DESCRIPTION
## Summary

Phase 2 step 3 of #224. Wraps `deploy watch` (Phase 2.2) into a systemd user unit so NAT-bound hosts pull releases automatically.

- `deploy install --enable-updater` writes `workbuddy-updater.service` (Type=simple, Restart=always, RestartSec=30s), runs daemon-reload, and enable+starts it. Off by default — first installs never silently enable auto-update.
- New flags: `--enable-updater`, `--updater-repo`, `--updater-interval`, `--updater-restart-units`, `--updater-name`. Updater inherits scope and `--env-file` from the install (one env file holds the GitHub PAT).
- `docs/deploy-cicd.md`: token scope/placement, pause (`systemctl --user stop workbuddy-updater`), manual upgrade, rollback.
- PR template: new compatibility checkbox for systemd unit / deploy command changes.
- `project-index.yaml`: REQ-097 added with status `tested`, deps [REQ-095].

Fixes #238

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go vet ./...`
- [x] `go run . validate-docs --strict`
- [x] `python3 scripts/validate_index.py project-index.yaml`
- [x] new tests: `TestRunDeployInstallEnableUpdaterWritesUnitAndEnables`, `TestParseDeployInstallFlagsEnableUpdaterDefaults`, `TestRunDeployInstallEnableUpdaterRejectsBadInterval`

## Compatibility

- [x] schema/API 兼容（只加列、加端点，不删/不改字段）
- [x] 涉及 systemd unit / deploy 命令的改动已更新对应文档

🤖 Generated with [Claude Code](https://claude.com/claude-code)