### PR TITLE
webui: responsive layout for phone and tablet (#260)

### DIFF
--- a/internal/app/auth_handlers.go
+++ b/internal/app/auth_handlers.go
@@ -14,14 +14,17 @@ var loginPageTemplate = template.Must(template.New("login").Parse(`<!doctype htm
 <html lang="en">
 <head>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>workbuddy login</title>
 <style>
-body{font-family:system-ui,sans-serif;max-width:24rem;margin:4rem auto;padding:0 1rem}
+body{font-family:system-ui,sans-serif;max-width:24rem;margin:4rem auto;padding:0 1rem;font-size:16px}
 h1{font-size:1.25rem;margin:0 0 1rem}
 label{display:block;margin:.5rem 0 .25rem}
-input[type=password]{width:100%;padding:.5rem;font:inherit;box-sizing:border-box}
+/* font-size:16px keeps iOS Safari from auto-zooming on focus */
+input[type=password]{width:100%;padding:.5rem;font:inherit;font-size:16px;box-sizing:border-box}
 button{margin-top:1rem;padding:.5rem 1rem;font:inherit;cursor:pointer}
 .error{color:#b00;margin:.5rem 0;font-size:.9rem}
+@media (max-width:480px){body{margin:2rem auto}}
 </style>
 </head>
 <body>

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -3540,3 +3540,34 @@ requirements:
       - internal/eventlog/eventlog_test.go
       - cmd/hooks_test.go
     deps: []
+
+  - id: REQ-102
+    title: webui responsive layout for phone and tablet (issue #260)
+    description: >
+      Make the webui SPA usable on ≤480px (phone) and 481–768px (tablet)
+      viewports without horizontal page scroll, while reusing the desktop
+      route/component tree via CSS media queries. Topbar collapses to a
+      hamburger drawer on phones and a single-row scrollable chip strip on
+      tablets. Wide tables overflow inside their panel with a sticky first
+      column (owner/repo#num) so the identity stays visible while the rest
+      scrolls. Session detail metadata stacks above the timeline at full
+      width and the Pretty-mode turn boundary thins out so tool_use /
+      tool_result bodies get the room. Form inputs (login, search,
+      password) get font-size:16px to suppress iOS Safari auto-zoom.
+    priority: P2
+    version: v0.5.0
+    status: tested
+    acceptance_criteria:
+      - "AC-102-1: styles.css declares @media (max-width:480px) and (max-width:768px) breakpoints and they override topbar, table, timeline, and meta-grid layout for the same routes desktop uses."
+      - "AC-102-2: Layout.tsx renders a hamburger button (.topbar-toggle) with aria-expanded and aria-controls; clicking it toggles .menu-open which the ≤480px CSS uses to reveal the stacked nav."
+      - "AC-102-3: ≤768px CSS pins the first table column with position:sticky so wide tables can scroll horizontally inside .panel without losing the identity column."
+      - "AC-102-4: ≤768px CSS sets font-size:16px on text/search/password/email/textarea/select inputs, and the server-rendered /login template inlines the same rule plus a viewport meta tag."
+      - "AC-102-5: ≤768px CSS collapses .wb-meta-grid to a single column and thins .wb-turn-group to a 1px left rule so timeline content reclaims width."
+      - "AC-102-6: vitest in web/src/components/Layout.test.tsx asserts the hamburger toggle, menu-open class, primary nav links, and the responsive CSS contract (breakpoints, sticky first column, 16px input rule, single-column meta grid, thinned turn boundary)."
+    code:
+      - web/src/styles.css
+      - web/src/components/Layout.tsx
+      - internal/app/auth_handlers.go
+    tests:
+      - web/src/components/Layout.test.tsx
+    deps: []

--- a/web/src/components/Layout.test.tsx
+++ b/web/src/components/Layout.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render } from '@testing-library/preact';
+import { LocationProvider } from 'preact-iso';
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Layout } from './Layout';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const stylesPath = join(__dirname, '..', 'styles.css');
+const css = readFileSync(stylesPath, 'utf8');
+
+function renderLayout() {
+  return render(
+    <LocationProvider>
+      <Layout>
+        <p>hello</p>
+      </Layout>
+    </LocationProvider>,
+  );
+}
+
+describe('Layout responsive shell', () => {
+  it('renders a hamburger toggle that collapses the nav by default', () => {
+    const { container } = renderLayout();
+    const toggle = container.querySelector('.topbar-toggle');
+    expect(toggle).not.toBeNull();
+    expect(toggle?.getAttribute('aria-expanded')).toBe('false');
+    expect(container.querySelector('.topbar.menu-open')).toBeNull();
+  });
+
+  it('toggles menu-open class when the hamburger is clicked', () => {
+    const { container } = renderLayout();
+    const toggle = container.querySelector('.topbar-toggle') as HTMLButtonElement;
+    fireEvent.click(toggle);
+    expect(container.querySelector('.topbar.menu-open')).not.toBeNull();
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('keeps a primary nav with all known links', () => {
+    const { container } = renderLayout();
+    const nav = container.querySelector('nav#primary-nav');
+    expect(nav).not.toBeNull();
+    const labels = Array.from(nav?.querySelectorAll('a') ?? []).map((a) => a.textContent);
+    expect(labels).toContain('Dashboard');
+    expect(labels).toContain('Sessions');
+  });
+});
+
+describe('styles.css responsive contract', () => {
+  it('declares both ≤480 and ≤768 breakpoints', () => {
+    expect(css).toMatch(/@media\s*\(max-width:\s*480px\)/);
+    expect(css).toMatch(/@media\s*\(max-width:\s*768px\)/);
+  });
+
+  it('makes form inputs at least 16px on narrow screens (iOS no-zoom)', () => {
+    // Pull the ≤768px block and assert the input rule sets font-size:16px.
+    const block = css.match(/@media\s*\(max-width:\s*768px\)\s*{([\s\S]*?)\n}\n/);
+    expect(block).not.toBeNull();
+    expect(block?.[1]).toMatch(/input\[type="password"\][\s\S]*font-size:\s*16px/);
+  });
+
+  it('pins the first table column on narrow screens', () => {
+    const block = css.match(/@media\s*\(max-width:\s*768px\)\s*{([\s\S]*?)\n}\n/);
+    expect(block?.[1]).toMatch(/th:first-child[\s\S]*position:\s*sticky/);
+  });
+
+  it('collapses session metadata to a single column on narrow screens', () => {
+    const block = css.match(/@media\s*\(max-width:\s*768px\)\s*{([\s\S]*?)\n}\n/);
+    expect(block?.[1]).toMatch(/\.wb-meta-grid[\s\S]*grid-template-columns:\s*1fr/);
+  });
+
+  it('thins the pretty-mode turn boundary on narrow screens', () => {
+    const block = css.match(/@media\s*\(max-width:\s*768px\)\s*{([\s\S]*?)\n}\n/);
+    expect(block?.[1]).toMatch(/\.wb-turn-group[\s\S]*border-left-width:\s*1px/);
+  });
+});

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,4 +1,5 @@
 import type { ComponentChildren } from 'preact';
+import { useState } from 'preact/hooks';
 import { useLocation } from 'preact-iso';
 import { logout } from '../api/client';
 
@@ -19,18 +20,30 @@ function isActive(currentPath: string, href: string): boolean {
 
 export function Layout({ children }: { children: ComponentChildren }) {
   const { path } = useLocation();
+  const [menuOpen, setMenuOpen] = useState(false);
   return (
     <div class="app">
-      <header class="topbar">
+      <header class={`topbar${menuOpen ? ' menu-open' : ''}`}>
         <a href="/" class="logo" aria-label="workbuddy home">
           workbuddy
         </a>
-        <nav>
+        <button
+          type="button"
+          class="topbar-toggle"
+          aria-expanded={menuOpen}
+          aria-controls="primary-nav"
+          aria-label="Toggle navigation menu"
+          onClick={() => setMenuOpen((v) => !v)}
+        >
+          <span aria-hidden="true">☰</span>
+        </button>
+        <nav id="primary-nav" aria-label="Primary">
           {NAV.map((item) => (
             <a
               href={item.href}
               class={isActive(path, item.href) ? 'active' : ''}
               aria-current={isActive(path, item.href) ? 'page' : undefined}
+              onClick={() => setMenuOpen(false)}
             >
               {item.label}
             </a>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -829,3 +829,161 @@ table.clickable tbody tr:hover {
   background: #fff8e6;
   border: 1px solid #f5d68a;
 }
+
+/* ---------------------------------------------------------------------------
+ * Responsive: tablets (481–768px) and phones (≤480px).
+ *
+ * Goals (issue #260):
+ *  - No horizontal page scroll; tables scroll inside their own panel and the
+ *    first column (owner/repo#num) stays visible via position:sticky.
+ *  - Topbar collapses to a hamburger that toggles the nav into a stacked menu
+ *    on phones; on tablets the nav becomes a single-row scrollable chip strip.
+ *  - Session detail metadata sits above the timeline at full width.
+ *  - Pretty-mode turn boundary uses a thinner left mark so text gets the room.
+ *  - Form inputs use font-size:16px to suppress iOS Safari auto-zoom.
+ * ------------------------------------------------------------------------- */
+
+/* Hamburger button is hidden on desktop; narrow-screen rules toggle it. */
+.topbar-toggle {
+  display: none;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.25rem 0.55rem;
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--text);
+}
+.topbar-toggle:hover { background: var(--bg); }
+
+/* Always allow tables to scroll horizontally inside their panel rather than
+ * forcing the whole page to scroll. The .panel/.wb-card wrapper clips the
+ * overflow, the inner element keeps a min-width so columns don't squish. */
+.panel { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+
+/* Inputs at >=16px stop iOS Safari from auto-zooming on focus. The .wb-toolbar
+ * and .wb-filters explicit overrides above use 13px, so we widen them only at
+ * narrow breakpoints. */
+
+@media (max-width: 768px) {
+  body { font-size: 14px; }
+
+  .topbar {
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    padding: 0.6rem 1rem;
+  }
+  .topbar nav {
+    /* Single-row scrollable chip strip on tablet. */
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    gap: 0.5rem;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: thin;
+  }
+  .topbar nav a { white-space: nowrap; }
+
+  .page { padding: 1rem; }
+  .page h1 { font-size: 1.2rem; }
+
+  .cards { grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 0.75rem; }
+  .card .value { font-size: 1.3rem; }
+
+  /* Sticky-first-column on horizontally scrolled tables. */
+  table th:first-child,
+  table td:first-child,
+  .wb-table th:first-child,
+  .wb-table td:first-child {
+    position: sticky;
+    left: 0;
+    background: var(--surface);
+    z-index: 1;
+    box-shadow: 1px 0 0 var(--border);
+  }
+  table thead th:first-child,
+  .wb-table thead th:first-child { background: var(--bg); }
+
+  /* Timeline row: collapse the 3-column grid into a stack. */
+  .timeline li {
+    grid-template-columns: 1fr;
+    gap: 0.25rem;
+  }
+
+  /* Session detail meta grid: drop the second column to its own line. */
+  .wb-meta-grid {
+    grid-template-columns: 1fr;
+    gap: 2px 0;
+  }
+  .wb-meta-grid dt { margin-top: 6px; }
+  .wb-meta-grid dd { margin-left: 0; }
+
+  /* Pretty-mode: thinner turn boundary marker, less indent. */
+  .wb-turn-group { padding-left: 6px; border-left-width: 1px; }
+  .wb-turn-boundary { margin-left: -8px; padding: 1px 6px; font-size: 10px; }
+
+  /* Long JSON/output blocks: cap height shorter on small screens; keep
+   * user-select on so the user can still copy the full content. */
+  .wb-event-body pre { max-height: 240px; font-size: 11px; }
+  .wb-sm-collapsible pre { max-height: 320px; font-size: 11px; }
+
+  /* Toolbar: ensure search input does not push other controls off-screen. */
+  .wb-toolbar { gap: 6px; padding: 8px; }
+  .wb-toolbar input[type="search"],
+  .wb-toolbar input { min-width: 0 !important; flex: 1 1 140px; }
+
+  .wb-shell { padding: 14px 12px 80px; }
+
+  /* Login/form inputs: 16px stops iOS Safari from zooming on focus. */
+  input[type="text"],
+  input[type="search"],
+  input[type="password"],
+  input[type="email"],
+  textarea,
+  select {
+    font-size: 16px;
+  }
+}
+
+@media (max-width: 480px) {
+  .topbar { padding: 0.5rem 0.75rem; gap: 0.5rem; }
+  .topbar .logo { font-size: 0.95rem; flex: 1 1 auto; }
+  .topbar-toggle { display: inline-flex; align-items: center; justify-content: center; }
+  .topbar nav {
+    /* Hamburger-controlled drawer: full-width stack below the brand row. */
+    display: none;
+    flex-basis: 100%;
+    flex-direction: column;
+    gap: 0.25rem;
+    overflow: visible;
+  }
+  .topbar.menu-open nav { display: flex; }
+  .topbar nav a { padding: 0.5rem 0.6rem; border-radius: 6px; }
+  .topbar .logout { padding: 0.3rem 0.6rem; font-size: 0.8rem; }
+
+  .page { padding: 0.75rem; }
+  .page h1 { font-size: 1.1rem; }
+  .page h2 { font-size: 1rem; }
+
+  .cards { grid-template-columns: 1fr 1fr; gap: 0.5rem; }
+  .card { padding: 0.75rem; }
+  .card .value { font-size: 1.15rem; }
+
+  /* Tighten table cells; first column stays sticky from the 768px rule. */
+  table th, table td,
+  .wb-table th, .wb-table td {
+    padding: 0.45rem 0.6rem;
+    font-size: 12px;
+  }
+
+  .wb-toolbar { padding: 6px; }
+  .wb-toolbar .kinds { gap: 2px; }
+  .wb-toolbar .kinds label { padding: 2px 6px; font-size: 11px; }
+
+  .wb-event-header { flex-wrap: wrap; }
+  .wb-event-title { white-space: normal; }
+  .wb-event-body pre { max-height: 180px; }
+
+  .wb-session-group-header { flex-wrap: wrap; padding: 8px 10px; }
+}
+


### PR DESCRIPTION
## Summary
- Adds `@media (max-width:480px)` and `(max-width:768px)` rules to `web/src/styles.css` that collapse the topbar, stack cards/meta-grid, scroll wide tables with a sticky first column, thin the Pretty-mode turn boundary, and bump form inputs to 16px so iOS Safari does not auto-zoom on focus.
- `Layout.tsx` renders a hamburger toggle that flips a `.menu-open` class on the topbar; the ≤480px CSS uses that class to reveal a stacked nav drawer. Desktop behaviour is unchanged — single component tree, CSS-only adaptation per the issue's non-goal of forking routes.
- Server-rendered `/login` form gets a viewport meta tag and a 16px `font-size` on the password input for the same iOS-no-zoom reason.
- Records the work as `REQ-101` in `project-index.yaml` (`status: tested`).

## Test plan
- [x] `pnpm -C web test` passes (5 files, 36 tests) — new `Layout.test.tsx` asserts the hamburger toggle, `menu-open` class, primary nav links, and the responsive CSS contract.
- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] `go test ./internal/app/...` passes (login template still parses).
- [x] `validate_index.py project-index.yaml` reports pass.
- [ ] Manual: load `/`, `/issues`, `/sessions`, `/sessions/:id`, `/login` in Chromium DevTools at iPhone 14 / Pixel 7 / iPad mini presets and confirm no horizontal page scroll, hamburger drawer toggles, and Pretty-mode timeline keeps tool_use bodies legible.

Fixes #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)