### PR TITLE
worker: refresh last_heartbeat on re-registration and every poll (#252)

### DIFF
--- a/internal/app/coordinator.go
+++ b/internal/app/coordinator.go
@@ -412,6 +412,9 @@ func (s *FullCoordinatorServer) HandlePollTask(w http.ResponseWriter, r *http.Re
 		CoordWriteJSON(w, http.StatusBadRequest, map[string]string{"error": "unknown worker"})
 		return
 	}
+	// Every poll counts as a liveness signal — bump heartbeat up front so an
+	// idle worker (no task to claim) doesn't get flagged as missing.
+	_ = s.Registry.Heartbeat(worker.ID)
 
 	deadline := time.NewTimer(timeout)
 	defer deadline.Stop()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1086,7 +1086,8 @@ func (s *Store) InsertWorker(w WorkerRecord) error {
 		 roles = excluded.roles,
 		 hostname = excluded.hostname,
 		 mgmt_base_url = excluded.mgmt_base_url,
-		 status = excluded.status`,
+		 status = excluded.status,
+		 last_heartbeat = CURRENT_TIMESTAMP`,
 		w.ID, w.Repo, w.ReposJSON, w.Roles, w.Hostname, w.MgmtBaseURL, w.Status,
 	)
 	if err != nil {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -894,6 +894,38 @@ func TestDeleteWorker(t *testing.T) {
 	}
 }
 
+func TestInsertWorkerReRegistrationBumpsHeartbeat(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.InsertWorker(WorkerRecord{ID: "w-rr", Repo: "org/repo", Roles: `["dev"]`, Hostname: "h1", Status: "online"}); err != nil {
+		t.Fatalf("InsertWorker initial: %v", err)
+	}
+	first, err := s.GetWorker("w-rr")
+	if err != nil || first == nil {
+		t.Fatalf("GetWorker initial: %v %+v", err, first)
+	}
+
+	// Force a stale heartbeat so we can prove re-registration refreshes it.
+	if _, err := s.DB().Exec(`UPDATE workers SET last_heartbeat = datetime('now', '-1 hour') WHERE id = 'w-rr'`); err != nil {
+		t.Fatalf("force stale heartbeat: %v", err)
+	}
+	stale, err := s.GetWorker("w-rr")
+	if err != nil || stale == nil {
+		t.Fatalf("GetWorker stale: %v %+v", err, stale)
+	}
+
+	if err := s.InsertWorker(WorkerRecord{ID: "w-rr", Repo: "org/repo", Roles: `["dev"]`, Hostname: "h1", Status: "online"}); err != nil {
+		t.Fatalf("InsertWorker re-register: %v", err)
+	}
+	after, err := s.GetWorker("w-rr")
+	if err != nil || after == nil {
+		t.Fatalf("GetWorker after: %v %+v", err, after)
+	}
+	if !after.LastHeartbeat.After(stale.LastHeartbeat) {
+		t.Fatalf("expected last_heartbeat to advance after re-registration; stale=%v after=%v", stale.LastHeartbeat, after.LastHeartbeat)
+	}
+}
+
 func TestWorkerHasRunningTask(t *testing.T) {
 	s := newTestStore(t)
 

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -3483,6 +3483,7 @@ requirements:
       - "AC-100-1: `Store.InsertWorker` ON CONFLICT updates `last_heartbeat = CURRENT_TIMESTAMP` so re-registration on restart counts as a heartbeat."
       - "AC-100-2: `HandlePollTask` calls `Registry.Heartbeat` on every poll (not only when a task is returned), so an idle worker's heartbeat refreshes at the long-poll cadence."
       - "AC-100-3: Unit test asserts that a stale heartbeat advances after re-registration."
+    priority: P1
     code:
       - internal/store/store.go
       - internal/app/coordinator.go

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -3464,3 +3464,28 @@ requirements:
       - web/src/lib/streamMessages.test.ts
       - web/src/components/StreamMessage.test.tsx
     deps: [REQ-093]
+
+  - id: REQ-100
+    title: worker idle/restart heartbeat refresh
+    description: >
+      Workers must show a fresh `last_heartbeat` after coordinator restart and
+      while idle. Pre-fix, `Store.InsertWorker` re-registration kept the old
+      `last_heartbeat` and `HandlePollTask` only bumped on successful task
+      claim, so an embedded `serve` deployment or any worker without traffic
+      tripped continuous `worker_missing` alerts even though the process was
+      alive.
+    rationale: >
+      Surfaced while observing #250 dispatch on a freshly-deployed v0.5.0
+      build (#252). Stale heartbeat made dashboards mislead operators and
+      prevented a clean diagnostic baseline.
+    status: tested
+    acceptance:
+      - "AC-100-1: `Store.InsertWorker` ON CONFLICT updates `last_heartbeat = CURRENT_TIMESTAMP` so re-registration on restart counts as a heartbeat."
+      - "AC-100-2: `HandlePollTask` calls `Registry.Heartbeat` on every poll (not only when a task is returned), so an idle worker's heartbeat refreshes at the long-poll cadence."
+      - "AC-100-3: Unit test asserts that a stale heartbeat advances after re-registration."
+    code:
+      - internal/store/store.go
+      - internal/app/coordinator.go
+    tests:
+      - internal/store/store_test.go
+    deps: []


### PR DESCRIPTION
Closes #252.

## Summary
- `Store.InsertWorker` ON CONFLICT now updates `last_heartbeat = CURRENT_TIMESTAMP`, so a coordinator restart re-registering the same worker ID counts as a fresh heartbeat instead of inheriting the stale one.
- `HandlePollTask` now bumps `Registry.Heartbeat` on every poll (not only when a task is returned), so idle workers no longer trip `worker_missing` alerts.

## Test plan
- [x] `go test ./internal/store/... -run TestInsertWorkerReRegistrationBumpsHeartbeat -v`
- [x] Manual: deploy fresh build, observe `workers.last_heartbeat` advances within seconds of `systemctl restart` and stays fresh while no tasks are queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)