### PR TITLE
hooks: design doc + v1 JSON schema (#262)

### DIFF
--- a/docs/decisions/2026-04-30-hook-system.md
+++ b/docs/decisions/2026-04-30-hook-system.md
@@ -1,0 +1,119 @@
+# Coordinator Hook System
+
+- Date: 2026-04-30
+- Status: accepted
+- Issue: #262
+
+## Context
+
+`internal/notifier/notifier.go` ships a hardcoded notifier that subscribes to alertbus + task completion and sends Slack/Feishu/Telegram/SMTP. It's rigid:
+
+- Only two trigger points (alert + task done). `state_entry`, `dispatch`, `dev_review_cycle_cap_reached`, `dispatch_blocked_by_dependency`, `coordinator_restart_gap` are invisible.
+- Channel set is compiled in. New destinations (DingTalk, PagerDuty, custom webhook, local script) require Go changes.
+- No declarative routing (per-repo / per-severity / per-label).
+
+We want users to declaratively describe *event → action* and have the coordinator execute it asynchronously.
+
+## Decision
+
+### Configuration is host-global, not per-repo
+
+Hooks live in `~/.config/workbuddy/hooks.yaml` (single file, same directory as `worker.env`). CLI `--hooks-config` overrides the path.
+
+`.github/workbuddy/hooks/*.md` is intentionally **not** supported. Rationale: per-repo hooks would let any PR contributor inject a `command:` action and gain RCE on the coordinator host. By restricting hooks to the operator's filesystem, the trust boundary collapses to "whoever has write access to `/home/<user>/.config/workbuddy/`" — same as the database, the systemd unit, and worker tokens.
+
+A consequence: we don't need an opt-in flag for `command` actions. The earlier draft (`--hooks-allow-command`) is gone.
+
+### One hook point: `eventlog.Logger.Log()`
+
+The dispatcher hooks into `internal/eventlog/eventlog.go` `Log(...)` after the SQLite insert. **Every existing event type is automatically subscribable**. Adding a new subscribable event = adding a new `eventlog.Log(...)` call in the originating code path. No new hook points.
+
+This is the load-bearing decision: hook surface area = eventlog type set. Documentation maintains one list.
+
+Three places currently log via `log.Printf` instead of `eventlog.Log` will be retrofitted to emit eventlog entries (Phase 2):
+
+- `coordinator_started` (cmd/serve.go, cmd/coordinator.go)
+- `coordinator_stopping` (graceful shutdown handler)
+- `config_reloaded` (auditapi config reload handler)
+
+### Action types (both default-on)
+
+| Type | Behaviour |
+|---|---|
+| `webhook` | POST v1 payload as application/json. 2xx = success. Headers support `${ENV_VAR}` substitution resolved at startup. |
+| `command` | Execute argv (no shell expansion). v1 payload on stdin. Env adds `WORKBUDDY_EVENT_TYPE`, `WORKBUDDY_REPO`, `WORKBUDDY_ISSUE_NUM`, `WORKBUDDY_HOOK_NAME`. Non-zero exit = failure. |
+
+Action types are pluggable via `internal/hooks/action.go` `ActionRegistry`. Adding a new type (e.g. SMTP, gRPC, pubsub) is a Go change but does not touch the dispatcher.
+
+### Dispatcher behaviour
+
+- **Async, buffered**: 1024-deep channel + worker pool. Default 4 workers. Overflow drops the message and increments `workbuddy_hook_overflow_total`. State machine is never blocked by hook latency.
+- **Per-hook independence**: each hook has its own bounded execution slot so a slow hook can't starve others.
+- **Timeout**: default 5s, configurable per hook. Webhook → request cancellation. Command → SIGTERM, then SIGKILL after a 2s grace (matches existing agent cancel semantics in `internal/supervisor/agent.go`).
+- **Auto-disable**: 5 consecutive failures disable the hook in-memory and emit `hook_disabled`. **No half-open probing** — operator must `workbuddy hooks reload`. Rationale: hooks are user-owned scripts/endpoints; if they're broken, eyes-on is the right response, not silent recovery.
+- **Self-amplification guard**: events with type prefix `hook_` (`hook_disabled`, `hook_failed`, `hook_overflow`) are written to eventlog but skipped by the dispatcher. Without this guard, a failing hook on `*` would log a `hook_failed`, which would re-trigger itself.
+
+### Stable v1 event payload
+
+The dispatcher does not pipe eventlog's internal JSON straight to user actions. `internal/hooks/eventpayload.go` translates each event into a versioned envelope:
+
+```json
+{
+  "schema_version": 1,
+  "event_type": "state_entry",
+  "ts": "2026-04-30T03:23:27Z",
+  "repo": "Lincyaw/workbuddy",
+  "issue_num": 250,
+  "data": { /* event-specific payload */ }
+}
+```
+
+`docs/hooks.md` lists every field; the `data` shape per event_type is also enumerated. **Fields are append-only**. Removing or renaming a field requires bumping `schema_version`.
+
+### Coexistence with `internal/notifier`
+
+Both run in parallel during the rollout. The notifier is not modified or removed by issue #262. A future issue (out of scope here) will:
+
+1. Write a migration guide showing the same Slack/Feishu/Telegram/SMTP behaviour in hook config.
+2. Reimplement the built-in notifier as auto-registered internal hooks.
+3. Delete `internal/notifier/notifier.go` once the migration sees real-world use.
+
+### CLI surface
+
+- `workbuddy hooks list` — registered hooks
+- `workbuddy hooks test --hook NAME --event-fixture path/to/event.json` — fire once with a fixture; **does not** write to eventlog
+- `workbuddy hooks status` — recent invocations, success/failure rate, auto-disable state
+- `workbuddy hooks reload` — re-read config and reset `hook_disabled` flags
+
+### Phase plan
+
+| Phase | Scope |
+|---|---|
+| 1a | `internal/hooks/` package skeleton, YAML parser, dispatcher, `ActionRegistry`, webhook action, eventlog hook, `workbuddy hooks list` |
+| 1b | command action, timeout/SIGKILL, auto-disable, self-amplification filter, `workbuddy hooks test` |
+| 2 | `match.severity` / `match.repo` filters, metrics, `workbuddy hooks status` / `hooks reload`, eventlog entries for `coordinator_started` / `_stopping` / `config_reloaded` |
+| 3 | webui Hooks page (list + recent 20 invocations + error rate) |
+
+Each phase is independently mergeable. `depends_on:` enforces serial execution.
+
+## Consequences
+
+### Positive
+
+- Hook surface is one file in code (`eventlog.Log`) and one config file on disk. Trivial mental model.
+- Adding subscribable events = `eventlog.Log(...)`. No "extend the hook system" recurring task.
+- No PR-injected RCE. Operator-only trust.
+- v1 payload is decoupled from internal eventlog JSON, giving us room to refactor eventlog without breaking user scripts.
+
+### Negative
+
+- Per-repo hook customization is impossible by design. Workaround: hook author filters on `payload.repo` inside their script/endpoint.
+- The `internal/notifier` migration is deferred. We carry two notification paths until that future issue lands.
+- `command` action runs as the coordinator process uid. Operator must vet scripts; we don't sandbox.
+
+## Alternatives considered
+
+- **Per-repo hooks at `.github/workbuddy/hooks/*.md`**: matches the existing agent/workflow config style but introduces a PR-injected RCE vector. Rejected.
+- **Plugin system (`.so` / RPC)**: more flexible than command/webhook but adds significant build-time, deployment, and security complexity. command + webhook covers >99% of expected use. Rejected.
+- **Reuse `internal/notifier` as the hook engine**: would couple the new declarative system to the legacy hardcoded one and complicate the eventual notifier removal. Rejected; kept them parallel instead.
+- **Replay-style retries with circuit breaker**: half-open probing adds operational nuance for marginal benefit. Rejected in favour of explicit operator reload.

--- a/schemas/hook.schema.json
+++ b/schemas/hook.schema.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Lincyaw/workbuddy/schemas/hook.schema.json",
+  "title": "Workbuddy Hooks Configuration (issue #262)",
+  "description": "Schema for ~/.config/workbuddy/hooks.yaml. Hooks are coordinator-host-level: only the operator who deploys workbuddy can edit this file. PR contributors cannot inject hooks. Per-repo .github/workbuddy/hooks/ is intentionally NOT supported. Keep in sync with internal/hooks/config.go.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["hooks"],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Top-level config schema version. Optional; defaults to 1."
+    },
+    "hooks": {
+      "type": "array",
+      "description": "List of hook definitions. Order is irrelevant; hooks fire concurrently.",
+      "items": { "$ref": "#/$defs/hook" }
+    }
+  },
+  "$defs": {
+    "hook": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "events", "action"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9._-]+$",
+          "description": "Stable identifier. Used in CLI (`workbuddy hooks list/test/status`), metrics (`workbuddy_hook_invocations_total{hook=\"<name>\"}`), and `hook_disabled` event payloads. Must be unique across the file."
+        },
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Set false to keep the definition but skip dispatch. Auto-disable on N consecutive failures (see hook_disabled event) is a separate runtime flag and does not modify this field."
+        },
+        "events": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Event type from internal/eventlog/eventlog.go (e.g. `state_entry`, `dispatch`, `completed`, `alert`, `dev_review_cycle_cap_reached`, `dispatch_blocked_by_dependency`, `infra_failure`, `issue_restarted`, `worker_registered`, `coordinator_started`, `coordinator_stopping`, `config_reloaded`). The literal `*` matches all events except those with the `hook_` prefix (which are filtered to prevent self-amplification). `poll_cycle_done` is allowed but documented as 'not recommended' due to volume."
+          }
+        },
+        "match": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Optional pre-action filter. Applied AFTER event-type matching. All present fields must match (AND).",
+          "properties": {
+            "severity": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": { "type": "string", "enum": ["info", "warn", "error"] },
+              "description": "Only meaningful when the event is `alert`. Other event types ignore this filter."
+            },
+            "repo": {
+              "type": "string",
+              "description": "Glob pattern matched against payload.repo (e.g. `Lincyaw/*`, `*`). Empty/missing means match-all."
+            }
+          }
+        },
+        "timeout": {
+          "type": "string",
+          "default": "5s",
+          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
+          "description": "Go time.Duration. After timeout: SIGTERM, then SIGKILL after a 2s grace (command actions); HTTP request cancelled (webhook actions)."
+        },
+        "action": { "$ref": "#/$defs/action" }
+      }
+    },
+    "action": {
+      "oneOf": [
+        { "$ref": "#/$defs/webhookAction" },
+        { "$ref": "#/$defs/commandAction" }
+      ],
+      "description": "Action to execute when an event matches. Action types are pluggable via internal/hooks/action.go ActionRegistry; new types require code changes but no dispatcher changes."
+    },
+    "webhookAction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "url"],
+      "properties": {
+        "type": { "const": "webhook" },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Target URL. The dispatcher POSTs the v1 event payload as application/json. HTTP 2xx is success; anything else (incl. timeout) is failure."
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "Optional headers. Values support `${ENV_VAR}` substitution at coordinator startup (resolved against the coordinator's environment, not the caller's request). Missing env vars resolve to empty string and emit a startup warning."
+        },
+        "method": {
+          "type": "string",
+          "enum": ["POST", "PUT"],
+          "default": "POST",
+          "description": "HTTP method. Defaults to POST; PUT supported for idempotent receivers."
+        }
+      }
+    },
+    "commandAction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "cmd"],
+      "properties": {
+        "type": { "const": "command" },
+        "cmd": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" },
+          "description": "argv. cmd[0] is the executable; remaining items are literal arguments (no shell expansion). The dispatcher writes the v1 event payload to stdin as JSON. Env: process inherits coordinator env plus `WORKBUDDY_EVENT_TYPE`, `WORKBUDDY_REPO`, `WORKBUDDY_ISSUE_NUM`, `WORKBUDDY_HOOK_NAME`. Non-zero exit code = failure."
+        },
+        "cwd": {
+          "type": "string",
+          "description": "Working directory. Defaults to the coordinator's working directory."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Lands the design artifacts for #262. No runtime code — Phase 1a..3 sub-issues follow and will be filed under this PR's wake.

## Summary
- `docs/decisions/2026-04-30-hook-system.md`: full design (host-global config, eventlog hook point, dispatcher behaviour, v1 payload, phase plan)
- `schemas/hook.schema.json`: v1 schema for `~/.config/workbuddy/hooks.yaml`

## Test plan
- [x] `python3 -m json.tool schemas/hook.schema.json` parses
- [x] design doc passes `validate-docs --strict` (no skill drift)
- [ ] subsequent Phase 1a impl PR will validate the schema actually parses real configs

🤖 Generated with [Claude Code](https://claude.com/claude-code)