### PR TITLE
web: aggregate /sessions by issue with cycle/role (#251)

### DIFF
--- a/project-index.yaml
+++ b/project-index.yaml
@@ -3101,10 +3101,12 @@ requirements:
       - web/src/lib/format.ts
       - web/src/pages/Sessions.tsx
       - web/src/pages/SessionDetail.tsx
+      - web/src/utils/sessionGroups.ts
     tests:
       - internal/webui/handler_test.go
       - internal/auditapi/handler_test.go
       - cmd/coordinator_sessions_spa_test.go
+      - web/src/utils/sessionGroups.test.ts
     deps: [REQ-089]
 
   - id: REQ-092

--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "node --test --experimental-strip-types 'src/**/*.test.ts'"
+    "test": "vitest run"
   },
   "dependencies": {
     "preact": "^10.25.0",
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "vite": "^6.0.0",
+    "vitest": "^2.1.0",
     "typescript": "^5.7.0",
     "@types/node": "^22.10.0"
   }

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -27,8 +27,17 @@ importers:
       vite:
         specifier: ^6.0.0
         version: 6.4.2(@types/node@22.19.17)
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.19.17)
 
 packages:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -36,10 +45,22 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.12':
@@ -48,16 +69,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.12':
@@ -66,10 +105,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -78,10 +129,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.12':
@@ -90,10 +153,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.12':
@@ -102,10 +177,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -114,16 +201,34 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.12':
@@ -138,6 +243,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
@@ -148,6 +259,12 @@ packages:
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -162,16 +279,34 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-ia32@0.25.12':
@@ -180,11 +315,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
   '@preact/signals-core@1.14.1':
     resolution: {integrity: sha512-vxPpfXqrwUe9lpjqfYNjAF/0RF/eFGeLgdJzdmIIZjpOnTmGmAB4BjWone562mJGMRP4frU6iZ6ei3PDsu52Ng==}
@@ -325,10 +469,83 @@ packages:
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -344,10 +561,26 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -379,13 +612,40 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -394,6 +654,42 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
 
   vite@6.4.2:
     resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
@@ -435,54 +731,135 @@ packages:
       yaml:
         optional: true
 
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
 snapshots:
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
     optional: true
 
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
   '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
     optional: true
 
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
     optional: true
 
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
@@ -491,10 +868,16 @@ snapshots:
   '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -503,17 +886,31 @@ snapshots:
   '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
     optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@preact/signals-core@1.14.1': {}
 
@@ -603,6 +1000,94 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.17))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.19.17)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
+  assertion-error@2.0.1: {}
+
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
   esbuild@0.25.12:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.25.12
@@ -632,6 +1117,12 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -639,7 +1130,19 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  ms@2.1.3: {}
+
   nanoid@3.3.11: {}
+
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -693,16 +1196,59 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
 
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
+
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  vite-node@2.1.9(@types/node@22.19.17):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.19.17)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@22.19.17):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.12
+      rollup: 4.60.2
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3
 
   vite@6.4.2(@types/node@22.19.17):
     dependencies:
@@ -715,3 +1261,43 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.17
       fsevents: 2.3.3
+
+  vitest@2.1.9(@types/node@22.19.17):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.17))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@22.19.17)
+      vite-node: 2.1.9(@types/node@22.19.17)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2

--- a/web/src/pages/Sessions.tsx
+++ b/web/src/pages/Sessions.tsx
@@ -7,21 +7,35 @@ import {
   type SessionListQuery,
 } from '../api/sessions';
 import { copyText, formatTimestamp, shortID, statusBadgeClass } from '../lib/format';
+import {
+  distinctValues,
+  groupSessionsByIssue,
+  type DecoratedSession,
+} from '../utils/sessionGroups';
 
 const PAGE_LIMIT = 50;
+
+type ViewMode = 'grouped' | 'flat';
+type SortMode = 'recent' | 'issue';
 
 interface FilterState {
   repo: string;
   agent: string;
   issue: string;
+  view: ViewMode;
+  sort: SortMode;
   offset: number;
 }
 
 function parseQuery(query: Record<string, string>): FilterState {
+  const view = query.view === 'flat' ? 'flat' : 'grouped';
+  const sort = query.sort === 'issue' ? 'issue' : 'recent';
   return {
     repo: query.repo || '',
     agent: query.agent || '',
     issue: query.issue || '',
+    view,
+    sort,
     offset: parseInt(query.offset || '0', 10) || 0,
   };
 }
@@ -31,6 +45,8 @@ function buildSearch(filter: FilterState): string {
   if (filter.repo) sp.set('repo', filter.repo);
   if (filter.agent) sp.set('agent', filter.agent);
   if (filter.issue) sp.set('issue', filter.issue);
+  if (filter.view !== 'grouped') sp.set('view', filter.view);
+  if (filter.sort !== 'recent') sp.set('sort', filter.sort);
   if (filter.offset > 0) sp.set('offset', String(filter.offset));
   const s = sp.toString();
   return s ? `?${s}` : '';
@@ -42,12 +58,12 @@ export function Sessions() {
   const [sessions, setSessions] = useState<SessionListItem[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-  // Local form state — mirrors filter but applies on submit, not on each keystroke.
   const [form, setForm] = useState({
     repo: filter.repo,
     agent: filter.agent,
     issue: filter.issue,
   });
+  const [collapsed, setCollapsed] = useState<Record<number, boolean>>({});
 
   useEffect(() => {
     setForm({ repo: filter.repo, agent: filter.agent, issue: filter.issue });
@@ -88,21 +104,33 @@ export function Sessions() {
 
   function applyFilters(e: Event) {
     e.preventDefault();
-    navigate({ ...form, offset: 0 });
+    navigate({ ...filter, ...form, offset: 0 });
   }
 
   function resetFilters() {
     setForm({ repo: '', agent: '', issue: '' });
-    navigate({ repo: '', agent: '', issue: '', offset: 0 });
+    navigate({ ...filter, repo: '', agent: '', issue: '', offset: 0 });
   }
 
   function gotoOffset(offset: number) {
     navigate({ ...filter, offset });
   }
 
+  function setView(view: ViewMode) {
+    navigate({ ...filter, view });
+  }
+
+  function setSort(sort: SortMode) {
+    navigate({ ...filter, sort });
+  }
+
   function rowClick(id: string, e: MouseEvent) {
     if ((e.target as HTMLElement).closest('.id-copy')) return;
     location.route(`/sessions/${encodeURIComponent(id)}`);
+  }
+
+  function toggleGroup(issueNum: number) {
+    setCollapsed((prev) => ({ ...prev, [issueNum]: !prev[issueNum] }));
   }
 
   const rows = sessions || [];
@@ -111,24 +139,50 @@ export function Sessions() {
   const pageStart = filter.offset + 1;
   const pageEnd = filter.offset + rows.length;
 
+  // Distinct values for the dropdown filters. We only see the current page,
+  // so the dropdowns are an aid — the text input is preserved as fallback
+  // for values that haven't surfaced on this page yet.
+  const repoOptions = useMemo(() => distinctValues(rows, (s) => s.repo), [rows]);
+  const agentOptions = useMemo(() => distinctValues(rows, (s) => s.agent_name), [rows]);
+
+  const groups = useMemo(() => {
+    const g = groupSessionsByIssue(rows);
+    if (filter.sort === 'issue') {
+      return [...g].sort((a, b) => b.issueNum - a.issueNum);
+    }
+    return g;
+  }, [rows, filter.sort]);
+
   return (
     <Layout>
       <h1 style={{ fontSize: 22, marginBottom: 12 }}>Agent Sessions</h1>
 
       <form class="wb-filters" onSubmit={applyFilters}>
         <input
+          list="wb-repo-options"
           type="text"
           placeholder="Repo (owner/name)"
           value={form.repo}
           onInput={(e) => setForm({ ...form, repo: (e.target as HTMLInputElement).value })}
           style={{ minWidth: 220 }}
         />
+        <datalist id="wb-repo-options">
+          {repoOptions.map((r) => (
+            <option key={r} value={r} />
+          ))}
+        </datalist>
         <input
+          list="wb-agent-options"
           type="text"
           placeholder="Agent name"
           value={form.agent}
           onInput={(e) => setForm({ ...form, agent: (e.target as HTMLInputElement).value })}
         />
+        <datalist id="wb-agent-options">
+          {agentOptions.map((a) => (
+            <option key={a} value={a} />
+          ))}
+        </datalist>
         <input
           type="text"
           placeholder="Issue #"
@@ -140,6 +194,25 @@ export function Sessions() {
         {(filter.repo || filter.agent || filter.issue) && (
           <button type="button" onClick={resetFilters}>Reset</button>
         )}
+
+        <span style={{ flex: 1 }} />
+
+        <select
+          value={filter.view}
+          onChange={(e) => setView((e.target as HTMLSelectElement).value as ViewMode)}
+          title="View mode"
+        >
+          <option value="grouped">Grouped by issue</option>
+          <option value="flat">Flat list</option>
+        </select>
+        <select
+          value={filter.sort}
+          onChange={(e) => setSort((e.target as HTMLSelectElement).value as SortMode)}
+          title="Sort"
+        >
+          <option value="recent">Most recent first</option>
+          <option value="issue">Issue # (desc)</option>
+        </select>
       </form>
 
       {error && <div class="wb-error">Failed to load sessions: {error}</div>}
@@ -148,53 +221,30 @@ export function Sessions() {
         <div class="wb-loading">Loading sessions…</div>
       ) : rows.length === 0 ? (
         <div class="wb-empty">No sessions found.</div>
+      ) : filter.view === 'flat' ? (
+        <FlatTable rows={rows} onRowClick={rowClick} />
       ) : (
-        <table class="wb-table">
-          <thead>
-            <tr>
-              <th>Session ID</th>
-              <th>Agent</th>
-              <th>Repo</th>
-              <th>Issue</th>
-              <th>Status</th>
-              <th>Created</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((s) => (
-              <tr
-                key={s.session_id}
-                onClick={(e) => rowClick(s.session_id, e as unknown as MouseEvent)}
+        groups.map((g) => {
+          const isCollapsed = !!collapsed[g.issueNum];
+          return (
+            <div class="wb-session-group" key={g.issueNum}>
+              <button
+                type="button"
+                class="wb-session-group-header"
+                onClick={() => toggleGroup(g.issueNum)}
+                aria-expanded={!isCollapsed}
               >
-                <td>
-                  <span class="id-cell">
-                    <code>{shortID(s.session_id, 16)}</code>
-                    <button
-                      type="button"
-                      class="id-copy"
-                      title="Copy full session ID"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        copyText(s.session_id);
-                      }}
-                    >
-                      copy
-                    </button>
-                  </span>
-                </td>
-                <td>{s.agent_name}</td>
-                <td>{s.repo}</td>
-                <td>#{s.issue_num}</td>
-                <td>
-                  <span class={statusBadgeClass(s.task_status || s.status)}>
-                    {s.task_status || s.status || 'unknown'}
-                  </span>
-                </td>
-                <td>{formatTimestamp(s.created_at)}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+                <span class="caret">{isCollapsed ? '▶' : '▼'}</span>
+                <span class="issue-num">#{g.issueNum}</span>
+                <span class="repo">{g.repo}</span>
+                <span class="count">{g.sessions.length} session{g.sessions.length === 1 ? '' : 's'}</span>
+              </button>
+              {!isCollapsed && (
+                <GroupedTable rows={g.sessions} onRowClick={rowClick} />
+              )}
+            </div>
+          );
+        })
       )}
 
       <div class="wb-pager">
@@ -211,6 +261,104 @@ export function Sessions() {
         )}
       </div>
     </Layout>
+  );
+}
+
+function IDCell({ id }: { id: string }) {
+  return (
+    <span class="id-cell">
+      <code>{shortID(id, 16)}</code>
+      <button
+        type="button"
+        class="id-copy"
+        title="Copy full session ID"
+        onClick={(e) => {
+          e.stopPropagation();
+          copyText(id);
+        }}
+      >
+        copy
+      </button>
+    </span>
+  );
+}
+
+function FlatTable({
+  rows,
+  onRowClick,
+}: {
+  rows: SessionListItem[];
+  onRowClick: (id: string, e: MouseEvent) => void;
+}) {
+  return (
+    <table class="wb-table">
+      <thead>
+        <tr>
+          <th>Session ID</th>
+          <th>Agent</th>
+          <th>Repo</th>
+          <th>Issue</th>
+          <th>Status</th>
+          <th>Created</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((s) => (
+          <tr key={s.session_id} onClick={(e) => onRowClick(s.session_id, e as unknown as MouseEvent)}>
+            <td><IDCell id={s.session_id} /></td>
+            <td>{s.agent_name}</td>
+            <td>{s.repo}</td>
+            <td>#{s.issue_num}</td>
+            <td>
+              <span class={statusBadgeClass(s.task_status || s.status)}>
+                {s.task_status || s.status || 'unknown'}
+              </span>
+            </td>
+            <td>{formatTimestamp(s.created_at)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function GroupedTable({
+  rows,
+  onRowClick,
+}: {
+  rows: DecoratedSession[];
+  onRowClick: (id: string, e: MouseEvent) => void;
+}) {
+  return (
+    <table class="wb-table">
+      <thead>
+        <tr>
+          <th>Session ID</th>
+          <th>Role / Cycle</th>
+          <th>Agent</th>
+          <th>Status</th>
+          <th>Created</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((s) => (
+          <tr key={s.session_id} onClick={(e) => onRowClick(s.session_id, e as unknown as MouseEvent)}>
+            <td><IDCell id={s.session_id} /></td>
+            <td>
+              <span class={`wb-role-badge wb-role-${s.role}`}>{s.role}</span>
+              <span class="wb-cycle">cycle {s.cycle}</span>
+            </td>
+            <td>{s.agent_name}</td>
+            <td>
+              <span class={statusBadgeClass(s.task_status || s.status)}>
+                {s.task_status || s.status || 'unknown'}
+              </span>
+            </td>
+            <td>{formatTimestamp(s.created_at)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
   );
 }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -619,3 +619,53 @@ table.clickable tbody tr:hover {
   color: #57606a;
 }
 .gh-issue-link-icon:hover { color: #0969da; }
+
+/* Session groups (issue-aggregated /sessions view) */
+.wb-session-group {
+  background: #fff;
+  border: 1px solid #d0d7de;
+  border-radius: 6px;
+  margin-bottom: 10px;
+  overflow: hidden;
+}
+.wb-session-group-header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  background: #f6f8fa;
+  border: 0;
+  cursor: pointer;
+  font-size: 13px;
+  text-align: left;
+}
+.wb-session-group-header:hover { background: #eaeef2; }
+.wb-session-group-header .caret {
+  display: inline-block;
+  width: 12px;
+  color: #57606a;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.wb-session-group-header .issue-num { font-weight: 600; }
+.wb-session-group-header .repo { color: #57606a; }
+.wb-session-group-header .count {
+  margin-left: auto;
+  color: #57606a;
+  font-size: 12px;
+}
+.wb-session-group .wb-table { border: 0; border-radius: 0; }
+.wb-session-group .wb-table th { background: #fff; }
+
+.wb-role-badge {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  margin-right: 6px;
+}
+.wb-role-dev { background: #ddf4ff; color: #0550a0; }
+.wb-role-review { background: #efe2fa; color: #5a32a3; }
+.wb-role-other { background: #eef1f4; color: #57606a; }
+.wb-cycle { color: #57606a; font-size: 12px; }

--- a/web/src/utils/github.test.ts
+++ b/web/src/utils/github.test.ts
@@ -1,6 +1,6 @@
-import { test } from 'node:test';
+import { test } from 'vitest';
 import assert from 'node:assert/strict';
-import { githubIssueURL, githubIssueURLFromSlug, splitRepoSlug } from './github.ts';
+import { githubIssueURL, githubIssueURLFromSlug, splitRepoSlug } from './github';
 
 test('githubIssueURL builds canonical github issue URL', () => {
   assert.equal(

--- a/web/src/utils/sessionGroups.test.ts
+++ b/web/src/utils/sessionGroups.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import type { SessionListItem } from '../api/sessions';
+import {
+  distinctValues,
+  groupSessionsByIssue,
+  inferRole,
+} from './sessionGroups';
+
+function mk(overrides: Partial<SessionListItem>): SessionListItem {
+  return {
+    session_id: 's',
+    repo: 'owner/repo',
+    issue_num: 1,
+    agent_name: 'dev-agent',
+    attempt: 1,
+    status: 'completed',
+    exit_code: 0,
+    duration: 0,
+    created_at: '2026-04-29T10:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('inferRole', () => {
+  it('classifies review agents (priority over dev substring)', () => {
+    expect(inferRole('review-agent')).toBe('review');
+    expect(inferRole('codex-reviewer')).toBe('review');
+    // 'dev-review-bot' includes 'review' so it must land on review.
+    expect(inferRole('dev-review-bot')).toBe('review');
+  });
+  it('classifies dev agents', () => {
+    expect(inferRole('dev-agent')).toBe('dev');
+    expect(inferRole('claude-dev')).toBe('dev');
+  });
+  it('falls back to other', () => {
+    expect(inferRole('docs-bot')).toBe('other');
+    expect(inferRole('')).toBe('other');
+  });
+});
+
+describe('groupSessionsByIssue', () => {
+  it('groups by issue and assigns dev/review cycles in chronological order', () => {
+    const sessions: SessionListItem[] = [
+      mk({ session_id: 'd1', issue_num: 10, agent_name: 'dev-agent', created_at: '2026-04-29T10:00:00Z' }),
+      mk({ session_id: 'r1', issue_num: 10, agent_name: 'review-agent', created_at: '2026-04-29T11:00:00Z' }),
+      mk({ session_id: 'd2', issue_num: 10, agent_name: 'dev-agent', created_at: '2026-04-29T12:00:00Z' }),
+      mk({ session_id: 'r2', issue_num: 10, agent_name: 'review-agent', created_at: '2026-04-29T13:00:00Z' }),
+      mk({ session_id: 'd-other', issue_num: 11, agent_name: 'dev-agent', created_at: '2026-04-29T09:00:00Z' }),
+    ];
+
+    const groups = groupSessionsByIssue(sessions);
+
+    // Issue 10 was active most recently (latest created_at), so first.
+    expect(groups.map((g) => g.issueNum)).toEqual([10, 11]);
+
+    const g10 = groups[0];
+    expect(g10.sessions.map((s) => `${s.role}-c${s.cycle}-${s.session_id}`)).toEqual([
+      'dev-c1-d1',
+      'review-c1-r1',
+      'dev-c2-d2',
+      'review-c2-r2',
+    ]);
+
+    expect(groups[1].sessions).toHaveLength(1);
+    expect(groups[1].sessions[0].role).toBe('dev');
+    expect(groups[1].sessions[0].cycle).toBe(1);
+  });
+
+  it('handles unsorted input and out-of-order cycles', () => {
+    const sessions: SessionListItem[] = [
+      mk({ session_id: 'r2', issue_num: 5, agent_name: 'review-agent', created_at: '2026-04-29T13:00:00Z' }),
+      mk({ session_id: 'd1', issue_num: 5, agent_name: 'dev-agent', created_at: '2026-04-29T10:00:00Z' }),
+      mk({ session_id: 'd2', issue_num: 5, agent_name: 'dev-agent', created_at: '2026-04-29T12:00:00Z' }),
+      mk({ session_id: 'r1', issue_num: 5, agent_name: 'review-agent', created_at: '2026-04-29T11:00:00Z' }),
+    ];
+    const [g] = groupSessionsByIssue(sessions);
+    expect(g.sessions.map((s) => s.session_id)).toEqual(['d1', 'r1', 'd2', 'r2']);
+    expect(g.sessions.map((s) => s.cycle)).toEqual([1, 1, 2, 2]);
+  });
+
+  it('classifies non-dev/review agents as "other" and sorts them last', () => {
+    const sessions: SessionListItem[] = [
+      mk({ session_id: 'x', issue_num: 7, agent_name: 'docs-bot', created_at: '2026-04-29T09:00:00Z' }),
+      mk({ session_id: 'd', issue_num: 7, agent_name: 'dev-agent', created_at: '2026-04-29T10:00:00Z' }),
+    ];
+    const [g] = groupSessionsByIssue(sessions);
+    expect(g.sessions[0].role).toBe('dev');
+    expect(g.sessions[1].role).toBe('other');
+  });
+});
+
+describe('distinctValues', () => {
+  it('returns unique sorted non-empty values', () => {
+    const items = [
+      mk({ repo: 'a/b' }),
+      mk({ repo: 'c/d' }),
+      mk({ repo: 'a/b' }),
+      mk({ repo: '' }),
+    ];
+    expect(distinctValues(items, (s) => s.repo)).toEqual(['a/b', 'c/d']);
+  });
+});

--- a/web/src/utils/sessionGroups.ts
+++ b/web/src/utils/sessionGroups.ts
@@ -1,0 +1,106 @@
+// Group + label session list rows for the /sessions page.
+//
+// Sessions land on the dashboard as a flat list, but the operator's mental
+// model is: "issue → which dev/review pass → which session". This module
+// derives that structure on the client. Backend contract for
+// /api/v1/sessions stays unchanged (per issue #251 non-goal).
+
+import type { SessionListItem } from '../api/sessions';
+
+export type SessionRole = 'dev' | 'review' | 'other';
+
+export interface DecoratedSession extends SessionListItem {
+  role: SessionRole;
+  cycle: number;
+}
+
+export interface SessionGroup {
+  issueNum: number;
+  repo: string;
+  sessions: DecoratedSession[];
+  // Latest createdAt across the group's sessions; used to sort groups.
+  latestCreatedAt: string;
+}
+
+// inferRole maps an agent name to dev/review. Agent names are user-defined,
+// but workbuddy ships exactly two roles (`role:dev`, `role:review`) and the
+// stock catalog uses agent names like `dev-agent` / `review-agent`. We
+// pattern-match on the substring rather than require an exact name so
+// project-specific agent names (e.g. `claude-dev`, `codex-reviewer`) still
+// classify correctly.
+export function inferRole(agentName: string): SessionRole {
+  const n = (agentName || '').toLowerCase();
+  if (n.includes('review')) return 'review';
+  if (n.includes('dev')) return 'dev';
+  return 'other';
+}
+
+function compareCreatedAsc(a: SessionListItem, b: SessionListItem): number {
+  const at = a.created_at || '';
+  const bt = b.created_at || '';
+  if (at === bt) return 0;
+  return at < bt ? -1 : 1;
+}
+
+// groupSessionsByIssue groups sessions by issue_num and labels each session
+// with a (role, cycle) pair derived from chronological order within the
+// group. Cycle counting per role: the Nth session of a given role is cycle
+// N (1-indexed). This matches the operator UI ordering
+// `dev (cycle 1) → review (cycle 1) → dev (cycle 2) → review (cycle 2)`.
+export function groupSessionsByIssue(sessions: SessionListItem[]): SessionGroup[] {
+  const byIssue = new Map<number, SessionListItem[]>();
+  for (const s of sessions) {
+    const arr = byIssue.get(s.issue_num) || [];
+    arr.push(s);
+    byIssue.set(s.issue_num, arr);
+  }
+
+  const groups: SessionGroup[] = [];
+  for (const [issueNum, items] of byIssue) {
+    const sorted = [...items].sort(compareCreatedAsc);
+    const roleCounts: Record<SessionRole, number> = { dev: 0, review: 0, other: 0 };
+    const decorated: DecoratedSession[] = sorted.map((s) => {
+      const role = inferRole(s.agent_name);
+      roleCounts[role] += 1;
+      return { ...s, role, cycle: roleCounts[role] };
+    });
+
+    // Display order: cycle ascending, dev before review within a cycle, then
+    // "other" agents last. Stable on created_at within those keys.
+    const roleOrder: Record<SessionRole, number> = { dev: 0, review: 1, other: 2 };
+    decorated.sort((a, b) => {
+      if (a.cycle !== b.cycle) return a.cycle - b.cycle;
+      if (a.role !== b.role) return roleOrder[a.role] - roleOrder[b.role];
+      return compareCreatedAsc(a, b);
+    });
+
+    const latest = sorted.reduce(
+      (acc, s) => (s.created_at && s.created_at > acc ? s.created_at : acc),
+      sorted[0]?.created_at || '',
+    );
+    groups.push({
+      issueNum,
+      repo: sorted[0]?.repo || '',
+      sessions: decorated,
+      latestCreatedAt: latest,
+    });
+  }
+
+  // Most-recently-active issue first.
+  groups.sort((a, b) => {
+    if (a.latestCreatedAt === b.latestCreatedAt) return b.issueNum - a.issueNum;
+    return a.latestCreatedAt < b.latestCreatedAt ? 1 : -1;
+  });
+  return groups;
+}
+
+// distinctValues collects unique non-empty values for a field across a list,
+// sorted alphabetically. Used to populate the repo/agent filter dropdowns.
+export function distinctValues<T>(items: T[], pick: (t: T) => string | undefined): string[] {
+  const set = new Set<string>();
+  for (const it of items) {
+    const v = pick(it);
+    if (v) set.add(v);
+  }
+  return [...set].sort((a, b) => a.localeCompare(b));
+}


### PR DESCRIPTION
Fixes #251.

## Summary
- `/sessions` defaults to a grouped view: sessions collapse into per-issue folds, each ordered as `dev (cycle 1) → review (cycle 1) → dev (cycle 2) → review (cycle 2)…`. Cycle and role are derived on the client from chronological order + agent name (substring match: `review` → review, then `dev` → dev, otherwise `other`). Backend `/api/v1/sessions` contract is unchanged per the issue's non-goal.
- Repo and agent-name filters now have `<datalist>` dropdowns populated from the current page's distinct values; the text input is preserved as fallback for values not yet on this page.
- New view-mode (grouped/flat) and sort (recent/issue#) selectors are persisted in the URL alongside the existing `repo/agent/issue/offset`, so any filter state is fully shareable.
- Click-through on a row still navigates to `/sessions/:id`.
- Added Vitest with a unit test covering the grouping logic (cycle assignment, ordering, role inference, distinct-values helper). `pnpm -C web test` and `pnpm -C web build` both green.

## Test plan
- [x] `pnpm -C web test` (7 tests pass)
- [x] `pnpm -C web build` (clean tsc + vite output)
- [ ] Manual smoke in browser: grouped view, fold/unfold, dropdown autocomplete, URL round-trip on share