### PR TITLE
webui: add GitHub issue external links (#250)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test --experimental-strip-types 'src/**/*.test.ts'"
   },
   "dependencies": {
     "preact": "^10.25.0",

--- a/web/src/components/GitHubIssueLink.tsx
+++ b/web/src/components/GitHubIssueLink.tsx
@@ -1,0 +1,28 @@
+import { githubIssueURL } from '../utils/github';
+
+interface Props {
+  owner: string;
+  repo: string;
+  num: number | string;
+  variant?: 'text' | 'icon';
+  label?: string;
+}
+
+export function GitHubIssueLink({ owner, repo, num, variant = 'text', label }: Props) {
+  const href = githubIssueURL(owner, repo, num);
+  const text = label ?? (variant === 'icon' ? '↗' : `Open #${num} on GitHub ↗`);
+  const title = `Open ${owner}/${repo}#${num} on GitHub`;
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      class={variant === 'icon' ? 'gh-issue-link gh-issue-link-icon' : 'gh-issue-link'}
+      title={title}
+      aria-label={title}
+      data-testid="github-issue-link"
+    >
+      {text}
+    </a>
+  );
+}

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'preact/hooks';
 import { useLocation } from 'preact-iso';
 import { Layout } from '../components/Layout';
 import { StateBadge } from '../components/StateBadge';
+import { GitHubIssueLink } from '../components/GitHubIssueLink';
 import { getInFlightIssues, getStatus } from '../api/client';
 import type { ApiError } from '../api/client';
 import type { InFlightIssue, StatusResponse } from '../api/types';
@@ -160,7 +161,13 @@ function IssueRow({ row, onOpen }: IssueRowProps) {
       <td>
         <a href={issueHref} class="code-chip">
           {row.repo}#{row.issue_num}
-        </a>
+        </a>{' '}
+        <GitHubIssueLink
+          owner={splitRepo(row.repo).owner}
+          repo={splitRepo(row.repo).name}
+          num={row.issue_num}
+          variant="icon"
+        />
       </td>
       <td>{row.title || <span class="muted">(no title)</span>}</td>
       <td>

--- a/web/src/pages/IssueDetail.tsx
+++ b/web/src/pages/IssueDetail.tsx
@@ -2,10 +2,12 @@ import { useEffect, useState } from 'preact/hooks';
 import { useRoute } from 'preact-iso';
 import { Layout } from '../components/Layout';
 import { StateBadge } from '../components/StateBadge';
+import { GitHubIssueLink } from '../components/GitHubIssueLink';
 import { getIssueDetail } from '../api/client';
 import type { ApiError } from '../api/client';
 import type { IssueDetail as IssueDetailDTO } from '../api/types';
 import { formatRelative } from '../utils/time';
+import { splitRepoSlug } from '../utils/github';
 
 interface FetchState {
   detail: IssueDetailDTO | null;
@@ -64,11 +66,13 @@ export function IssueDetail() {
 }
 
 function IssueDetailBody({ detail }: { detail: IssueDetailDTO }) {
+  const { owner, name } = splitRepoSlug(detail.repo);
   return (
     <>
       <h1>
         <span class="code-chip">{detail.repo}#{detail.issue_num}</span>{' '}
-        {detail.title || <span class="muted">(no title)</span>}
+        {detail.title || <span class="muted">(no title)</span>}{' '}
+        <GitHubIssueLink owner={owner} repo={name} num={detail.issue_num} />
       </h1>
 
       <dl class="kv">

--- a/web/src/pages/SessionDetail.tsx
+++ b/web/src/pages/SessionDetail.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { useRoute } from 'preact-iso';
 import { Layout } from '../components/Layout';
+import { GitHubIssueLink } from '../components/GitHubIssueLink';
+import { splitRepoSlug } from '../utils/github';
 import {
   fetchSession,
   fetchSessionEvents,
@@ -332,7 +334,17 @@ export function SessionDetail() {
               <dt>Repo</dt>
               <dd>{meta.repo}</dd>
               <dt>Issue</dt>
-              <dd>#{meta.issue_num}</dd>
+              <dd>
+                #{meta.issue_num}{' '}
+                {meta.repo && (
+                  <GitHubIssueLink
+                    owner={splitRepoSlug(meta.repo).owner}
+                    repo={splitRepoSlug(meta.repo).name}
+                    num={meta.issue_num}
+                    variant="icon"
+                  />
+                )}
+              </dd>
               {meta.worker_id && (
                 <>
                   <dt>Worker</dt>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -604,3 +604,18 @@ table.clickable tbody tr:hover {
   cursor: pointer;
 }
 .wb-nav form button:hover { background: #f6f8fa; }
+
+.gh-issue-link {
+  font-size: 0.85rem;
+  text-decoration: none;
+  color: #0969da;
+  white-space: nowrap;
+}
+.gh-issue-link:hover { text-decoration: underline; }
+.gh-issue-link-icon {
+  display: inline-block;
+  font-size: 0.9rem;
+  padding: 0 0.25rem;
+  color: #57606a;
+}
+.gh-issue-link-icon:hover { color: #0969da; }

--- a/web/src/utils/github.test.ts
+++ b/web/src/utils/github.test.ts
@@ -1,0 +1,32 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { githubIssueURL, githubIssueURLFromSlug, splitRepoSlug } from './github.ts';
+
+test('githubIssueURL builds canonical github issue URL', () => {
+  assert.equal(
+    githubIssueURL('Lincyaw', 'workbuddy', 250),
+    'https://github.com/Lincyaw/workbuddy/issues/250',
+  );
+});
+
+test('githubIssueURL accepts string num', () => {
+  assert.equal(
+    githubIssueURL('octocat', 'hello-world', '42'),
+    'https://github.com/octocat/hello-world/issues/42',
+  );
+});
+
+test('splitRepoSlug splits owner/name', () => {
+  assert.deepEqual(splitRepoSlug('Lincyaw/workbuddy'), { owner: 'Lincyaw', name: 'workbuddy' });
+});
+
+test('splitRepoSlug handles missing slash', () => {
+  assert.deepEqual(splitRepoSlug('orphan'), { owner: 'orphan', name: '' });
+});
+
+test('githubIssueURLFromSlug derives URL from owner/name slug', () => {
+  assert.equal(
+    githubIssueURLFromSlug('Lincyaw/workbuddy', 250),
+    'https://github.com/Lincyaw/workbuddy/issues/250',
+  );
+});

--- a/web/src/utils/github.ts
+++ b/web/src/utils/github.ts
@@ -1,0 +1,14 @@
+export function githubIssueURL(owner: string, repo: string, num: number | string): string {
+  return `https://github.com/${owner}/${repo}/issues/${num}`;
+}
+
+export function splitRepoSlug(repo: string): { owner: string; name: string } {
+  const slash = repo.indexOf('/');
+  if (slash <= 0) return { owner: repo, name: '' };
+  return { owner: repo.slice(0, slash), name: repo.slice(slash + 1) };
+}
+
+export function githubIssueURLFromSlug(repo: string, num: number | string): string {
+  const { owner, name } = splitRepoSlug(repo);
+  return githubIssueURL(owner, name, num);
+}


### PR DESCRIPTION
## Summary
- Add `GitHubIssueLink` component + `githubIssueURL` helper that builds `https://github.com/{owner}/{repo}/issues/{num}`.
- Surface the link on the issue detail page header (text), each in-flight row on the dashboard (icon), and the Issue field of the session detail page (icon).
- All links open in a new tab with `rel="noopener noreferrer"`.
- Add a `node:test` unit test for href construction and wire `pnpm test` via `node --test --experimental-strip-types`.

Fixes #250

## Test plan
- [x] `node --test --experimental-strip-types web/src/utils/github.test.ts` — 5/5 pass
- [ ] Manual: load /, /issues/Lincyaw/workbuddy/250, /sessions/<id>; click external links open the right GitHub URL in a new tab