### PR TITLE
worker: route claude runtime through supervisor IPC (#244)

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -59,7 +59,17 @@ func runRuntimeCmd(cmd *cobra.Command, _ []string) error {
 	if err := requireWritable(cmd, "run"); err != nil {
 		return err
 	}
-	return runRuntimeWithOpts(cmd.Context(), opts, launcher.NewLauncher(), cmdStdout(cmd), cmdStderr(cmd))
+	stateDir, err := os.MkdirTemp("", "workbuddy-run-supervisor-")
+	if err != nil {
+		return fmt.Errorf("run: state dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(stateDir) }()
+	supClient, supShutdown, err := launcher.NewInProcessSupervisor(stateDir, 5*time.Second)
+	if err != nil {
+		return fmt.Errorf("run: %w", err)
+	}
+	defer supShutdown()
+	return runRuntimeWithOpts(cmd.Context(), opts, launcher.NewLauncher(supClient, nil), cmdStdout(cmd), cmdStderr(cmd))
 }
 
 func parseRunFlags(cmd *cobra.Command) (*runOpts, error) {

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -18,7 +18,7 @@ func TestRunRuntimeWithOpts_UsesLauncher(t *testing.T) {
 	mockRT := &mockRuntime{name: config.RuntimeClaudeShot, resultFn: func(ctx context.Context, agent *config.AgentConfig, task *launcher.TaskContext) (*launcher.Result, error) {
 		return &launcher.Result{ExitCode: 0, LastMessage: "review complete", SessionPath: filepath.Join(task.WorkDir, "artifact.jsonl")}, nil
 	}}
-	lnch := launcher.NewLauncher()
+	lnch := launcher.NewLauncher(nil, nil)
 	lnch.Register(mockRT, config.RuntimeClaudeCode, config.RuntimeClaudeShot)
 
 	var out bytes.Buffer
@@ -49,7 +49,7 @@ func TestRunRuntimeWithOpts_FailsOnNonZeroExit(t *testing.T) {
 	mockRT := &mockRuntime{name: config.RuntimeCodex, resultFn: func(ctx context.Context, agent *config.AgentConfig, task *launcher.TaskContext) (*launcher.Result, error) {
 		return &launcher.Result{ExitCode: 23, LastMessage: "review failed", SessionPath: filepath.Join(task.WorkDir, "artifact.jsonl")}, nil
 	}}
-	lnch := launcher.NewLauncher()
+	lnch := launcher.NewLauncher(nil, nil)
 	lnch.Register(mockRT, config.RuntimeCodex, config.RuntimeCodex)
 
 	var out bytes.Buffer
@@ -117,7 +117,7 @@ func TestRunRuntime_CodexPromptE2E(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lnch := launcher.NewLauncher()
+	lnch := launcher.NewLauncher(nil, nil)
 	var out bytes.Buffer
 	var errOut bytes.Buffer
 	err := runRuntimeWithOpts(context.Background(), &runOpts{

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -20,6 +20,8 @@ import (
 	"github.com/Lincyaw/workbuddy/internal/reporter"
 	runtimepkg "github.com/Lincyaw/workbuddy/internal/runtime"
 	"github.com/Lincyaw/workbuddy/internal/store"
+	"github.com/Lincyaw/workbuddy/internal/supervisor"
+	supclient "github.com/Lincyaw/workbuddy/internal/supervisor/client"
 	workerexec "github.com/Lincyaw/workbuddy/internal/worker"
 	workersession "github.com/Lincyaw/workbuddy/internal/worker/session"
 	"github.com/Lincyaw/workbuddy/internal/workerclient"
@@ -62,6 +64,7 @@ type workerOpts struct {
 	heartbeatInterval time.Duration
 	shutdownTimeout   time.Duration
 	concurrency       int
+	supervisorSocket  string
 }
 
 type workerIssueReader interface {
@@ -89,6 +92,7 @@ func init() {
 	workerCmd.Flags().String("mgmt-public-url", "", "Coordinator-reachable base URL for the worker management/session viewer surface")
 	workerCmd.Flags().String("mgmt-auth-token", "", "Optional bearer token for worker management and session-viewer endpoints")
 	workerCmd.Flags().Int("concurrency", 1, "Maximum concurrent tasks per worker")
+	workerCmd.Flags().String("supervisor-socket", "", "Unix socket of the local agent supervisor (default: $XDG_RUNTIME_DIR/workbuddy-supervisor.sock)")
 	_ = workerCmd.MarkFlagRequired("coordinator")
 
 	workerUnregisterCmd.Flags().String("coordinator", "", "Coordinator base URL")
@@ -159,6 +163,7 @@ func parseWorkerFlags(cmd *cobra.Command) (*workerOpts, error) {
 	mgmtPublicURL, _ := cmd.Flags().GetString("mgmt-public-url")
 	mgmtAuthToken, _ := cmd.Flags().GetString("mgmt-auth-token")
 	concurrency, _ := cmd.Flags().GetInt("concurrency")
+	supervisorSocket, _ := cmd.Flags().GetString("supervisor-socket")
 	if concurrency < 1 {
 		concurrency = 1
 	}
@@ -199,6 +204,7 @@ func parseWorkerFlags(cmd *cobra.Command) (*workerOpts, error) {
 		heartbeatInterval: defaultWorkerHeartbeat,
 		shutdownTimeout:   defaultWorkerShutdownDeadline,
 		concurrency:       concurrency,
+		supervisorSocket:  strings.TrimSpace(supervisorSocket),
 	}, nil
 }
 
@@ -298,18 +304,48 @@ func runWorkerWithOpts(opts *workerOpts, lnch *runtimepkg.Registry, reader worke
 		workerID = hostname
 	}
 
-	if lnch == nil {
-		lnch = launcher.NewLauncher()
-	}
-	if reader == nil {
-		reader = &GHCLIReader{}
-	}
-
 	localStore, err := store.NewStore(opts.dbPath)
 	if err != nil {
 		return fmt.Errorf("worker: init local store: %w", err)
 	}
 	defer func() { _ = localStore.Close() }()
+
+	hook := func(taskID, agentID string) {
+		if err := localStore.UpdateTaskSupervisorAgentID(taskID, agentID); err != nil {
+			log.Printf("[worker] persist supervisor_agent_id for task %s: %v", taskID, err)
+		}
+	}
+	var supShutdown func()
+	if lnch == nil {
+		socket := opts.supervisorSocket
+		if socket == "" {
+			socket = supervisor.DefaultSocketPath()
+		}
+		// External supervisor when the socket exists (operator-managed, the
+		// canonical deployment); fall back to an in-process supervisor for
+		// `workbuddy serve` and other one-process invocations.
+		if _, statErr := os.Stat(socket); statErr == nil {
+			lnch = launcher.NewLauncher(supclient.NewUnix(socket), hook)
+		} else {
+			stateDir := filepath.Join(workDir, ".workbuddy", "supervisor")
+			if mkErr := os.MkdirAll(stateDir, 0o755); mkErr != nil {
+				return fmt.Errorf("worker: state dir for in-process supervisor: %w", mkErr)
+			}
+			supClient, shutdown, supErr := launcher.NewInProcessSupervisor(stateDir, supervisor.DefaultCancelGrace)
+			if supErr != nil {
+				return fmt.Errorf("worker: %w", supErr)
+			}
+			supShutdown = shutdown
+			lnch = launcher.NewLauncher(supClient, hook)
+			log.Printf("[worker] no supervisor socket at %s; running in-process supervisor (state %s)", socket, stateDir)
+		}
+	}
+	if supShutdown != nil {
+		defer supShutdown()
+	}
+	if reader == nil {
+		reader = &GHCLIReader{}
+	}
 
 	// Wire the session manager so the runtime registry creates a ManagedSession
 	// per task and populates taskCtx.SessionHandle(). Without this, the bridge

--- a/cmd/worker_test.go
+++ b/cmd/worker_test.go
@@ -254,7 +254,7 @@ func TestWorkerRejectsInvalidToken(t *testing.T) {
 		pollTimeout:       100 * time.Millisecond,
 		heartbeatInterval: 50 * time.Millisecond,
 		shutdownTimeout:   time.Second,
-	}, launcher.NewLauncher(), &mockGHReader{})
+	}, launcher.NewLauncher(nil, nil), &mockGHReader{})
 	if err == nil {
 		t.Fatal("expected invalid token error")
 	}
@@ -535,7 +535,7 @@ func TestWorkerPairsWithCoordinatorAndCompletesTask(t *testing.T) {
 			Meta:        map[string]string{},
 		}, nil
 	}}
-	lnch := launcher.NewLauncher()
+	lnch := launcher.NewLauncher(nil, nil)
 	lnch.Register(mockRT, config.RuntimeClaudeCode)
 
 	ctxWorker, cancelWorker := context.WithCancel(context.Background())
@@ -663,7 +663,7 @@ func TestWorkerUsesTaskRepoConfigForMultiRepoBindings(t *testing.T) {
 		}
 		return &launcher.Result{ExitCode: 0, LastMessage: "done", Meta: map[string]string{}}, nil
 	}}
-	lnch := launcher.NewLauncher()
+	lnch := launcher.NewLauncher(nil, nil)
 	lnch.Register(mockRT, config.RuntimeClaudeCode)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -749,7 +749,7 @@ func TestWorkerShutdownRequeuesInFlightTask(t *testing.T) {
 		<-ctx.Done()
 		return nil, ctx.Err()
 	}}
-	lnch := launcher.NewLauncher()
+	lnch := launcher.NewLauncher(nil, nil)
 	lnch.Register(mockRT, config.RuntimeClaudeCode)
 
 	ctxWorker, cancelWorker := context.WithCancel(context.Background())
@@ -874,7 +874,7 @@ func TestWorkerUsesMappedRepoPathAndCleansAddrFile(t *testing.T) {
 		}
 		return &launcher.Result{ExitCode: 0, LastMessage: "done", Meta: map[string]string{}}, nil
 	}}
-	lnch := launcher.NewLauncher()
+	lnch := launcher.NewLauncher(nil, nil)
 	lnch.Register(mockRT, config.RuntimeClaudeCode)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -977,7 +977,7 @@ func TestWorkerRegistersMgmtPublicURL(t *testing.T) {
 			pollTimeout:       20 * time.Millisecond,
 			heartbeatInterval: 20 * time.Millisecond,
 			shutdownTimeout:   100 * time.Millisecond,
-		}, launcher.NewLauncher(), &mockGHReader{}, ctx)
+		}, launcher.NewLauncher(nil, nil), &mockGHReader{}, ctx)
 	}()
 
 	select {
@@ -1051,7 +1051,7 @@ func TestWorkerReleasesUnmappedTask(t *testing.T) {
 			pollTimeout:       20 * time.Millisecond,
 			heartbeatInterval: 20 * time.Millisecond,
 			shutdownTimeout:   100 * time.Millisecond,
-		}, launcher.NewLauncher(), &mockGHReader{}, ctx)
+		}, launcher.NewLauncher(nil, nil), &mockGHReader{}, ctx)
 	}()
 
 	select {
@@ -1133,7 +1133,7 @@ func TestWorkerDynamicRepoAddUpdatesCoordinatorAndDispatchesTask(t *testing.T) {
 		}
 		return &launcher.Result{ExitCode: 0, LastMessage: "done", Meta: map[string]string{}}, nil
 	}}
-	lnch := launcher.NewLauncher()
+	lnch := launcher.NewLauncher(nil, nil)
 	lnch.Register(mockRT, config.RuntimeClaudeCode)
 
 	ctxWorker, cancelWorker := context.WithCancel(context.Background())
@@ -1287,7 +1287,7 @@ func TestExecuteRemoteTaskStopsHeartbeatAfterKilledProcess(t *testing.T) {
 		<-firstHeartbeat
 		return nil, errors.New("signal: killed")
 	}}
-	lnch := launcher.NewLauncher()
+	lnch := launcher.NewLauncher(nil, nil)
 	lnch.Register(mockRT, config.RuntimeClaudeCode)
 
 	rep := reporter.NewReporter(&mockCommentWriter{})
@@ -1379,7 +1379,7 @@ func TestExecuteRemoteTaskRequeuesWorktreeSetupFailure(t *testing.T) {
 		task,
 		client,
 		cfg,
-		workerexec.NewExecutor(launcher.NewLauncher(), reader),
+		workerexec.NewExecutor(launcher.NewLauncher(nil, nil), reader),
 		recorder,
 		rep,
 		reader,
@@ -1485,7 +1485,7 @@ func TestWorkerRecoversAfterKilledTaskWhenResultSubmitFails(t *testing.T) {
 			return &launcher.Result{ExitCode: 0, Meta: map[string]string{}}, nil
 		}
 	}}
-	lnch := launcher.NewLauncher()
+	lnch := launcher.NewLauncher(nil, nil)
 	lnch.Register(mockRT, config.RuntimeClaudeCode)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/launcher/claude_stream_test.go
+++ b/internal/launcher/claude_stream_test.go
@@ -92,7 +92,7 @@ func TestProcessSessionRun_ClaudePromptEmitsStructuredEvents(t *testing.T) {
 	})
 	defer restore()
 
-	launcher := NewLauncher()
+	launcher := newTestLauncher(t)
 	task := newTestTask(t)
 	agent := &config.AgentConfig{
 		Name:    "claude-agent",

--- a/internal/launcher/infra_failure_test.go
+++ b/internal/launcher/infra_failure_test.go
@@ -17,7 +17,7 @@ import (
 // signature, the process runtime must mark Meta[infra_failure] so the
 // reporter renders "Infra Error" instead of "Failure".
 func TestProcessRuntime_RuntimePanicSignatureMarksInfraFailure(t *testing.T) {
-	launcher := NewLauncher()
+	launcher := newTestLauncher(t)
 	task := newTestTask(t)
 
 	// The command emits a Rust-style panic to stderr and exits 101 with
@@ -47,7 +47,7 @@ func TestProcessRuntime_RuntimePanicSignatureMarksInfraFailure(t *testing.T) {
 // downstream. Without this guard, we would over-report infra errors and
 // lose the original FAIL verdict semantics. See AC-5.
 func TestProcessRuntime_GenuineExitNoInfraFailure(t *testing.T) {
-	launcher := NewLauncher()
+	launcher := newTestLauncher(t)
 	task := newTestTask(t)
 
 	agent := &config.AgentConfig{

--- a/internal/launcher/launcher.go
+++ b/internal/launcher/launcher.go
@@ -7,13 +7,22 @@ import (
 	"github.com/Lincyaw/workbuddy/internal/agent/codex"
 	"github.com/Lincyaw/workbuddy/internal/config"
 	runtimepkg "github.com/Lincyaw/workbuddy/internal/runtime"
+	supclient "github.com/Lincyaw/workbuddy/internal/supervisor/client"
 )
 
 // Launcher is kept as a compatibility alias while runtime owns the canonical registry.
 type Launcher = runtimepkg.Registry
 
-func NewLauncher() *Launcher {
+// NewLauncher builds a Registry pre-populated with the workbuddy built-in
+// runtimes, wired to the supplied supervisor client. The hook is fired
+// immediately after each successful StartAgent (taskID, agentID); workers use
+// it to persist task_queue.supervisor_agent_id so a worker restart can adopt
+// the running subprocess instead of orphaning it. Either argument may be nil
+// only in unit tests that exercise stubbed runtimes.
+func NewLauncher(client *supclient.Client, hook runtimepkg.AgentStartedHook) *Launcher {
 	l := runtimepkg.NewRegistry()
+	l.SetSupervisorClient(client)
+	l.SetAgentStartedHook(hook)
 	l.SetSessionStarter(func(_ context.Context, agent *config.AgentConfig, task *runtimepkg.TaskContext) (runtimepkg.Session, error, bool) {
 		if agent != nil && agent.Runner == config.RunnerGitHubActions {
 			return runtimepkg.NewGHASession(agent, task), nil, true
@@ -24,7 +33,9 @@ func NewLauncher() *Launcher {
 	return l
 }
 
-// RegisterBuiltins installs the built-in runtimes into a registry.
+// RegisterBuiltins installs the built-in runtimes into a registry. The
+// supervisor client and agent-started hook are pulled off the registry, so
+// callers should call SetSupervisorClient / SetAgentStartedHook first.
 func RegisterBuiltins(l *runtimepkg.Registry) {
 	if l == nil {
 		return

--- a/internal/launcher/launcher_test.go
+++ b/internal/launcher/launcher_test.go
@@ -109,7 +109,7 @@ func eventErrorCodes(t *testing.T, events []launcherevents.Event) []string {
 
 // Test 1: Normal execution — command runs and returns stdout, stderr, exit code 0
 func TestLaunch_NormalExec(t *testing.T) {
-	launcher := NewLauncher()
+	launcher := newTestLauncher(t)
 	task := newTestTask(t)
 
 	agent := &config.AgentConfig{
@@ -136,7 +136,7 @@ func TestLaunch_NormalExec(t *testing.T) {
 
 // Test 2: Timeout — subprocess killed after timeout
 func TestLaunch_Timeout(t *testing.T) {
-	launcher := NewLauncher()
+	launcher := newTestLauncher(t)
 	task := newTestTask(t)
 
 	agent := &config.AgentConfig{
@@ -157,7 +157,7 @@ func TestLaunch_Timeout(t *testing.T) {
 
 // Test 3: Template rendering — variables are expanded in command
 func TestLaunch_TemplateRender(t *testing.T) {
-	launcher := NewLauncher()
+	launcher := newTestLauncher(t)
 	task := newTestTask(t)
 
 	agent := &config.AgentConfig{
@@ -191,7 +191,7 @@ func TestLaunch_TemplateRender(t *testing.T) {
 
 // Test 4: Context cancellation — subprocess killed when context is cancelled
 func TestLaunch_Cancel(t *testing.T) {
-	launcher := NewLauncher()
+	launcher := newTestLauncher(t)
 	task := newTestTask(t)
 
 	agent := &config.AgentConfig{
@@ -217,7 +217,7 @@ func TestLaunch_Cancel(t *testing.T) {
 }
 
 func TestStart_GitHubActionsRunnerUsesRemoteSession(t *testing.T) {
-	launcher := NewLauncher()
+	launcher := newTestLauncher(t)
 	task := newTestTask(t)
 	agent := &config.AgentConfig{
 		Name:    "remote-agent",
@@ -248,7 +248,7 @@ func TestStart_GitHubActionsRunnerUsesRemoteSession(t *testing.T) {
 
 // Test 5: Meta parse success — WORKBUDDY_META block is extracted from stdout
 func TestLaunch_MetaParseSuccess(t *testing.T) {
-	launcher := NewLauncher()
+	launcher := newTestLauncher(t)
 	task := newTestTask(t)
 
 	agent := &config.AgentConfig{
@@ -281,7 +281,7 @@ func TestLaunch_MetaParseSuccess(t *testing.T) {
 
 // Test 6: Meta missing — no WORKBUDDY_META block, Meta should be nil (no error)
 func TestLaunch_MetaMissing(t *testing.T) {
-	launcher := NewLauncher()
+	launcher := newTestLauncher(t)
 	task := newTestTask(t)
 
 	agent := &config.AgentConfig{
@@ -302,7 +302,7 @@ func TestLaunch_MetaMissing(t *testing.T) {
 
 // Test 7: claude-code runtime — verify the runtime is registered and works
 func TestLaunch_ClaudeCodeRuntime(t *testing.T) {
-	launcher := NewLauncher()
+	launcher := newTestLauncher(t)
 	task := newTestTask(t)
 
 	agent := &config.AgentConfig{
@@ -326,7 +326,7 @@ func TestLaunch_CodexRuntime(t *testing.T) {
 	restore := installFakeCodex(t)
 	defer restore()
 
-	launcher := NewLauncher()
+	launcher := newTestLauncher(t)
 	task := newTestTask(t)
 
 	agent := &config.AgentConfig{
@@ -350,7 +350,7 @@ func TestLaunch_CodexRuntime(t *testing.T) {
 }
 
 func TestLaunch_OutputContractValidatesProcessOutput(t *testing.T) {
-	launcher := NewLauncher()
+	launcher := newTestLauncher(t)
 	task := newTestTask(t)
 	agentDir := t.TempDir()
 	schemaPath := writeOutputSchema(t, agentDir)
@@ -379,7 +379,7 @@ func TestLaunch_OutputContractValidatesProcessOutput(t *testing.T) {
 }
 
 func TestLaunch_OutputContractRejectsInvalidProcessOutput(t *testing.T) {
-	launcher := NewLauncher()
+	launcher := newTestLauncher(t)
 	task := newTestTask(t)
 	agentDir := t.TempDir()
 	writeOutputSchema(t, agentDir)
@@ -412,7 +412,7 @@ func TestProcessSessionRun_EmitsErrorTerminalEventOnOutputContractFailure(t *tes
 	agentDir := t.TempDir()
 	writeOutputSchema(t, agentDir)
 
-	session := newProcessSession(config.RuntimeClaudeCode, &config.AgentConfig{
+	session := newTestProcessSession(t, config.RuntimeClaudeCode, &config.AgentConfig{
 		Name:    "structured-agent",
 		Runtime: config.RuntimeClaudeCode,
 		Command: `printf '{"missing":"status"}'`,
@@ -440,7 +440,7 @@ func TestProcessSessionRun_EmitsErrorTerminalEventOnOutputContractFailure(t *tes
 
 // Test 9: Unknown runtime — clear error message
 func TestLaunch_UnknownRuntime(t *testing.T) {
-	launcher := NewLauncher()
+	launcher := newTestLauncher(t)
 	task := newTestTask(t)
 
 	agent := &config.AgentConfig{
@@ -464,7 +464,7 @@ func TestLaunch_UnknownRuntime(t *testing.T) {
 
 // Test: default runtime is claude-code when not specified
 func TestLaunch_DefaultRuntime(t *testing.T) {
-	launcher := NewLauncher()
+	launcher := newTestLauncher(t)
 	task := newTestTask(t)
 
 	agent := &config.AgentConfig{
@@ -485,7 +485,7 @@ func TestLaunch_DefaultRuntime(t *testing.T) {
 
 // Test: environment variables are set correctly
 func TestLaunch_EnvVars(t *testing.T) {
-	launcher := NewLauncher()
+	launcher := newTestLauncher(t)
 	task := newTestTask(t)
 
 	agent := &config.AgentConfig{
@@ -516,7 +516,7 @@ func TestLaunch_EnvVars(t *testing.T) {
 
 // Test: non-zero exit code is captured
 func TestLaunch_NonZeroExit(t *testing.T) {
-	launcher := NewLauncher()
+	launcher := newTestLauncher(t)
 	task := newTestTask(t)
 
 	agent := &config.AgentConfig{
@@ -537,7 +537,7 @@ func TestLaunch_NonZeroExit(t *testing.T) {
 
 // Test: command working directory is set to task.Repo
 func TestLaunch_WorkingDirectory(t *testing.T) {
-	launcher := NewLauncher()
+	launcher := newTestLauncher(t)
 	task := newTestTask(t)
 
 	// Create a marker file in the temp dir
@@ -780,7 +780,7 @@ func TestRenderCommand_AutoEscapesIssueFields(t *testing.T) {
 
 // Test: shell injection via issue title is neutralized end-to-end
 func TestLaunch_ShellInjectionTitle(t *testing.T) {
-	launcher := NewLauncher()
+	launcher := newTestLauncher(t)
 	dir := t.TempDir()
 
 	// A malicious title that tries to create a file via command injection
@@ -823,7 +823,7 @@ func TestLaunch_ShellInjectionTitle(t *testing.T) {
 
 // Test: shell injection via issue body is neutralized end-to-end
 func TestLaunch_ShellInjectionBody(t *testing.T) {
-	launcher := NewLauncher()
+	launcher := newTestLauncher(t)
 	dir := t.TempDir()
 
 	markerFile := filepath.Join(dir, "pwned_body.txt")

--- a/internal/launcher/permissions_test.go
+++ b/internal/launcher/permissions_test.go
@@ -141,7 +141,7 @@ func TestProcessSessionRun_EmitsPermissionEvent(t *testing.T) {
 		Policy:  config.PolicyConfig{Sandbox: "read-only"},
 	}
 
-	session := newProcessSession(config.RuntimeClaudeCode, agent, task, nil)
+	session := newTestProcessSession(t, config.RuntimeClaudeCode, agent, task, nil)
 	events, result, err := collectSessionEvents(t, session)
 	if err != nil {
 		t.Fatalf("run: %v", err)
@@ -178,7 +178,7 @@ func TestCodexSessionRun_EmitsPermissionEvent(t *testing.T) {
 		Policy:  config.PolicyConfig{Sandbox: "read-only", Approval: "never"},
 		Timeout: 10 * time.Second,
 	}
-	session, err := NewLauncher().Start(context.Background(), agent, task)
+	session, err := newTestLauncher(t).Start(context.Background(), agent, task)
 	if err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -216,7 +216,7 @@ func TestCodexSessionRun_DangerBypassesSandboxThroughLauncher(t *testing.T) {
 		Policy:  config.PolicyConfig{Sandbox: "danger-full-access", Approval: "never"},
 		Timeout: 10 * time.Second,
 	}
-	session, err := NewLauncher().Start(context.Background(), agent, task)
+	session, err := newTestLauncher(t).Start(context.Background(), agent, task)
 	if err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -292,7 +292,7 @@ func TestCodexSessionRun_DangerFullAccessE2E_FileWrite(t *testing.T) {
 		Policy:  config.PolicyConfig{Sandbox: "danger-full-access", Approval: "never"},
 		Timeout: 2 * time.Minute,
 	}
-	session, err := NewLauncher().Start(context.Background(), agent, task)
+	session, err := newTestLauncher(t).Start(context.Background(), agent, task)
 	if err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -347,7 +347,7 @@ func TestClaudeStreamSessionRun_EmitsPermissionEvent(t *testing.T) {
 		Policy:  config.PolicyConfig{Sandbox: "read-only"},
 		Timeout: 10 * time.Second,
 	}
-	session, err := NewLauncher().Start(context.Background(), agent, task)
+	session, err := newTestLauncher(t).Start(context.Background(), agent, task)
 	if err != nil {
 		t.Fatalf("start: %v", err)
 	}

--- a/internal/launcher/process.go
+++ b/internal/launcher/process.go
@@ -1,21 +1,10 @@
 package launcher
 
 import (
-	"context"
-	"os/exec"
-
 	"github.com/Lincyaw/workbuddy/internal/config"
 	launcherevents "github.com/Lincyaw/workbuddy/internal/launcher/events"
 	runtimepkg "github.com/Lincyaw/workbuddy/internal/runtime"
 )
-
-func newProcessSession(runtimeName string, agent *config.AgentConfig, task *TaskContext, findSession runtimepkg.SessionFinder) Session {
-	return runtimepkg.NewProcessSession(runtimeName, agent, task, findSession)
-}
-
-func newClaudePromptCommand(execCtx context.Context, prompt string, extraArgs []string, policy config.PolicyConfig) *exec.Cmd {
-	return runtimepkg.NewClaudePromptCommand(execCtx, prompt, extraArgs, policy)
-}
 
 func hasPrintFlag(args []string) bool {
 	return runtimepkg.HasPrintFlag(args)

--- a/internal/launcher/process_test.go
+++ b/internal/launcher/process_test.go
@@ -1,8 +1,6 @@
 package launcher
 
 import (
-	"context"
-	"io"
 	"strings"
 	"testing"
 
@@ -10,7 +8,7 @@ import (
 	runtimepkg "github.com/Lincyaw/workbuddy/internal/runtime"
 )
 
-func TestProcessSessionBuildCommand_UsesPromptForClaude(t *testing.T) {
+func TestProcessSessionBuildSpec_UsesPromptForClaude(t *testing.T) {
 	task := newTestTask(t)
 	sess := &runtimepkg.ProcessSession{
 		RuntimeName: config.RuntimeClaudeCode,
@@ -25,25 +23,21 @@ func TestProcessSessionBuildCommand_UsesPromptForClaude(t *testing.T) {
 		Task: task,
 	}
 
-	cmd, err := sess.BuildCommand(context.Background())
+	spec, err := sess.BuildSpec()
 	if err != nil {
-		t.Fatalf("buildCommand: %v", err)
+		t.Fatalf("BuildSpec: %v", err)
 	}
-	if got := cmd.Args[0]; got != "claude" && !strings.HasSuffix(got, "/claude") {
-		t.Fatalf("command path = %q", got)
+	if spec.Binary != "claude" {
+		t.Fatalf("binary = %q, want claude", spec.Binary)
 	}
-	joined := strings.Join(cmd.Args[1:], " ")
+	joined := strings.Join(spec.Args, " ")
 	for _, want := range []string{"--dangerously-skip-permissions", "--output-format stream-json", "--verbose"} {
 		if !strings.Contains(joined, want) {
 			t.Fatalf("args %q missing %q", joined, want)
 		}
 	}
-	data, err := io.ReadAll(cmd.Stdin)
-	if err != nil {
-		t.Fatalf("read stdin: %v", err)
-	}
-	if got := string(data); got != "review issue 42" {
-		t.Fatalf("stdin = %q", got)
+	if spec.Stdin != "review issue 42" {
+		t.Fatalf("stdin = %q", spec.Stdin)
 	}
 }
 

--- a/internal/launcher/supervisor_inproc.go
+++ b/internal/launcher/supervisor_inproc.go
@@ -1,0 +1,58 @@
+package launcher
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/Lincyaw/workbuddy/internal/supervisor"
+	supclient "github.com/Lincyaw/workbuddy/internal/supervisor/client"
+)
+
+// NewInProcessSupervisor starts a supervisor inside the current process,
+// bound to a localhost TCP port (no unix socket), and returns a client for
+// it. This is the launch model for one-shot CLI commands like `workbuddy
+// run` and for unit tests, where running a separate `workbuddy supervisor`
+// would be overkill. The returned shutdown function stops the HTTP server
+// and closes the supervisor.
+//
+// In long-lived deployments (worker, serve), callers connect to a
+// pre-existing supervisor over a unix socket via supclient.NewUnix instead;
+// the whole point of the supervisor is that its lifetime is independent of
+// the worker's.
+func NewInProcessSupervisor(stateDir string, cancelGrace time.Duration) (*supclient.Client, func(), error) {
+	if stateDir == "" {
+		return nil, nil, errors.New("launcher: in-process supervisor requires a stateDir")
+	}
+	sup, err := supervisor.New(supervisor.Config{
+		// SocketPath unused: we serve over a localhost TCP listener so we
+		// don't depend on a writable XDG_RUNTIME_DIR or fight stale unix
+		// sockets in CI.
+		SocketPath:  stateDir + "/.unused.sock",
+		StateDir:    stateDir,
+		CancelGrace: cancelGrace,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("init in-process supervisor: %w", err)
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		_ = sup.Close()
+		return nil, nil, fmt.Errorf("listen 127.0.0.1: %w", err)
+	}
+	srv := &http.Server{Handler: sup.Handler(), ReadHeaderTimeout: 5 * time.Second}
+	go func() {
+		_ = srv.Serve(ln)
+	}()
+	cli := supclient.NewHTTP("http://"+ln.Addr().String(), &http.Client{Timeout: 0})
+	shutdown := func() {
+		shutCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		_ = srv.Shutdown(shutCtx)
+		cancel()
+		_ = sup.Close()
+	}
+	return cli, shutdown, nil
+}

--- a/internal/launcher/supervisor_ipc_test.go
+++ b/internal/launcher/supervisor_ipc_test.go
@@ -1,0 +1,161 @@
+package launcher
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Lincyaw/workbuddy/internal/config"
+	launcherevents "github.com/Lincyaw/workbuddy/internal/launcher/events"
+	runtimepkg "github.com/Lincyaw/workbuddy/internal/runtime"
+)
+
+// TestProcessSessionRun_RoutesThroughSupervisor verifies the worker's
+// claude-style runtime no longer spawns subprocesses directly: it must
+// POST /agents to the supervisor, fire the OnAgentStarted hook with the
+// returned agent_id (so the worker can persist task_queue.supervisor_agent_id),
+// and stream stdout back through the SSE channel.
+//
+// Issue #244 / REQ-096: this is the behavioral test that the IPC client
+// path is wired in place of the previous exec.Cmd path.
+func TestProcessSessionRun_RoutesThroughSupervisor(t *testing.T) {
+	client := newTestSupervisorClient(t)
+
+	var (
+		hookMu       sync.Mutex
+		hookCalls    []string
+		hookTaskIDs  []string
+	)
+	hook := func(taskID, agentID string) {
+		hookMu.Lock()
+		defer hookMu.Unlock()
+		hookTaskIDs = append(hookTaskIDs, taskID)
+		hookCalls = append(hookCalls, agentID)
+	}
+
+	lnch := NewLauncher(client, hook)
+
+	task := newTestTask(t)
+	task.Session.TaskID = "task-244-supervised"
+	agent := &config.AgentConfig{
+		Name:    "ipc-agent",
+		Runtime: config.RuntimeClaudeCode,
+		Command: `echo "from-supervisor"`,
+		Timeout: 10 * time.Second,
+	}
+
+	session, err := lnch.Start(context.Background(), agent, task)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = session.Close() }()
+
+	ch := make(chan launcherevents.Event, 16)
+	doneCh := make(chan struct{})
+	go func() {
+		for range ch {
+		}
+		close(doneCh)
+	}()
+	result, err := session.Run(context.Background(), ch)
+	close(ch)
+	<-doneCh
+
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if !strings.Contains(result.Stdout, "from-supervisor") {
+		t.Fatalf("stdout = %q, want it to contain 'from-supervisor'", result.Stdout)
+	}
+
+	hookMu.Lock()
+	defer hookMu.Unlock()
+	if len(hookCalls) != 1 {
+		t.Fatalf("OnAgentStarted called %d times, want 1: %v", len(hookCalls), hookCalls)
+	}
+	if hookCalls[0] == "" {
+		t.Fatal("OnAgentStarted received empty agent_id")
+	}
+	if hookTaskIDs[0] != "task-244-supervised" {
+		t.Fatalf("OnAgentStarted received task_id %q, want %q", hookTaskIDs[0], "task-244-supervised")
+	}
+}
+
+// TestProcessSessionRun_PassesPromptViaSupervisorStdin verifies the claude
+// prompt path: the supervisor must receive the prompt as the Stdin of its
+// StartAgentRequest so the agent process can read it from stdin (the same
+// shape the previous exec.Cmd path used). We exercise this end-to-end by
+// installing a fake `claude` binary that echoes its stdin.
+func TestProcessSessionRun_PassesPromptViaSupervisorStdin(t *testing.T) {
+	restore := installFakeClaude(t, []string{
+		`{"type":"system.init","session_id":"prompt-test"}`,
+		`{"type":"assistant.content_block_delta","delta":{"type":"text_delta","text":"got prompt"}}`,
+		`{"type":"assistant.message_stop","usage":{"input_tokens":1,"output_tokens":1}}`,
+	})
+	defer restore()
+
+	client := newTestSupervisorClient(t)
+	lnch := NewLauncher(client, nil)
+
+	task := newTestTask(t)
+	agent := &config.AgentConfig{
+		Name:    "claude-prompt-agent",
+		Runtime: config.RuntimeClaudeCode,
+		Prompt:  "say hi",
+		Policy:  config.PolicyConfig{Sandbox: "read-only"},
+		Timeout: 5 * time.Second,
+	}
+
+	session, err := lnch.Start(context.Background(), agent, task)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = session.Close() }()
+
+	ch := make(chan launcherevents.Event, 32)
+	doneCh := make(chan struct{})
+	go func() {
+		for range ch {
+		}
+		close(doneCh)
+	}()
+	result, err := session.Run(context.Background(), ch)
+	close(ch)
+	<-doneCh
+
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", result.ExitCode)
+	}
+	if result.LastMessage != "got prompt" {
+		t.Fatalf("LastMessage = %q, want %q", result.LastMessage, "got prompt")
+	}
+}
+
+// TestProcessSession_NoClientFailsLoudly checks the explicit guard against
+// running without a wired-up supervisor — the previous exec.Cmd path is
+// gone, so nil client must be a clear error rather than a silent no-op.
+func TestProcessSession_NoClientFailsLoudly(t *testing.T) {
+	task := newTestTask(t)
+	agent := &config.AgentConfig{
+		Name:    "no-client-agent",
+		Runtime: config.RuntimeClaudeCode,
+		Command: `echo "nope"`,
+		Timeout: 1 * time.Second,
+	}
+	sess := runtimepkg.NewProcessSession(nil, nil, config.RuntimeClaudeCode, agent, task, nil)
+	_, err := sess.Run(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error when supervisor client is nil")
+	}
+	if !strings.Contains(err.Error(), "supervisor client not configured") {
+		t.Fatalf("error = %v, want mention of 'supervisor client not configured'", err)
+	}
+}

--- a/internal/launcher/test_helper_test.go
+++ b/internal/launcher/test_helper_test.go
@@ -1,0 +1,39 @@
+package launcher
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Lincyaw/workbuddy/internal/config"
+	runtimepkg "github.com/Lincyaw/workbuddy/internal/runtime"
+	supclient "github.com/Lincyaw/workbuddy/internal/supervisor/client"
+)
+
+// newTestLauncher returns a Launcher backed by an in-process supervisor
+// rooted at t.TempDir(). The supervisor is shut down when the test ends.
+// Tests that previously called NewLauncher() use this helper instead so the
+// claude/sh runtimes have a real IPC backend without requiring an external
+// `workbuddy supervisor` process.
+func newTestLauncher(t *testing.T) *Launcher {
+	t.Helper()
+	return NewLauncher(newTestSupervisorClient(t), nil)
+}
+
+func newTestSupervisorClient(t *testing.T) *supclient.Client {
+	t.Helper()
+	cli, shutdown, err := NewInProcessSupervisor(t.TempDir(), 200*time.Millisecond)
+	if err != nil {
+		t.Fatalf("in-process supervisor: %v", err)
+	}
+	t.Cleanup(shutdown)
+	return cli
+}
+
+// newTestProcessSession constructs a ProcessSession with a per-test
+// in-process supervisor client. Tests use this in place of the previous
+// production helper of the same name (which is gone now that ProcessSession
+// requires a *supclient.Client).
+func newTestProcessSession(t *testing.T, runtimeName string, agent *config.AgentConfig, task *TaskContext, finder runtimepkg.SessionFinder) Session {
+	t.Helper()
+	return runtimepkg.NewProcessSession(newTestSupervisorClient(t), nil, runtimeName, agent, task, finder)
+}

--- a/internal/runtime/claude.go
+++ b/internal/runtime/claude.go
@@ -6,14 +6,22 @@ import (
 	"path/filepath"
 
 	"github.com/Lincyaw/workbuddy/internal/config"
+	supclient "github.com/Lincyaw/workbuddy/internal/supervisor/client"
 )
 
-type ClaudeRuntime struct{}
+// ClaudeRuntime executes claude (and the generic shell-style claude-code
+// runtime) by handing the spec off to the local supervisor over IPC. Both
+// SupervisorClient and the registry-level OnAgentStarted hook are populated
+// when the runtime is registered (see RegisterBuiltins / Registry.attach).
+type ClaudeRuntime struct {
+	SupervisorClient *supclient.Client
+	OnAgentStarted   AgentStartedHook
+}
 
 func (r *ClaudeRuntime) Name() string { return config.RuntimeClaudeShot }
 
 func (r *ClaudeRuntime) Start(_ context.Context, agent *config.AgentConfig, task *TaskContext) (Session, error) {
-	return NewProcessSession(r.Name(), agent, task, FindClaudeSessionPath), nil
+	return NewProcessSession(r.SupervisorClient, r.OnAgentStarted, r.Name(), agent, task, FindClaudeSessionPath), nil
 }
 
 func (r *ClaudeRuntime) Launch(ctx context.Context, agent *config.AgentConfig, task *TaskContext) (*Result, error) {

--- a/internal/runtime/claude_stream.go
+++ b/internal/runtime/claude_stream.go
@@ -1,20 +1,14 @@
 package runtime
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
-	"io/fs"
-	"os/exec"
 	"strings"
-	"sync"
-	"syscall"
 	"time"
 
 	launcherevents "github.com/Lincyaw/workbuddy/internal/launcher/events"
+	supclient "github.com/Lincyaw/workbuddy/internal/supervisor/client"
 )
 
 type ClaudeToolCall struct {
@@ -185,107 +179,81 @@ func (m *ClaudeStreamEventMapper) makeEvent(seq *uint64, kind launcherevents.Eve
 }
 
 func (s *ProcessSession) runClaudeStream(ctx context.Context, timeout time.Duration, events chan<- launcherevents.Event) (*Result, error) {
+	if s.Client == nil {
+		infra := &Result{ExitCode: -1, Meta: map[string]string{}}
+		MarkInfraFailure(infra, "supervisor client not configured")
+		return infra, fmt.Errorf("runtime: %s: supervisor client not configured", s.RuntimeName)
+	}
 	execCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	cmd, err := s.BuildCommand(execCtx)
+	spec, err := s.BuildSpec()
 	if err != nil {
 		infra := &Result{ExitCode: -1, Meta: map[string]string{}}
 		MarkInfraFailure(infra, "build command failed (template render)")
 		return infra, err
 	}
-	if s.Task.WorkDir != "" {
-		cmd.Dir = s.Task.WorkDir
-	}
-	cmd.Env = BuildScopedEnv(s.Agent, s.Task)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	cmd.Cancel = func() error { return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL) }
-	cmd.WaitDelay = 10 * time.Second
 
-	stdoutPipe, err := cmd.StdoutPipe()
+	start := time.Now()
+	var seq uint64
+	mapper := NewClaudeStreamEventMapper(s.Task.Session.ID)
+	EmitPermissionEvent(events, &seq, s.Task.Session.ID, mapper.EffectiveTurnID(), s.Agent, EmitEvent)
+
+	startResp, err := s.Client.StartAgent(execCtx, s.startRequestFor(spec))
 	if err != nil {
-		infra := &Result{ExitCode: -1, Meta: map[string]string{}}
-		MarkInfraFailure(infra, "stdout pipe setup failed")
-		return infra, fmt.Errorf("runtime: %s: stdout pipe: %w", s.RuntimeName, err)
-	}
-	stderrPipe, err := cmd.StderrPipe()
-	if err != nil {
-		infra := &Result{ExitCode: -1, Meta: map[string]string{}}
-		MarkInfraFailure(infra, "stderr pipe setup failed")
-		return infra, fmt.Errorf("runtime: %s: stderr pipe: %w", s.RuntimeName, err)
-	}
-	if err := cmd.Start(); err != nil {
 		infra := &Result{ExitCode: -1, Meta: map[string]string{}}
 		reason := "claude process start failed"
-		if IsExecStartError(err) {
+		if isExecStartFailure(err) {
 			reason = "claude binary not runnable (exec start error)"
 		}
 		MarkInfraFailure(infra, reason)
 		return infra, fmt.Errorf("runtime: %s: start: %w", s.RuntimeName, err)
 	}
+	agentID := startResp.AgentID
+	if s.OnAgentStarted != nil && s.Task != nil && s.Task.Session.TaskID != "" {
+		s.OnAgentStarted(s.Task.Session.TaskID, agentID)
+	}
 
-	start := time.Now()
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	var seq uint64
-	mapper := NewClaudeStreamEventMapper(s.Task.Session.ID)
-	EmitPermissionEvent(events, &seq, s.Task.Session.ID, mapper.EffectiveTurnID(), s.Agent, EmitEvent)
+	cancelDone := make(chan struct{})
+	go s.watchCancel(execCtx, agentID, cancelDone)
+	defer close(cancelDone)
 
-	var wg sync.WaitGroup
-	var stdoutErr error
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		dec := json.NewDecoder(stdoutPipe)
-		for {
-			var raw json.RawMessage
-			if err := dec.Decode(&raw); err != nil {
-				if !errors.Is(err, io.EOF) && !errors.Is(err, context.Canceled) && !errors.Is(err, io.ErrUnexpectedEOF) && !errors.Is(err, fs.ErrClosed) {
-					stdoutErr = err
-				}
-				return
-			}
-			stdout.Write(raw)
-			stdout.WriteByte('\n')
+	streamErr := s.Client.StreamEvents(execCtx, agentID, 0, func(ev supclient.StreamEvent) error {
+		raw := json.RawMessage(ev.Line)
+		if handle := s.Task.SessionHandle(); handle != nil {
+			_ = handle.WriteStdout(append(append([]byte(nil), raw...), '\n'))
+		}
+		for _, evt := range mapper.Map(raw, &seq) {
 			if handle := s.Task.SessionHandle(); handle != nil {
-				_ = handle.WriteStdout(append(append([]byte(nil), raw...), '\n'))
+				_ = PersistToolCallEvent(handle, "claude-code", evt)
 			}
-			for _, evt := range mapper.Map(raw, &seq) {
-				if handle := s.Task.SessionHandle(); handle != nil {
-					_ = PersistToolCallEvent(handle, "claude-code", evt)
-				}
-				if events != nil {
-					select {
-					case events <- evt:
-					case <-ctx.Done():
-						return
-					}
+			if events != nil {
+				select {
+				case events <- evt:
+				case <-ctx.Done():
+					return ctx.Err()
 				}
 			}
 		}
-	}()
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		_, _ = stderr.ReadFrom(stderrPipe)
-	}()
-
-	wg.Wait()
-	runErr := cmd.Wait()
+		return nil
+	})
 	duration := time.Since(start)
 
-	if stdoutErr != nil {
+	status, statusErr := s.Client.Status(context.Background(), agentID)
+	if statusErr != nil {
 		infra := &Result{
-			ExitCode: -1,
-			Stdout:   stdout.String(),
-			Stderr:   stderr.String(),
-			Duration: duration,
-			Meta:     map[string]string{},
+			ExitCode:    -1,
+			Duration:    duration,
+			Meta:        map[string]string{},
+			LastMessage: mapper.LastMessageValue,
+			TokenUsage:  mapper.TokenUsageValue,
+			SessionRef:  mapper.SessionRefValue,
 		}
-		MarkInfraFailure(infra, "stdout stream read error")
-		return infra, fmt.Errorf("runtime: %s: read stdout: %w", s.RuntimeName, stdoutErr)
+		MarkInfraFailure(infra, "supervisor status lookup failed")
+		return infra, fmt.Errorf("runtime: %s: status: %w", s.RuntimeName, statusErr)
 	}
+	stdoutBytes := readFileIfExists(status.StdoutPath)
+	stderrBytes := readFileIfExists(status.StderrPath)
 
 	if execCtx.Err() == context.DeadlineExceeded {
 		if events != nil {
@@ -295,8 +263,8 @@ func (s *ProcessSession) runClaudeStream(ctx context.Context, timeout time.Durat
 		}
 		return &Result{
 			ExitCode:    -1,
-			Stdout:      stdout.String(),
-			Stderr:      stderr.String(),
+			Stdout:      string(stdoutBytes),
+			Stderr:      string(stderrBytes),
 			Duration:    duration,
 			Meta:        map[string]string{"timeout": "true"},
 			LastMessage: mapper.LastMessageValue,
@@ -304,7 +272,6 @@ func (s *ProcessSession) runClaudeStream(ctx context.Context, timeout time.Durat
 			SessionRef:  mapper.SessionRefValue,
 		}, fmt.Errorf("runtime: %s: timeout after %s: %w", s.RuntimeName, timeout, execCtx.Err())
 	}
-
 	if ctx.Err() != nil {
 		if events != nil {
 			EmitEvent(events, &seq, s.Task.Session.ID, mapper.EffectiveTurnID(), launcherevents.KindError, launcherevents.ErrorPayload{Code: "cancelled", Message: ctx.Err().Error(), Recoverable: false}, nil)
@@ -313,72 +280,70 @@ func (s *ProcessSession) runClaudeStream(ctx context.Context, timeout time.Durat
 		}
 		return &Result{
 			ExitCode:    -1,
-			Stdout:      stdout.String(),
-			Stderr:      stderr.String(),
+			Stdout:      string(stdoutBytes),
+			Stderr:      string(stderrBytes),
 			Duration:    duration,
 			LastMessage: mapper.LastMessageValue,
 			TokenUsage:  mapper.TokenUsageValue,
 			SessionRef:  mapper.SessionRefValue,
 		}, fmt.Errorf("runtime: %s: cancelled: %w", s.RuntimeName, ctx.Err())
 	}
-
-	exitCode := 0
-	if runErr != nil {
-		exitErr, ok := runErr.(*exec.ExitError)
-		if !ok {
-			infra := &Result{
-				ExitCode:    -1,
-				Stdout:      stdout.String(),
-				Stderr:      stderr.String(),
-				Duration:    duration,
-				LastMessage: mapper.LastMessageValue,
-				TokenUsage:  mapper.TokenUsageValue,
-				SessionRef:  mapper.SessionRefValue,
-				Meta:        map[string]string{},
-			}
-			MarkInfraFailure(infra, "claude wait error (non-exit)")
-			return infra, fmt.Errorf("runtime: %s: wait: %w", s.RuntimeName, runErr)
+	if streamErr != nil {
+		infra := &Result{
+			ExitCode:    -1,
+			Stdout:      string(stdoutBytes),
+			Stderr:      string(stderrBytes),
+			Duration:    duration,
+			LastMessage: mapper.LastMessageValue,
+			TokenUsage:  mapper.TokenUsageValue,
+			SessionRef:  mapper.SessionRefValue,
+			Meta:        map[string]string{},
 		}
-		exitCode = exitErr.ExitCode()
+		MarkInfraFailure(infra, "stdout stream read error")
+		return infra, fmt.Errorf("runtime: %s: read stdout: %w", s.RuntimeName, streamErr)
+	}
+	exitCode := 0
+	if status.ExitCode != nil {
+		exitCode = *status.ExitCode
 	}
 
 	if events != nil && !mapper.TurnCompleteSaw {
-		status := "ok"
+		statusName := "ok"
 		if exitCode != 0 {
-			status = "error"
+			statusName = "error"
 			EmitEvent(events, &seq, s.Task.Session.ID, mapper.EffectiveTurnID(), launcherevents.KindError, launcherevents.ErrorPayload{
 				Code:        "claude_exit",
 				Message:     fmt.Sprintf("claude exited %d without assistant.message_stop", exitCode),
 				Recoverable: false,
 			}, nil)
 		}
-		EmitEvent(events, &seq, s.Task.Session.ID, mapper.EffectiveTurnID(), launcherevents.KindTurnCompleted, launcherevents.TurnCompletedPayload{TurnID: mapper.EffectiveTurnID(), Status: status}, nil)
+		EmitEvent(events, &seq, s.Task.Session.ID, mapper.EffectiveTurnID(), launcherevents.KindTurnCompleted, launcherevents.TurnCompletedPayload{TurnID: mapper.EffectiveTurnID(), Status: statusName}, nil)
 	}
 
 	sessionPath := ""
 	if s.FindSession != nil {
 		sessionPath = s.FindSession(s.SessionLookupPath())
 	}
-	if events != nil && stderr.Len() > 0 {
+	if events != nil && len(stderrBytes) > 0 {
 		if handle := s.Task.SessionHandle(); handle != nil {
-			_ = handle.WriteStderr(stderr.Bytes())
+			_ = handle.WriteStderr(stderrBytes)
 		}
-		for _, line := range splitLines(stderr.String()) {
+		for _, line := range splitLines(string(stderrBytes)) {
 			EmitEvent(events, &seq, s.Task.Session.ID, mapper.EffectiveTurnID(), launcherevents.KindLog, launcherevents.LogPayload{Stream: "stderr", Line: line}, nil)
 		}
 	}
 
 	result := &Result{
 		ExitCode:    exitCode,
-		Stdout:      stdout.String(),
-		Stderr:      stderr.String(),
+		Stdout:      string(stdoutBytes),
+		Stderr:      string(stderrBytes),
 		Duration:    duration,
 		SessionPath: sessionPath,
 		LastMessage: mapper.LastMessageValue,
 		TokenUsage:  mapper.TokenUsageValue,
 		SessionRef:  mapper.SessionRefValue,
 	}
-	if exitCode != 0 && !mapper.TurnCompleteSaw && mapper.LastMessageValue == "" && StderrLooksLikeRuntimePanic(stderr.String()) {
+	if exitCode != 0 && !mapper.TurnCompleteSaw && mapper.LastMessageValue == "" && StderrLooksLikeRuntimePanic(string(stderrBytes)) {
 		MarkInfraFailure(result, "claude runtime panic/abort before agent output")
 	}
 	return result, nil

--- a/internal/runtime/process.go
+++ b/internal/runtime/process.go
@@ -3,27 +3,59 @@ package runtime
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
-	"os/exec"
+	"os"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/Lincyaw/workbuddy/internal/config"
 	launcherevents "github.com/Lincyaw/workbuddy/internal/launcher/events"
+	"github.com/Lincyaw/workbuddy/internal/supervisor"
+	supclient "github.com/Lincyaw/workbuddy/internal/supervisor/client"
 )
 
 type SessionFinder func(repoPath string) string
 
+// AgentStartedHook is invoked exactly once per session, immediately after the
+// supervisor has accepted POST /agents and returned an agent_id. Workers wire
+// this to Store.UpdateTaskSupervisorAgentID so a worker crash mid-run leaves
+// the task row pointing at the live supervisor-managed subprocess.
+type AgentStartedHook func(taskID, agentID string)
+
 type ProcessSession struct {
-	RuntimeName string
-	Agent       *config.AgentConfig
-	Task        *TaskContext
-	FindSession SessionFinder
+	RuntimeName    string
+	Agent          *config.AgentConfig
+	Task           *TaskContext
+	FindSession    SessionFinder
+	Client         *supclient.Client
+	OnAgentStarted AgentStartedHook
 }
 
-func NewProcessSession(runtimeName string, agent *config.AgentConfig, task *TaskContext, findSession SessionFinder) Session {
-	return &ProcessSession{RuntimeName: runtimeName, Agent: agent, Task: task, FindSession: findSession}
+// NewProcessSession returns a Session that runs a workbuddy claude-style
+// agent through the local supervisor IPC API. The returned session does not
+// start the subprocess until Run is called; onAgentStarted (if non-nil) is
+// invoked exactly once after the supervisor accepts POST /agents.
+func NewProcessSession(client *supclient.Client, onAgentStarted AgentStartedHook, runtimeName string, agent *config.AgentConfig, task *TaskContext, findSession SessionFinder) Session {
+	return &ProcessSession{
+		RuntimeName:    runtimeName,
+		Agent:          agent,
+		Task:           task,
+		FindSession:    findSession,
+		Client:         client,
+		OnAgentStarted: onAgentStarted,
+	}
+}
+
+// CommandSpec describes a runnable command independent of os/exec. It is the
+// IPC-shaped equivalent of the previous exec.Cmd construction: a binary plus
+// argv plus optional stdin payload. The supervisor executes it on the
+// caller's behalf so the worker process can exit without orphaning the
+// subprocess.
+type CommandSpec struct {
+	Binary string
+	Args   []string
+	Stdin  string
 }
 
 func (s *ProcessSession) Run(ctx context.Context, events chan<- launcherevents.Event) (*Result, error) {
@@ -34,104 +66,173 @@ func (s *ProcessSession) Run(ctx context.Context, events chan<- launcherevents.E
 	if s.WantsClaudeStreamJSON() {
 		return s.runClaudeStream(ctx, timeout, events)
 	}
+	if s.Client == nil {
+		infra := &Result{ExitCode: -1, Meta: map[string]string{}}
+		MarkInfraFailure(infra, "supervisor client not configured")
+		return infra, fmt.Errorf("runtime: %s: supervisor client not configured", s.RuntimeName)
+	}
 	execCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	cmd, err := s.BuildCommand(execCtx)
+	spec, err := s.BuildSpec()
 	if err != nil {
 		infra := &Result{ExitCode: -1, Meta: map[string]string{}}
 		MarkInfraFailure(infra, "build command failed (template render)")
 		return infra, err
 	}
-	if s.Task.WorkDir != "" {
-		cmd.Dir = s.Task.WorkDir
-	}
-	cmd.Env = BuildScopedEnv(s.Agent, s.Task)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	cmd.Cancel = func() error { return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL) }
-	cmd.WaitDelay = 10 * time.Second
-
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
 
 	start := time.Now()
 	var seq uint64
 	EmitPermissionEvent(events, &seq, s.Task.Session.ID, s.Task.Session.ID, s.Agent, EmitEvent)
 	EmitEvent(events, &seq, s.Task.Session.ID, s.Task.Session.ID, launcherevents.KindTurnStarted, launcherevents.TurnStartedPayload{TurnID: s.Task.Session.ID}, nil)
-	runErr := cmd.Run()
-	duration := time.Since(start)
-	exitCode := 0
-	status := "ok"
-	if runErr != nil {
-		status = "error"
-		if execCtx.Err() == context.DeadlineExceeded {
-			result := &Result{ExitCode: -1, Stdout: stdout.String(), Stderr: stderr.String(), Duration: duration, Meta: map[string]string{"timeout": "true"}}
-			EmitEvent(events, &seq, s.Task.Session.ID, s.Task.Session.ID, launcherevents.KindError, launcherevents.ErrorPayload{Code: "timeout", Message: execCtx.Err().Error(), Recoverable: false}, nil)
-			EmitEvent(events, &seq, s.Task.Session.ID, s.Task.Session.ID, launcherevents.KindTurnCompleted, launcherevents.TurnCompletedPayload{TurnID: s.Task.Session.ID, Status: "error"}, nil)
-			return result, fmt.Errorf("runtime: %s: timeout after %s: %w", s.RuntimeName, timeout, execCtx.Err())
+
+	startResp, err := s.Client.StartAgent(execCtx, s.startRequestFor(spec))
+	if err != nil {
+		infra := &Result{ExitCode: -1, Meta: map[string]string{}}
+		reason := "supervisor StartAgent failed"
+		if isExecStartFailure(err) {
+			reason = "exec start error (binary not runnable)"
 		}
-		if ctx.Err() != nil {
-			result := &Result{ExitCode: -1, Stdout: stdout.String(), Stderr: stderr.String(), Duration: duration}
-			EmitEvent(events, &seq, s.Task.Session.ID, s.Task.Session.ID, launcherevents.KindError, launcherevents.ErrorPayload{Code: "cancelled", Message: ctx.Err().Error(), Recoverable: false}, nil)
-			EmitEvent(events, &seq, s.Task.Session.ID, s.Task.Session.ID, launcherevents.KindTurnCompleted, launcherevents.TurnCompletedPayload{TurnID: s.Task.Session.ID, Status: "interrupted"}, nil)
-			return result, fmt.Errorf("runtime: %s: cancelled: %w", s.RuntimeName, ctx.Err())
-		}
-		if exitErr, ok := runErr.(*exec.ExitError); ok {
-			exitCode = exitErr.ExitCode()
-		} else {
-			EmitEvent(events, &seq, s.Task.Session.ID, s.Task.Session.ID, launcherevents.KindError, launcherevents.ErrorPayload{Code: "exec", Message: runErr.Error(), Recoverable: false}, nil)
-			EmitEvent(events, &seq, s.Task.Session.ID, s.Task.Session.ID, launcherevents.KindTurnCompleted, launcherevents.TurnCompletedPayload{TurnID: s.Task.Session.ID, Status: "error"}, nil)
-			infra := &Result{
-				ExitCode: -1,
-				Stdout:   stdout.String(),
-				Stderr:   stderr.String(),
-				Duration: duration,
-				Meta:     map[string]string{},
-			}
-			reason := "launcher exec error"
-			if IsExecStartError(runErr) {
-				reason = "exec start error (binary not runnable)"
-			}
-			MarkInfraFailure(infra, reason)
-			return infra, fmt.Errorf("runtime: %s: exec: %w", s.RuntimeName, runErr)
-		}
+		MarkInfraFailure(infra, reason)
+		EmitEvent(events, &seq, s.Task.Session.ID, s.Task.Session.ID, launcherevents.KindError, launcherevents.ErrorPayload{Code: "exec", Message: err.Error(), Recoverable: false}, nil)
+		EmitEvent(events, &seq, s.Task.Session.ID, s.Task.Session.ID, launcherevents.KindTurnCompleted, launcherevents.TurnCompletedPayload{TurnID: s.Task.Session.ID, Status: "error"}, nil)
+		return infra, fmt.Errorf("runtime: %s: start: %w", s.RuntimeName, err)
+	}
+	agentID := startResp.AgentID
+	if s.OnAgentStarted != nil && s.Task != nil && s.Task.Session.TaskID != "" {
+		s.OnAgentStarted(s.Task.Session.TaskID, agentID)
 	}
 
-	meta := ParseMeta(stdout.String())
+	// Watch ctx and the timeout, sending Cancel to the supervisor so the
+	// agent process is reaped; the StreamEvents call returns naturally
+	// once the supervisor observes the exit.
+	cancelDone := make(chan struct{})
+	go s.watchCancel(execCtx, agentID, cancelDone)
+	defer close(cancelDone)
+
+	stdoutBuf, streamErr := collectStdoutLines(execCtx, s.Client, agentID, nil)
+	duration := time.Since(start)
+
+	status, statusErr := s.Client.Status(context.Background(), agentID)
+	exitCode := 0
+	if statusErr != nil {
+		infra := &Result{ExitCode: -1, Stdout: stdoutBuf.String(), Duration: duration, Meta: map[string]string{}}
+		MarkInfraFailure(infra, "supervisor status lookup failed")
+		return infra, fmt.Errorf("runtime: %s: status: %w", s.RuntimeName, statusErr)
+	}
+	stderrBytes := readFileIfExists(status.StderrPath)
+	stdoutBytes := readFileIfExists(status.StdoutPath)
+	if stdoutBytes != nil {
+		stdoutBuf.Reset()
+		stdoutBuf.Write(stdoutBytes)
+	}
+
+	if execCtx.Err() == context.DeadlineExceeded {
+		EmitEvent(events, &seq, s.Task.Session.ID, s.Task.Session.ID, launcherevents.KindError, launcherevents.ErrorPayload{Code: "timeout", Message: execCtx.Err().Error(), Recoverable: false}, nil)
+		EmitEvent(events, &seq, s.Task.Session.ID, s.Task.Session.ID, launcherevents.KindTurnCompleted, launcherevents.TurnCompletedPayload{TurnID: s.Task.Session.ID, Status: "error"}, nil)
+		result := &Result{ExitCode: -1, Stdout: stdoutBuf.String(), Stderr: string(stderrBytes), Duration: duration, Meta: map[string]string{"timeout": "true"}}
+		return result, fmt.Errorf("runtime: %s: timeout after %s: %w", s.RuntimeName, timeout, execCtx.Err())
+	}
+	if ctx.Err() != nil {
+		EmitEvent(events, &seq, s.Task.Session.ID, s.Task.Session.ID, launcherevents.KindError, launcherevents.ErrorPayload{Code: "cancelled", Message: ctx.Err().Error(), Recoverable: false}, nil)
+		EmitEvent(events, &seq, s.Task.Session.ID, s.Task.Session.ID, launcherevents.KindTurnCompleted, launcherevents.TurnCompletedPayload{TurnID: s.Task.Session.ID, Status: "interrupted"}, nil)
+		result := &Result{ExitCode: -1, Stdout: stdoutBuf.String(), Stderr: string(stderrBytes), Duration: duration}
+		return result, fmt.Errorf("runtime: %s: cancelled: %w", s.RuntimeName, ctx.Err())
+	}
+	if streamErr != nil {
+		infra := &Result{ExitCode: -1, Stdout: stdoutBuf.String(), Stderr: string(stderrBytes), Duration: duration, Meta: map[string]string{}}
+		MarkInfraFailure(infra, "supervisor stream read error")
+		return infra, fmt.Errorf("runtime: %s: stream: %w", s.RuntimeName, streamErr)
+	}
+	if status.ExitCode != nil {
+		exitCode = *status.ExitCode
+	}
+
+	statusName := "ok"
+	if exitCode != 0 {
+		statusName = "error"
+	}
+
+	meta := ParseMeta(stdoutBuf.String())
 	var sessionPath string
 	if s.FindSession != nil {
 		sessionPath = s.FindSession(s.SessionLookupPath())
 	}
 	if handle := s.Task.SessionHandle(); handle != nil {
-		_ = handle.WriteStdout(stdout.Bytes())
-		if stderr.Len() > 0 {
-			_ = handle.WriteStderr(stderr.Bytes())
+		_ = handle.WriteStdout(stdoutBuf.Bytes())
+		if len(stderrBytes) > 0 {
+			_ = handle.WriteStderr(stderrBytes)
 		}
 	}
-	if stderr.Len() > 0 {
-		EmitEvent(events, &seq, s.Task.Session.ID, s.Task.Session.ID, launcherevents.KindLog, launcherevents.LogPayload{Stream: "stderr", Line: strings.TrimRight(stderr.String(), "\n")}, nil)
+	if len(stderrBytes) > 0 {
+		EmitEvent(events, &seq, s.Task.Session.ID, s.Task.Session.ID, launcherevents.KindLog, launcherevents.LogPayload{Stream: "stderr", Line: strings.TrimRight(string(stderrBytes), "\n")}, nil)
 	}
 
-	result := &Result{ExitCode: exitCode, Stdout: stdout.String(), Stderr: stderr.String(), Duration: duration, Meta: meta, SessionPath: sessionPath}
-	if exitCode != 0 && strings.TrimSpace(stdout.String()) == "" && StderrLooksLikeRuntimePanic(stderr.String()) {
+	result := &Result{ExitCode: exitCode, Stdout: stdoutBuf.String(), Stderr: string(stderrBytes), Duration: duration, Meta: meta, SessionPath: sessionPath}
+	if exitCode != 0 && strings.TrimSpace(stdoutBuf.String()) == "" && StderrLooksLikeRuntimePanic(string(stderrBytes)) {
 		MarkInfraFailure(result, "runtime panic/abort before agent output")
 	}
 	if err := ValidateOutputContract(s.Agent, result); err != nil {
 		EmitOutputContractFailure(events, &seq, s.Task.Session.ID, s.Task.Session.ID, err, EmitEvent)
 		return result, err
 	}
-	EmitEvent(events, &seq, s.Task.Session.ID, s.Task.Session.ID, launcherevents.KindTurnCompleted, launcherevents.TurnCompletedPayload{TurnID: s.Task.Session.ID, Status: status}, nil)
+	EmitEvent(events, &seq, s.Task.Session.ID, s.Task.Session.ID, launcherevents.KindTurnCompleted, launcherevents.TurnCompletedPayload{TurnID: s.Task.Session.ID, Status: statusName}, nil)
 	return result, nil
 }
 
-func (s *ProcessSession) BuildCommand(execCtx context.Context) (*exec.Cmd, error) {
+// watchCancel observes execCtx and, on cancellation/deadline, sends Cancel to
+// the supervisor so the subprocess is signalled; doneCh closes when the
+// caller is finished and we should stop watching.
+func (s *ProcessSession) watchCancel(execCtx context.Context, agentID string, doneCh <-chan struct{}) {
+	select {
+	case <-execCtx.Done():
+		// Use a fresh context for the cancel call so the cancel itself
+		// isn't aborted by the very ctx we're reacting to.
+		cancelCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_ = s.Client.Cancel(cancelCtx, agentID)
+		cancel()
+	case <-doneCh:
+	}
+}
+
+// startRequestFor packages the spec + task env/workdir into an IPC request.
+func (s *ProcessSession) startRequestFor(spec *CommandSpec) supervisor.StartAgentRequest {
+	envSlice := BuildScopedEnv(s.Agent, s.Task)
+	envMap := make(map[string]string, len(envSlice))
+	for _, kv := range envSlice {
+		eq := strings.IndexByte(kv, '=')
+		if eq < 0 {
+			continue
+		}
+		envMap[kv[:eq]] = kv[eq+1:]
+	}
+	workdir := ""
+	if s.Task != nil && s.Task.WorkDir != "" {
+		workdir = s.Task.WorkDir
+	}
+	sessionID := ""
+	if s.Task != nil {
+		sessionID = s.Task.Session.ID
+	}
+	return supervisor.StartAgentRequest{
+		Runtime:   spec.Binary,
+		Args:      append([]string{}, spec.Args...),
+		Workdir:   workdir,
+		Env:       envMap,
+		SessionID: sessionID,
+		Stdin:     spec.Stdin,
+	}
+}
+
+// BuildSpec is the IPC-shaped replacement for the previous BuildCommand:
+// it returns the binary, argv, and optional stdin to hand to the supervisor.
+func (s *ProcessSession) BuildSpec() (*CommandSpec, error) {
 	if IsClaudeRuntime(s.RuntimeName) && strings.TrimSpace(s.Agent.Prompt) != "" {
 		prompt, err := RenderAgentPrompt(s.Agent.Prompt, s.Task)
 		if err != nil {
 			return nil, err
 		}
-		return NewClaudePromptCommand(execCtx, prompt, nil, s.Agent.Policy), nil
+		return claudePromptSpec(prompt, nil, s.Agent.Policy), nil
 	}
 
 	rendered, err := RenderCommand(s.Agent.Command, s.Task)
@@ -145,13 +246,16 @@ func (s *ProcessSession) BuildCommand(execCtx context.Context) (*exec.Cmd, error
 				return nil, rawErr
 			}
 			rawPrompt, _, _ := ExtractPrompt(rawRendered)
-			return NewClaudePromptCommand(execCtx, rawPrompt, args, s.Agent.Policy), nil
+			return claudePromptSpec(rawPrompt, args, s.Agent.Policy), nil
 		}
 	}
-	return exec.CommandContext(execCtx, "sh", "-c", rendered), nil
+	return &CommandSpec{Binary: "sh", Args: []string{"-c", rendered}}, nil
 }
 
-func NewClaudePromptCommand(execCtx context.Context, prompt string, extraArgs []string, policy config.PolicyConfig) *exec.Cmd {
+// claudePromptSpec mirrors the argument list the previous exec.Cmd path built
+// for `claude --print --output-format stream-json --verbose` invocations,
+// reading the prompt from stdin.
+func claudePromptSpec(prompt string, extraArgs []string, policy config.PolicyConfig) *CommandSpec {
 	args := append([]string{}, extraArgs...)
 	args = append(args, ClaudePolicyArgs(policy)...)
 	if !HasPrintFlag(args) {
@@ -161,9 +265,7 @@ func NewClaudePromptCommand(execCtx context.Context, prompt string, extraArgs []
 	if !HasVerboseFlag(args) {
 		args = append(args, "--verbose")
 	}
-	cmd := exec.CommandContext(execCtx, "claude", args...)
-	cmd.Stdin = strings.NewReader(prompt)
-	return cmd
+	return &CommandSpec{Binary: "claude", Args: args, Stdin: prompt}
 }
 
 func HasPrintFlag(args []string) bool {
@@ -221,3 +323,45 @@ func (s *ProcessSession) SessionLookupPath() string {
 func (s *ProcessSession) SetApprover(Approver) error { return ErrNotSupported }
 
 func (s *ProcessSession) Close() error { return nil }
+
+// collectStdoutLines streams the supervisor SSE feed and accumulates each
+// line, separated by '\n', into the returned buffer. The optional onLine
+// callback receives each line for callers (claude_stream) that need to map
+// events on the fly. Returns whatever was collected even on error.
+func collectStdoutLines(ctx context.Context, client *supclient.Client, agentID string, onLine func(supclient.StreamEvent) error) (bytes.Buffer, error) {
+	var buf bytes.Buffer
+	err := client.StreamEvents(ctx, agentID, 0, func(ev supclient.StreamEvent) error {
+		buf.WriteString(ev.Line)
+		buf.WriteByte('\n')
+		if onLine != nil {
+			return onLine(ev)
+		}
+		return nil
+	})
+	return buf, err
+}
+
+func readFileIfExists(path string) []byte {
+	if path == "" {
+		return nil
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+func isExecStartFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, supclient.ErrAgentNotFound) {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "exec format error") ||
+		strings.Contains(msg, "no such file") ||
+		strings.Contains(msg, "executable file not found") ||
+		strings.Contains(msg, "permission denied")
+}

--- a/internal/runtime/registry.go
+++ b/internal/runtime/registry.go
@@ -8,20 +8,63 @@ import (
 
 	"github.com/Lincyaw/workbuddy/internal/config"
 	launcherevents "github.com/Lincyaw/workbuddy/internal/launcher/events"
+	supclient "github.com/Lincyaw/workbuddy/internal/supervisor/client"
 )
 
 // Registry dispatches agent execution to the appropriate Runtime implementation.
 type Registry struct {
-	runtimes map[string]Runtime
-	manager  *SessionManager
-	starter  func(ctx context.Context, agent *config.AgentConfig, task *TaskContext) (Session, error, bool)
+	runtimes         map[string]Runtime
+	manager          *SessionManager
+	starter          func(ctx context.Context, agent *config.AgentConfig, task *TaskContext) (Session, error, bool)
+	supervisorClient *supclient.Client
+	onAgentStarted   AgentStartedHook
 }
 
 func NewRegistry() *Registry {
 	return &Registry{runtimes: make(map[string]Runtime)}
 }
 
+// SetSupervisorClient configures the IPC client every supervisor-backed
+// runtime (currently the claude family) uses to launch and observe agent
+// subprocesses. Must be called before the first Start. Re-applies to any
+// already-registered ClaudeRuntime so registration order does not matter.
+func (l *Registry) SetSupervisorClient(c *supclient.Client) {
+	l.supervisorClient = c
+	for _, rt := range l.runtimes {
+		if cr, ok := rt.(*ClaudeRuntime); ok {
+			cr.SupervisorClient = c
+		}
+	}
+}
+
+// SetAgentStartedHook installs a callback fired exactly once after the
+// supervisor returns an agent_id for a session — the worker uses this to
+// persist task_queue.supervisor_agent_id so a worker restart can adopt the
+// running agent without orphaning it.
+func (l *Registry) SetAgentStartedHook(h AgentStartedHook) {
+	l.onAgentStarted = h
+	for _, rt := range l.runtimes {
+		if cr, ok := rt.(*ClaudeRuntime); ok {
+			cr.OnAgentStarted = h
+		}
+	}
+}
+
+// SupervisorClient returns the configured client (nil before SetSupervisorClient).
+func (l *Registry) SupervisorClient() *supclient.Client { return l.supervisorClient }
+
+// OnAgentStarted returns the configured hook (may be nil).
+func (l *Registry) OnAgentStarted() AgentStartedHook { return l.onAgentStarted }
+
 func (l *Registry) Register(rt Runtime, aliases ...string) {
+	if cr, ok := rt.(*ClaudeRuntime); ok {
+		if cr.SupervisorClient == nil {
+			cr.SupervisorClient = l.supervisorClient
+		}
+		if cr.OnAgentStarted == nil {
+			cr.OnAgentStarted = l.onAgentStarted
+		}
+	}
 	l.runtimes[rt.Name()] = rt
 	for _, alias := range aliases {
 		l.runtimes[alias] = rt

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -231,6 +231,12 @@ type StartAgentRequest struct {
 	Workdir   string            `json:"workdir,omitempty"`
 	Env       map[string]string `json:"env,omitempty"`
 	SessionID string            `json:"session_id,omitempty"`
+	// Stdin, when non-empty, is fed to the child process's stdin. The
+	// supervisor closes stdin once the bytes are drained so callers don't
+	// need to send EOF separately. This is required by the workbuddy
+	// claude runtime, which passes the rendered prompt over stdin instead
+	// of as an argument to avoid shell-metachar concerns.
+	Stdin string `json:"stdin,omitempty"`
 }
 
 // StartAgentResponse is returned by POST /agents.
@@ -241,14 +247,16 @@ type StartAgentResponse struct {
 
 // AgentStatus is the response shape for GET /agents/:id.
 type AgentStatus struct {
-	AgentID   string    `json:"agent_id"`
-	Status    string    `json:"status"`
-	ExitCode  *int      `json:"exit_code,omitempty"`
-	SessionID string    `json:"session_id"`
-	PID       int       `json:"pid"`
-	Runtime   string    `json:"runtime,omitempty"`
-	Workdir   string    `json:"workdir,omitempty"`
-	StartedAt time.Time `json:"started_at"`
+	AgentID    string    `json:"agent_id"`
+	Status     string    `json:"status"`
+	ExitCode   *int      `json:"exit_code,omitempty"`
+	SessionID  string    `json:"session_id"`
+	PID        int       `json:"pid"`
+	Runtime    string    `json:"runtime,omitempty"`
+	Workdir    string    `json:"workdir,omitempty"`
+	StartedAt  time.Time `json:"started_at"`
+	StdoutPath string    `json:"stdout_path,omitempty"`
+	StderrPath string    `json:"stderr_path,omitempty"`
 }
 
 // StartAgent launches a new subprocess. The runtime+args are exec'd as-is;
@@ -276,6 +284,9 @@ func (s *Supervisor) StartAgent(req StartAgentRequest) (*Agent, error) {
 	cmd.Dir = req.Workdir
 	cmd.Stdout = stdoutF
 	cmd.Stderr = stderrF
+	if req.Stdin != "" {
+		cmd.Stdin = strings.NewReader(req.Stdin)
+	}
 	if len(req.Env) > 0 {
 		envv := os.Environ()
 		for k, v := range req.Env {
@@ -367,14 +378,16 @@ func (s *Supervisor) Status(id string) (AgentStatus, bool) {
 	}
 	status, exitCode := a.snapshotStatus()
 	return AgentStatus{
-		AgentID:   a.ID,
-		Status:    status,
-		ExitCode:  exitCode,
-		SessionID: a.SessionID,
-		PID:       a.pid,
-		Runtime:   a.Runtime,
-		Workdir:   a.Workdir,
-		StartedAt: a.StartedAt,
+		AgentID:    a.ID,
+		Status:     status,
+		ExitCode:   exitCode,
+		SessionID:  a.SessionID,
+		PID:        a.pid,
+		Runtime:    a.Runtime,
+		Workdir:    a.Workdir,
+		StartedAt:  a.StartedAt,
+		StdoutPath: a.StdoutPath,
+		StderrPath: a.StderrPath,
 	}, true
 }
 
@@ -389,6 +402,7 @@ func (s *Supervisor) List() []AgentStatus {
 			AgentID: a.ID, Status: status, ExitCode: exitCode,
 			SessionID: a.SessionID, PID: a.pid, Runtime: a.Runtime,
 			Workdir: a.Workdir, StartedAt: a.StartedAt,
+			StdoutPath: a.StdoutPath, StderrPath: a.StderrPath,
 		})
 	}
 	return out

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -3287,8 +3287,22 @@ requirements:
       - internal/supervisor/supervisor.go
       - internal/store/store.go
       - internal/store/types.go
+      - internal/runtime/process.go
+      - internal/runtime/claude_stream.go
+      - internal/runtime/claude.go
+      - internal/runtime/registry.go
+      - internal/launcher/launcher.go
+      - internal/launcher/supervisor_inproc.go
+      - cmd/worker.go
+      - cmd/run.go
     tests:
       - internal/supervisor/client/client_test.go
       - internal/store/store_supervisor_agent_id_test.go
+      - internal/launcher/launcher_test.go
+      - internal/launcher/process_test.go
+      - internal/launcher/claude_stream_test.go
+      - internal/launcher/permissions_test.go
+      - internal/launcher/test_helper_test.go
+      - internal/launcher/supervisor_ipc_test.go
     deps:
       - REQ-092


### PR DESCRIPTION
Fixes #244.

Phase 1.2 of the supervisor migration (#224 / Option A): swap the worker's exec.Cmd-based ProcessSession launch path for the supervisor IPC client landed by #240, so a worker process exit no longer drags the agent subprocess down with it.

## Summary

- `internal/runtime/process.go::Run` and `internal/runtime/claude_stream.go::runClaudeStream` no longer use `exec.Cmd`. Both now POST `/agents`, immediately fire `OnAgentStarted(taskID, agentID)` so the worker persists `task_queue.supervisor_agent_id` (#240's `Store.UpdateTaskSupervisorAgentID`), and consume stdout via the supervisor's `/agents/:id/events` SSE stream.
- `ClaudeStreamEventMapper` is **unchanged** — SSE lines are fed straight in.
- The previous exec.Cmd path is **deleted**, not parallel-implemented (per the no-parallel-implementations rule).

## Supervisor IPC additions

Two narrow extensions needed by the worker, both backwards compatible:

- `StartAgentRequest.Stdin` — claude reads its prompt from stdin (existing exec.Cmd behavior).
- `AgentStatus.StdoutPath` / `AgentStatus.StderrPath` — SSE only emits newline-terminated lines, so post-exit reads need the file paths to capture trailing partial output and full stderr.

## Worker / serve / run wiring

- `launcher.NewLauncher(client, hook)` is the new required signature.
- `cmd/worker` dials the configured `--supervisor-socket` (default `$XDG_RUNTIME_DIR/workbuddy-supervisor.sock`) and falls back to an in-process supervisor when no socket exists, so `workbuddy serve` and tests don't need a separate `workbuddy supervisor` process.
- `cmd/run` starts an in-process supervisor for the duration of the one-shot command.
- `internal/launcher/supervisor_inproc.go` exposes `NewInProcessSupervisor(stateDir, grace)` for both fallback paths.

## Tests

- `internal/launcher/*` migrated to a per-test in-process supervisor (`newTestLauncher(t)`, `newTestProcessSession(t, ...)`).
- New `internal/launcher/supervisor_ipc_test.go` pins the routing contract:
  - `TestProcessSessionRun_RoutesThroughSupervisor` — IPC path is used end-to-end and `OnAgentStarted` is invoked once with the supervisor's agent_id.
  - `TestProcessSessionRun_PassesPromptViaSupervisorStdin` — prompt flows over `StartAgentRequest.Stdin`.
  - `TestProcessSession_NoClientFailsLoudly` — nil client is an explicit error, no silent exec.Cmd fallback.

## Out of scope (per #244 scope)

- Worker resume / claim renewal protocol — Phase 2 (#234b).
- codex `agent_bridge.go` migration — separate runtime.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1` — all green
- [x] `golangci-lint run --new-from-rev=45a985d ./...` — 0 new issues
- [x] `go run . validate-docs --strict`
- [x] `python3 ~/.autoharness/scripts/validate_index.py project-index.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)