### PR TITLE
hooks: phase 1b — command action + timeout + auto-disable + hooks test

### DIFF
--- a/cmd/coordinator.go
+++ b/cmd/coordinator.go
@@ -658,7 +658,11 @@ func initHooksDispatcher(configFlag string, evlog *eventlog.EventLogger) (*hooks
 		log.Printf("[coordinator] hooks: no hooks configured (looked at %s)", path)
 		return nil, nil
 	}
-	dispatcher, dispatchWarnings, err := hooks.NewDispatcher(cfg, hooks.DefaultActionRegistry(), hooks.WithLogger(log.Default()))
+	opts := []hooks.DispatcherOption{hooks.WithLogger(log.Default())}
+	if evlog != nil {
+		opts = append(opts, hooks.WithEventEmitter(evlog.Log))
+	}
+	dispatcher, dispatchWarnings, err := hooks.NewDispatcher(cfg, hooks.DefaultActionRegistry(), opts...)
 	if err != nil {
 		return nil, fmt.Errorf("coordinator: build hooks dispatcher: %w", err)
 	}

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -1,12 +1,15 @@
 package cmd
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/Lincyaw/workbuddy/internal/hooks"
 	"github.com/spf13/cobra"
@@ -25,9 +28,28 @@ var hooksListCmd = &cobra.Command{
 	RunE:  runHooksList,
 }
 
+var (
+	hooksTestHookName     string
+	hooksTestEventFixture string
+)
+
+var hooksTestCmd = &cobra.Command{
+	Use:   "test",
+	Short: "Fire a hook once with a fixture event (does NOT write eventlog)",
+	Long: `Run the action attached to --hook against a v1 payload built from --event-fixture.
+The fixture is a JSON file with at least { "type": "...", "repo": "...", "issue_num": N, "payload": {...} }.
+Stdout/stderr/exit/duration of the underlying action are printed; nothing is persisted.`,
+	RunE: runHooksTest,
+}
+
 func init() {
 	hooksCmd.PersistentFlags().String(flagHooksConfig, "", "Path to hooks YAML (default: ~/.config/workbuddy/hooks.yaml or $WORKBUDDY_HOOKS_CONFIG)")
 	hooksCmd.AddCommand(hooksListCmd)
+	hooksTestCmd.Flags().StringVar(&hooksTestHookName, "hook", "", "Name of the hook to fire (required)")
+	hooksTestCmd.Flags().StringVar(&hooksTestEventFixture, "event-fixture", "", "Path to a JSON event fixture (required)")
+	_ = hooksTestCmd.MarkFlagRequired("hook")
+	_ = hooksTestCmd.MarkFlagRequired("event-fixture")
+	hooksCmd.AddCommand(hooksTestCmd)
 	rootCmd.AddCommand(hooksCmd)
 
 	// Make --hooks-config available on serve and coordinator so the loaded
@@ -81,6 +103,113 @@ func ResolveHooksConfigPath(flagValue string) string {
 		return ""
 	}
 	return filepath.Join(home, ".config", "workbuddy", "hooks.yaml")
+}
+
+// fixtureFile is the on-disk shape of `--event-fixture` JSON. Unknown keys
+// are tolerated for forward compatibility.
+type fixtureFile struct {
+	Type     string          `json:"type"`
+	Repo     string          `json:"repo"`
+	IssueNum int             `json:"issue_num"`
+	Payload  json.RawMessage `json:"payload"`
+}
+
+func runHooksTest(cmd *cobra.Command, _ []string) error {
+	path, _ := cmd.Flags().GetString(flagHooksConfig)
+	resolved := ResolveHooksConfigPath(path)
+	cfg, warnings, err := hooks.LoadConfig(resolved)
+	if err != nil {
+		return err
+	}
+	for _, w := range warnings {
+		fmt.Fprintf(cmdStderr(cmd), "warning: %s\n", w)
+	}
+	if cfg == nil {
+		return fmt.Errorf("no hooks configured at %s", displayHooksPath(resolved))
+	}
+	var hook *hooks.Hook
+	for i := range cfg.Hooks {
+		if cfg.Hooks[i].Name == hooksTestHookName {
+			hook = &cfg.Hooks[i]
+			break
+		}
+	}
+	if hook == nil {
+		return fmt.Errorf("hook %q not found in %s", hooksTestHookName, displayHooksPath(resolved))
+	}
+
+	raw, err := os.ReadFile(hooksTestEventFixture)
+	if err != nil {
+		return fmt.Errorf("read fixture: %w", err)
+	}
+	var fx fixtureFile
+	if err := json.Unmarshal(raw, &fx); err != nil {
+		return fmt.Errorf("parse fixture %s: %w", hooksTestEventFixture, err)
+	}
+	if strings.TrimSpace(fx.Type) == "" {
+		return fmt.Errorf("fixture %s: missing required field \"type\"", hooksTestEventFixture)
+	}
+
+	ev := hooks.Event{
+		Type:      fx.Type,
+		Repo:      fx.Repo,
+		IssueNum:  fx.IssueNum,
+		Payload:   []byte(fx.Payload),
+		Timestamp: time.Now().UTC(),
+	}
+	envelope := hooks.BuildEnvelope(ev)
+	payload, err := hooks.MarshalEnvelope(envelope)
+	if err != nil {
+		return fmt.Errorf("marshal envelope: %w", err)
+	}
+
+	timeout := hook.Timeout
+	if timeout <= 0 {
+		timeout = hooks.DefaultHookTimeout
+	}
+	ctx, cancel := context.WithTimeout(cmd.Context(), timeout)
+	defer cancel()
+
+	out := cmdStdout(cmd)
+	switch hook.Action.Type {
+	case hooks.ActionTypeCommand:
+		action, err := hooks.BuildCommandAction(hook)
+		if err != nil {
+			return err
+		}
+		res := action.Run(ctx, ev, payload)
+		fmt.Fprintf(out, "hook: %s\naction: command\nduration: %s\nexit: %d\n", hook.Name, res.Duration, res.ExitCode)
+		if res.Err != nil {
+			fmt.Fprintf(out, "error: %v\n", res.Err)
+		}
+		fmt.Fprintf(out, "--- stdout ---\n%s", string(res.Stdout))
+		if len(res.Stdout) > 0 && res.Stdout[len(res.Stdout)-1] != '\n' {
+			fmt.Fprintln(out)
+		}
+		fmt.Fprintf(out, "--- stderr ---\n%s", string(res.Stderr))
+		if len(res.Stderr) > 0 && res.Stderr[len(res.Stderr)-1] != '\n' {
+			fmt.Fprintln(out)
+		}
+		if res.Err != nil {
+			return fmt.Errorf("hook %q failed: %w", hook.Name, res.Err)
+		}
+		return nil
+	default:
+		// webhook (and any future generic action) — fall back to the registry.
+		action, _, err := hooks.DefaultActionRegistry().Build(hook)
+		if err != nil {
+			return err
+		}
+		start := time.Now()
+		execErr := action.Execute(ctx, ev, payload)
+		fmt.Fprintf(out, "hook: %s\naction: %s\nduration: %s\n", hook.Name, hook.Action.Type, time.Since(start))
+		if execErr != nil {
+			fmt.Fprintf(out, "error: %v\n", execErr)
+			return fmt.Errorf("hook %q failed: %w", hook.Name, execErr)
+		}
+		fmt.Fprintln(out, "result: ok")
+		return nil
+	}
 }
 
 func displayHooksPath(p string) string {

--- a/cmd/hooks_test.go
+++ b/cmd/hooks_test.go
@@ -63,6 +63,76 @@ hooks:
 	}
 }
 
+func TestHooksTestRunsCommandActionWithoutEventlog(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "hooks.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`
+hooks:
+  - name: echo
+    events: ["alert"]
+    action:
+      type: command
+      cmd: ["sh", "-c", "printf '%s/%s' \"$WORKBUDDY_EVENT_TYPE\" \"$WORKBUDDY_HOOK_NAME\"; cat"]
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	fixturePath := filepath.Join(dir, "ev.json")
+	if err := os.WriteFile(fixturePath, []byte(`{"type":"alert","repo":"x/y","issue_num":7,"payload":{"hello":"world"}}`), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	rootCmd.SetArgs([]string{"hooks", "test",
+		"--" + flagHooksConfig, cfgPath,
+		"--hook", "echo",
+		"--event-fixture", fixturePath,
+	})
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(stderr)
+	defer rootCmd.SetArgs(nil)
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("execute: %v\nstderr: %s", err, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "exit: 0") {
+		t.Fatalf("expected exit: 0 in output, got: %q", out)
+	}
+	if !strings.Contains(out, "alert/echo") {
+		t.Fatalf("expected env vars to surface in stdout, got: %q", out)
+	}
+	if !strings.Contains(out, `"hello":"world"`) {
+		t.Fatalf("expected fixture payload to be piped on stdin and echoed back, got: %q", out)
+	}
+}
+
+func TestHooksTestUnknownHookErrors(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "hooks.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`hooks: [{name: a, events: [alert], action: {type: webhook, url: http://x}}]`), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	fxPath := filepath.Join(dir, "ev.json")
+	if err := os.WriteFile(fxPath, []byte(`{"type":"alert"}`), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	rootCmd.SetArgs([]string{"hooks", "test",
+		"--" + flagHooksConfig, cfgPath,
+		"--hook", "does-not-exist",
+		"--event-fixture", fxPath,
+	})
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	defer rootCmd.SetArgs(nil)
+
+	err := rootCmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected hook-not-found error, got %v", err)
+	}
+}
+
 func TestResolveHooksConfigPathPrecedence(t *testing.T) {
 	t.Setenv("WORKBUDDY_HOOKS_CONFIG", "/tmp/from-env.yaml")
 	if got := ResolveHooksConfigPath("/tmp/from-flag.yaml"); got != "/tmp/from-flag.yaml" {

--- a/internal/hooks/action.go
+++ b/internal/hooks/action.go
@@ -14,11 +14,13 @@ const (
 
 // Action is the runtime contract every action implementation satisfies. The
 // payload is a stable v1 envelope (see eventpayload.go); already JSON-encoded.
+// The raw Event is passed alongside for actions (notably command) that need
+// the structured fields without re-parsing the envelope JSON.
 type Action interface {
 	// Type returns the action type identifier (e.g. "webhook").
 	Type() string
 	// Execute runs the action. ctx cancellation must be respected.
-	Execute(ctx context.Context, payload []byte) error
+	Execute(ctx context.Context, ev Event, payload []byte) error
 }
 
 // ActionRegistry registers concrete Action implementations bound to a Hook.
@@ -63,5 +65,6 @@ func (r *ActionRegistry) Build(h *Hook) (Action, []string, error) {
 func DefaultActionRegistry() *ActionRegistry {
 	r := NewActionRegistry()
 	r.Register(ActionTypeWebhook, buildWebhookAction)
+	r.Register(ActionTypeCommand, buildCommandAction)
 	return r
 }

--- a/internal/hooks/command.go
+++ b/internal/hooks/command.go
@@ -1,0 +1,140 @@
+package hooks
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// commandKillGrace mirrors internal/supervisor/agent.go: SIGTERM, 2s grace,
+// then SIGKILL. Implemented via exec.Cmd.WaitDelay so the kernel-side
+// enforcement matches the supervisor's cancel path even if the child traps
+// SIGTERM.
+const commandKillGrace = 2 * time.Second
+
+// CommandAction runs an argv (no shell) with the v1 payload on stdin.
+//
+// Cancellation discipline: ctx cancellation triggers cmd.Cancel which sends
+// SIGTERM. After WaitDelay (commandKillGrace) os/exec force-kills the process.
+// Any non-zero exit (including kill-by-signal) is reported as failure.
+type CommandAction struct {
+	name string
+	argv []string
+	cwd  string
+}
+
+// Type implements Action.
+func (c *CommandAction) Type() string { return ActionTypeCommand }
+
+// Execute runs the command and discards stdout/stderr. For captured runs
+// (e.g. `workbuddy hooks test`), use Run.
+func (c *CommandAction) Execute(ctx context.Context, ev Event, payload []byte) error {
+	return c.run(ctx, ev, payload, io.Discard, io.Discard).Err
+}
+
+// CommandResult is the outcome of a single Run invocation, used by the
+// `hooks test` CLI to render stdout / stderr / exit / duration.
+type CommandResult struct {
+	Stdout   []byte
+	Stderr   []byte
+	ExitCode int
+	Duration time.Duration
+	// Err is non-nil for any failure (non-zero exit, signal, exec error,
+	// timeout). nil only on a clean exit code 0.
+	Err error
+}
+
+// Run executes the command with stdout/stderr buffered for inspection.
+func (c *CommandAction) Run(ctx context.Context, ev Event, payload []byte) CommandResult {
+	var stdout, stderr bytes.Buffer
+	res := c.run(ctx, ev, payload, &stdout, &stderr)
+	res.Stdout = stdout.Bytes()
+	res.Stderr = stderr.Bytes()
+	return res
+}
+
+func (c *CommandAction) run(ctx context.Context, ev Event, payload []byte, stdout, stderr io.Writer) CommandResult {
+	start := time.Now()
+	if len(c.argv) == 0 {
+		return CommandResult{Err: errors.New("hooks: command argv is empty")}
+	}
+
+	cmd := exec.CommandContext(ctx, c.argv[0], c.argv[1:]...)
+	cmd.Stdin = bytes.NewReader(payload)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if c.cwd != "" {
+		cmd.Dir = c.cwd
+	}
+	cmd.Env = commandEnv(c.name, ev.Type, ev.Repo, ev.IssueNum)
+	// Custom cancel: SIGTERM first; WaitDelay forces SIGKILL after grace.
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return cmd.Process.Signal(syscall.SIGTERM)
+	}
+	cmd.WaitDelay = commandKillGrace
+
+	err := cmd.Run()
+	res := CommandResult{
+		Duration: time.Since(start),
+		Err:      err,
+	}
+	if cmd.ProcessState != nil {
+		res.ExitCode = cmd.ProcessState.ExitCode()
+	}
+	return res
+}
+
+// BuildCommandAction is exported for use by `hooks test` (which needs to
+// reconstruct an action from a Hook entry).
+func BuildCommandAction(h *Hook) (*CommandAction, error) {
+	if len(h.Action.Cmd) == 0 {
+		return nil, fmt.Errorf("hooks: hook %q: command.cmd must be a non-empty argv", h.Name)
+	}
+	if strings.TrimSpace(h.Action.Cmd[0]) == "" {
+		return nil, fmt.Errorf("hooks: hook %q: command.cmd[0] (program) is empty", h.Name)
+	}
+	return &CommandAction{
+		name: h.Name,
+		argv: append([]string(nil), h.Action.Cmd...),
+		cwd:  h.Action.Cwd,
+	}, nil
+}
+
+func buildCommandAction(h *Hook) (Action, []string, error) {
+	a, err := BuildCommandAction(h)
+	if err != nil {
+		return nil, nil, err
+	}
+	return a, nil, nil
+}
+
+func finalizeCommandAction(h *Hook) ([]string, error) {
+	if _, err := BuildCommandAction(h); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+// commandEnv builds the child env: the coordinator process env plus the four
+// WORKBUDDY_* introspection variables documented in the design doc.
+func commandEnv(hookName, eventType, repo string, issueNum int) []string {
+	base := os.Environ()
+	base = append(base,
+		"WORKBUDDY_EVENT_TYPE="+eventType,
+		"WORKBUDDY_REPO="+repo,
+		"WORKBUDDY_ISSUE_NUM="+strconv.Itoa(issueNum),
+		"WORKBUDDY_HOOK_NAME="+hookName,
+	)
+	return base
+}

--- a/internal/hooks/command_test.go
+++ b/internal/hooks/command_test.go
@@ -1,0 +1,206 @@
+package hooks
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestCommandActionSuccessSetsEnvAndStdin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("posix-only command tests")
+	}
+	// Echo the four WORKBUDDY_* env vars + stdin so the test can assert
+	// the action wired them through.
+	a := &CommandAction{
+		name: "echo-hook",
+		argv: []string{"sh", "-c", `printf '%s|%s|%s|%s|' "$WORKBUDDY_EVENT_TYPE" "$WORKBUDDY_REPO" "$WORKBUDDY_ISSUE_NUM" "$WORKBUDDY_HOOK_NAME"; cat`},
+	}
+	ev := Event{Type: "alert", Repo: "x/y", IssueNum: 42}
+	res := a.Run(context.Background(), ev, []byte(`STDIN-PAYLOAD`))
+	if res.Err != nil {
+		t.Fatalf("unexpected err: %v (stderr=%s)", res.Err, res.Stderr)
+	}
+	want := "alert|x/y|42|echo-hook|STDIN-PAYLOAD"
+	if got := string(res.Stdout); got != want {
+		t.Fatalf("stdout mismatch:\nwant: %q\ngot:  %q", want, got)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("expected exit 0, got %d", res.ExitCode)
+	}
+}
+
+func TestCommandActionNonZeroExitIsFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("posix-only")
+	}
+	a := &CommandAction{name: "fail", argv: []string{"sh", "-c", "exit 7"}}
+	res := a.Run(context.Background(), Event{Type: "x"}, nil)
+	if res.Err == nil {
+		t.Fatalf("expected error for non-zero exit")
+	}
+	if res.ExitCode != 7 {
+		t.Fatalf("expected exit 7, got %d", res.ExitCode)
+	}
+}
+
+func TestCommandActionTimeoutSigtermThenSigkill(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("posix-only")
+	}
+	// Trap SIGTERM and ignore it; the kernel-side WaitDelay must escalate to
+	// SIGKILL so the process actually exits within the test budget.
+	a := &CommandAction{name: "trap", argv: []string{"sh", "-c", "trap '' TERM; sleep 30"}}
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	res := a.Run(ctx, Event{Type: "alert"}, nil)
+	dur := time.Since(start)
+	if res.Err == nil {
+		t.Fatalf("expected timeout error, got nil")
+	}
+	// Timeout (200ms) + grace (~2s commandKillGrace) — give some slack.
+	if dur > 4*time.Second {
+		t.Fatalf("kill path too slow (%s); SIGKILL escalation likely broken", dur)
+	}
+	var ee *exec.ExitError
+	if !errors.As(res.Err, &ee) && !strings.Contains(res.Err.Error(), "signal") && !strings.Contains(res.Err.Error(), "killed") && !strings.Contains(res.Err.Error(), "deadline") {
+		// Different Go versions wrap the WaitDelay error differently; just
+		// require *some* error.
+		t.Logf("note: timeout err = %v", res.Err)
+	}
+}
+
+// failingAction always errors, used to drive the auto-disable threshold.
+type failingAction struct {
+	calls atomic.Int64
+}
+
+func (a *failingAction) Type() string                                    { return "failing" }
+func (a *failingAction) Execute(_ context.Context, _ Event, _ []byte) error {
+	a.calls.Add(1)
+	return errors.New("boom")
+}
+
+func TestDispatcherAutoDisableAfterFiveFailures(t *testing.T) {
+	action := &failingAction{}
+	reg := NewActionRegistry()
+	reg.Register("test", func(h *Hook) (Action, []string, error) { return action, nil, nil })
+	cfg := &Config{Hooks: []Hook{{
+		Name:   "flaky",
+		Events: []string{"alert"},
+		Action: ActionConfig{Type: "test"},
+	}}}
+
+	var emitted struct {
+		typ      string
+		hookName string
+		lastErr  string
+		count    atomic.Int64
+	}
+	emitter := func(eventType, _ string, _ int, payload interface{}) {
+		emitted.count.Add(1)
+		emitted.typ = eventType
+		if m, ok := payload.(map[string]interface{}); ok {
+			if v, ok := m["hook"].(string); ok {
+				emitted.hookName = v
+			}
+			if v, ok := m["last_error"].(string); ok {
+				emitted.lastErr = v
+			}
+		}
+	}
+
+	d, _, err := NewDispatcher(cfg, reg, WithEventEmitter(emitter))
+	if err != nil {
+		t.Fatalf("dispatcher: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d.Start(ctx)
+	defer d.Stop()
+
+	// Push events one at a time so each is consumed before the next, keeping
+	// the failure counter linear.
+	for i := 0; i < 10; i++ {
+		d.Publish(Event{Type: "alert"})
+		// Spin until the action has observed this call (or the dispatcher has
+		// disabled the hook and stopped delivering).
+		deadline := time.Now().Add(time.Second)
+		for time.Now().Before(deadline) {
+			if action.calls.Load() >= int64(i+1) || d.IsDisabled("flaky") {
+				break
+			}
+			time.Sleep(2 * time.Millisecond)
+		}
+	}
+
+	if !d.IsDisabled("flaky") {
+		t.Fatalf("hook should be disabled after %d failures", AutoDisableThreshold)
+	}
+	if got := action.calls.Load(); got != int64(AutoDisableThreshold) {
+		t.Fatalf("action should have been called exactly %d times before auto-disable, got %d", AutoDisableThreshold, got)
+	}
+	if got := emitted.count.Load(); got != 1 {
+		t.Fatalf("hook_disabled should be emitted exactly once, got %d", got)
+	}
+	if emitted.typ != HookDisabledEvent {
+		t.Fatalf("emitted type = %q, want %q", emitted.typ, HookDisabledEvent)
+	}
+	if emitted.hookName != "flaky" {
+		t.Fatalf("emitted hook = %q", emitted.hookName)
+	}
+	if emitted.lastErr != "boom" {
+		t.Fatalf("emitted last_error = %q", emitted.lastErr)
+	}
+}
+
+// flakyAction fails the first few invocations then succeeds, to verify the
+// failure counter resets on success (so a later flake doesn't trip disable).
+type flakyAction struct {
+	calls atomic.Int64
+}
+
+func (a *flakyAction) Type() string { return "flaky" }
+func (a *flakyAction) Execute(_ context.Context, _ Event, _ []byte) error {
+	n := a.calls.Add(1)
+	if n <= 3 {
+		return errors.New("transient")
+	}
+	return nil
+}
+
+func TestDispatcherSuccessResetsFailureCounter(t *testing.T) {
+	action := &flakyAction{}
+	reg := NewActionRegistry()
+	reg.Register("test", func(h *Hook) (Action, []string, error) { return action, nil, nil })
+	cfg := &Config{Hooks: []Hook{{Name: "h", Events: []string{"alert"}, Action: ActionConfig{Type: "test"}}}}
+
+	d, _, err := NewDispatcher(cfg, reg)
+	if err != nil {
+		t.Fatalf("dispatcher: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d.Start(ctx)
+	defer d.Stop()
+
+	for i := 0; i < 10; i++ {
+		d.Publish(Event{Type: "alert"})
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if action.calls.Load() >= 10 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if d.IsDisabled("h") {
+		t.Fatalf("hook should not be disabled — successes should have reset the counter")
+	}
+}

--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -151,9 +151,7 @@ func finalizeAction(h *Hook) ([]string, error) {
 	case ActionTypeWebhook:
 		return finalizeWebhookAction(h)
 	case ActionTypeCommand:
-		// command action lands in Phase 1b; reject for now so users don't
-		// silently mis-configure.
-		return nil, fmt.Errorf("hooks: hook %q: action type %q not yet supported (Phase 1b)", h.Name, h.Action.Type)
+		return finalizeCommandAction(h)
 	default:
 		return nil, fmt.Errorf("hooks: hook %q: unknown action type %q", h.Name, h.Action.Type)
 	}

--- a/internal/hooks/config_test.go
+++ b/internal/hooks/config_test.go
@@ -88,11 +88,22 @@ func TestParseConfigUnknownActionType(t *testing.T) {
 	}
 }
 
-func TestParseConfigCommandTypeRejectedInPhase1a(t *testing.T) {
+func TestParseConfigCommandActionAccepted(t *testing.T) {
 	yaml := []byte(`hooks: [{name: x, events: [alert], action: {type: command, cmd: ["/bin/true"]}}]`)
-	_, _, err := ParseConfig([]byte(yaml))
-	if err == nil || !strings.Contains(err.Error(), "Phase 1b") {
-		t.Fatalf("expected Phase 1b rejection, got %v", err)
+	cfg, _, err := ParseConfig([]byte(yaml))
+	if err != nil {
+		t.Fatalf("expected command to be accepted, got %v", err)
+	}
+	if cfg.Hooks[0].Action.Type != ActionTypeCommand {
+		t.Fatalf("expected command action, got %q", cfg.Hooks[0].Action.Type)
+	}
+}
+
+func TestParseConfigCommandRequiresCmd(t *testing.T) {
+	yaml := []byte(`hooks: [{name: x, events: [alert], action: {type: command}}]`)
+	_, _, err := ParseConfig(yaml)
+	if err == nil || !strings.Contains(err.Error(), "command.cmd") {
+		t.Fatalf("expected command.cmd error, got %v", err)
 	}
 }
 

--- a/internal/hooks/dispatcher.go
+++ b/internal/hooks/dispatcher.go
@@ -2,21 +2,45 @@ package hooks
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"log"
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
 // channelCapacity is the dispatcher's bounded buffer per design doc.
 const channelCapacity = 1024
 
-// boundHook pairs a parsed Hook with its constructed Action.
+// DefaultHookTimeout is applied to actions that don't override `timeout:`.
+const DefaultHookTimeout = 5 * time.Second
+
+// AutoDisableThreshold is the consecutive failure count that trips a hook
+// into the disabled state. Per design (docs/decisions/2026-04-30-hook-system.md)
+// no half-open probing — operator must `workbuddy hooks reload` to re-enable.
+const AutoDisableThreshold = 5
+
+// HookDisabledEvent is the eventlog type emitted when a hook trips
+// auto-disable. Lives under HookEventPrefix so it does not re-enter the
+// dispatcher (self-amplification guard).
+const HookDisabledEvent = HookEventPrefix + "disabled"
+
+// boundHook pairs a parsed Hook with its constructed Action and tracks the
+// per-hook auto-disable state.
 type boundHook struct {
 	hook   *Hook
 	action Action
+
+	mu       sync.Mutex
+	failures int
+	disabled bool
+	lastErr  string
 }
+
+// EventEmitter is the optional callback the dispatcher uses to surface
+// hook-system self-events (notably hook_disabled) back into the eventlog.
+// Signature matches eventlog.EventLogger.Log so wiring is `WithEventEmitter(evlog.Log)`.
+type EventEmitter func(eventType, repo string, issueNum int, payload interface{})
 
 // Dispatcher fans event-log entries out to declarative hooks.
 //
@@ -28,8 +52,12 @@ type boundHook struct {
 //     hook cannot starve other hooks.
 //   - Events with a `hook_` prefix are filtered out (see IsHookSelfEvent)
 //     so a failing hook bound to `*` does not amplify itself.
+//   - Per-hook timeout (default 5s); command actions are SIGTERMed then
+//     SIGKILLed after a 2s grace.
+//   - 5 consecutive failures auto-disable a hook in memory; a `hook_disabled`
+//     eventlog entry is emitted via EventEmitter (no half-open probing).
 type Dispatcher struct {
-	hooks  []boundHook
+	hooks  []*boundHook
 	in     chan Event
 	stopCh chan struct{}
 	wg     sync.WaitGroup
@@ -37,6 +65,8 @@ type Dispatcher struct {
 
 	overflow atomic.Uint64
 	dropped  atomic.Uint64
+
+	emitter EventEmitter
 
 	mu       sync.Mutex
 	started  bool
@@ -54,6 +84,12 @@ func WithLogger(l *log.Logger) DispatcherOption {
 			d.logger = l
 		}
 	}
+}
+
+// WithEventEmitter installs a callback used to push hook self-events back
+// into the eventlog. nil disables emission (useful in tests).
+func WithEventEmitter(e EventEmitter) DispatcherOption {
+	return func(d *Dispatcher) { d.emitter = e }
 }
 
 // NewDispatcher binds the parsed config to actions via the registry.
@@ -84,7 +120,7 @@ func NewDispatcher(cfg *Config, registry *ActionRegistry, opts ...DispatcherOpti
 				return nil, nil, err
 			}
 			warnings = append(warnings, w...)
-			d.hooks = append(d.hooks, boundHook{hook: h, action: action})
+			d.hooks = append(d.hooks, &boundHook{hook: h, action: action})
 		}
 	}
 	return d, warnings, nil
@@ -97,11 +133,14 @@ func (d *Dispatcher) Hooks() []HookSummary {
 	}
 	out := make([]HookSummary, 0, len(d.hooks))
 	for _, b := range d.hooks {
+		b.mu.Lock()
+		disabled := b.disabled
+		b.mu.Unlock()
 		out = append(out, HookSummary{
 			Name:       b.hook.Name,
 			Events:     append([]string(nil), b.hook.Events...),
 			ActionType: b.hook.Action.Type,
-			Enabled:    b.hook.IsEnabled(),
+			Enabled:    b.hook.IsEnabled() && !disabled,
 		})
 	}
 	return out
@@ -173,6 +212,19 @@ func (d *Dispatcher) OverflowCount() uint64 { return d.overflow.Load() }
 // DroppedCount is the cumulative count of per-hook slot drops (slow hook).
 func (d *Dispatcher) DroppedCount() uint64 { return d.dropped.Load() }
 
+// IsDisabled reports whether a hook has been auto-disabled. Exposed for the
+// `hooks list` / `hooks status` surfaces and tests.
+func (d *Dispatcher) IsDisabled(hookName string) bool {
+	for _, b := range d.hooks {
+		if b.hook.Name == hookName {
+			b.mu.Lock()
+			defer b.mu.Unlock()
+			return b.disabled
+		}
+	}
+	return false
+}
+
 func (d *Dispatcher) runFanIn(ctx context.Context) {
 	defer d.wg.Done()
 	for {
@@ -189,6 +241,12 @@ func (d *Dispatcher) runFanIn(ctx context.Context) {
 
 func (d *Dispatcher) fanOut(ev Event) {
 	for _, b := range d.hooks {
+		b.mu.Lock()
+		disabled := b.disabled
+		b.mu.Unlock()
+		if disabled {
+			continue
+		}
 		if !b.hook.MatchesEvent(ev.Type) {
 			continue
 		}
@@ -205,7 +263,7 @@ func (d *Dispatcher) fanOut(ev Event) {
 	}
 }
 
-func (d *Dispatcher) runHook(ctx context.Context, b boundHook, ch chan Event) {
+func (d *Dispatcher) runHook(ctx context.Context, b *boundHook, ch chan Event) {
 	defer d.wg.Done()
 	for {
 		select {
@@ -219,17 +277,62 @@ func (d *Dispatcher) runHook(ctx context.Context, b boundHook, ch chan Event) {
 	}
 }
 
-func (d *Dispatcher) executeOne(ctx context.Context, b boundHook, ev Event) {
+func (d *Dispatcher) executeOne(ctx context.Context, b *boundHook, ev Event) {
 	envelope := BuildEnvelope(ev)
 	payload, err := MarshalEnvelope(envelope)
 	if err != nil {
 		d.logger.Printf("hooks: hook %q: marshal envelope: %v", b.hook.Name, err)
 		return
 	}
-	if err := b.action.Execute(ctx, payload); err != nil {
-		d.logger.Printf("hooks: hook %q action %s failed: %v", b.hook.Name, b.action.Type(), err)
+
+	timeout := b.hook.Timeout
+	if timeout <= 0 {
+		timeout = DefaultHookTimeout
+	}
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	err = b.action.Execute(runCtx, ev, payload)
+	cancel()
+
+	if err == nil {
+		b.mu.Lock()
+		b.failures = 0
+		b.lastErr = ""
+		b.mu.Unlock()
 		return
 	}
+
+	d.logger.Printf("hooks: hook %q action %s failed: %v", b.hook.Name, b.action.Type(), err)
+
+	b.mu.Lock()
+	b.failures++
+	b.lastErr = err.Error()
+	tripped := false
+	if !b.disabled && b.failures >= AutoDisableThreshold {
+		b.disabled = true
+		tripped = true
+	}
+	lastErr := b.lastErr
+	b.mu.Unlock()
+
+	if tripped {
+		d.emitDisabled(b.hook.Name, lastErr)
+	}
+}
+
+// emitDisabled forwards a hook_disabled event to the eventlog (if an emitter
+// is wired). The dispatcher's Publish itself filters hook_* events, so even
+// without the emitter this never re-enters the dispatcher.
+func (d *Dispatcher) emitDisabled(hookName, lastErr string) {
+	d.logger.Printf("hooks: hook %q auto-disabled after %d consecutive failures: %s", hookName, AutoDisableThreshold, lastErr)
+	if d.emitter == nil {
+		return
+	}
+	d.emitter(HookDisabledEvent, "", 0, map[string]interface{}{
+		"hook":            hookName,
+		"failures":        AutoDisableThreshold,
+		"last_error":      lastErr,
+		"requires_reload": true,
+	})
 }
 
 // PublishFromRaw is a convenience for callers that already have a JSON-encoded
@@ -243,5 +346,3 @@ func (d *Dispatcher) PublishFromRaw(eventType, repo string, issueNum int, payloa
 	})
 }
 
-// Ensure fmt is used (no-op import shield against re-org churn).
-var _ = fmt.Sprintf

--- a/internal/hooks/dispatcher_test.go
+++ b/internal/hooks/dispatcher_test.go
@@ -18,7 +18,7 @@ type blockingAction struct {
 }
 
 func (a *blockingAction) Type() string { return "blocking" }
-func (a *blockingAction) Execute(ctx context.Context, _ []byte) error {
+func (a *blockingAction) Execute(ctx context.Context, _ Event, _ []byte) error {
 	a.count.Add(1)
 	select {
 	case <-a.gate:
@@ -35,7 +35,7 @@ type countingAction struct {
 }
 
 func (a *countingAction) Type() string { return "counting" }
-func (a *countingAction) Execute(_ context.Context, _ []byte) error {
+func (a *countingAction) Execute(_ context.Context, _ Event, _ []byte) error {
 	a.count.Add(1)
 	a.once.Do(func() { close(a.done) })
 	return nil
@@ -190,7 +190,7 @@ func TestWebhookActionNon2xxIsError(t *testing.T) {
 	}))
 	defer srv.Close()
 	w := &WebhookAction{url: srv.URL, method: "POST", client: http.DefaultClient}
-	if err := w.Execute(context.Background(), []byte(`{}`)); err == nil {
+	if err := w.Execute(context.Background(), Event{}, []byte(`{}`)); err == nil {
 		t.Fatalf("expected non-2xx error")
 	}
 }
@@ -207,7 +207,7 @@ func TestWebhookActionTimeoutIsError(t *testing.T) {
 	w := &WebhookAction{url: srv.URL, method: "POST", client: http.DefaultClient}
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
-	if err := w.Execute(ctx, []byte(`{}`)); err == nil {
+	if err := w.Execute(ctx, Event{}, []byte(`{}`)); err == nil {
 		t.Fatalf("expected timeout/cancelled error")
 	}
 }

--- a/internal/hooks/webhook.go
+++ b/internal/hooks/webhook.go
@@ -27,7 +27,7 @@ func (w *WebhookAction) Type() string { return ActionTypeWebhook }
 
 // Execute sends the HTTP request and returns an error for non-2xx responses
 // or transport-level failures (including context cancellation).
-func (w *WebhookAction) Execute(ctx context.Context, payload []byte) error {
+func (w *WebhookAction) Execute(ctx context.Context, _ Event, payload []byte) error {
 	req, err := http.NewRequestWithContext(ctx, w.method, w.url, bytes.NewReader(payload))
 	if err != nil {
 		return fmt.Errorf("hooks: webhook build request: %w", err)

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -3614,3 +3614,41 @@ requirements:
     tests:
       - internal/statemachine/pipeline_hazards_test.go
     deps: []
+  - id: REQ-104
+    title: hook system phase 1b — command action + timeout + auto-disable + hooks test
+    description: >
+      Phase 1b of the operator-owned hook system (#262). Adds the local-script
+      action type, per-hook timeout with SIGTERM→SIGKILL escalation, automatic
+      disable after 5 consecutive failures, and the `workbuddy hooks test`
+      CLI for fixture-based dry runs that do NOT touch the eventlog. See
+      docs/decisions/2026-04-30-hook-system.md.
+    rationale: >
+      Phase 1a ships webhook delivery only; without command actions, hooks
+      cannot drive operator-local scripts (paging, ticket creation, log
+      shipping) — the original motivation for the system. Timeouts and
+      auto-disable are required before exposing the system to broken user
+      scripts that would otherwise hang or amplify failures.
+    status: tested
+    acceptance:
+      - "AC-104-1: internal/hooks/command.go runs argv via exec.CommandContext (no shell), writes the v1 payload to stdin, and adds WORKBUDDY_EVENT_TYPE / _REPO / _ISSUE_NUM / _HOOK_NAME to the child env. Non-zero exit (including kill-by-signal) is failure."
+      - "AC-104-2: Default timeout is 5s, configurable per hook via `timeout: 10s`. Webhook cancels the request via context; command sends SIGTERM and force-kills after a 2s grace via cmd.WaitDelay (matches internal/supervisor/agent.go cancel path)."
+      - "AC-104-3: 5 consecutive failures auto-disable a hook in memory; subsequent matching events skip dispatch. A `hook_disabled` eventlog entry is emitted via the configured EventEmitter (payload includes hook name + last failure reason). No half-open probing."
+      - "AC-104-4: The dispatcher's Publish path filters all event types prefixed `hook_` (hook_disabled / hook_failed / hook_overflow), so self-events never re-trigger hooks."
+      - "AC-104-5: `workbuddy hooks test --hook NAME --event-fixture path/to/event.json` parses the fixture, builds the v1 payload, calls the action's Execute directly, and prints stdout / stderr / exit code / duration. The test path does not write to the eventlog."
+      - "AC-104-6: Unit tests cover command success (env + stdin), non-zero exit, timeout SIGTERM→SIGKILL escalation, auto-disable trigger + skip-after-disable, and the hooks test CLI path with a fake fixture and echo command."
+    priority: P1
+    code:
+      - internal/hooks/command.go
+      - internal/hooks/dispatcher.go
+      - internal/hooks/config.go
+      - internal/hooks/action.go
+      - internal/hooks/webhook.go
+      - cmd/hooks.go
+      - cmd/coordinator.go
+    tests:
+      - internal/hooks/command_test.go
+      - internal/hooks/dispatcher_test.go
+      - internal/hooks/config_test.go
+      - cmd/hooks_test.go
+    deps:
+      - REQ-101


### PR DESCRIPTION
Fixes #265. Builds on #268 (Phase 1a).

## Summary
- Adds the `command` action: argv via `exec.CommandContext` (no shell), v1 payload on stdin, four `WORKBUDDY_*` env vars on the child.
- Per-hook timeout (default 5s, overridable). Webhook cancels via context; command sends SIGTERM then SIGKILL after a 2s grace via `cmd.WaitDelay` (matches `internal/supervisor/agent.go`).
- Auto-disable after 5 consecutive failures: in-memory flag flips off the hook, future events skip fan-out, and a `hook_disabled` eventlog entry is emitted via an `EventEmitter` callback wired to `evlog.Log`. No half-open probing — operator must reload.
- `workbuddy hooks test --hook NAME --event-fixture path/to/event.json`: builds the v1 envelope from the fixture, calls `Execute` directly, prints stdout/stderr/exit/duration, and does **not** write the eventlog.
- Self-amplification guard already in place from Phase 1a (Publish skips `hook_*` types).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/hooks/... ./cmd/...` (the only failure is a pre-existing one on `main`, unrelated to hooks)
- New tests:
  - command success: env vars + stdin piped through correctly
  - command non-zero exit reported as failure with exit code preserved
  - command timeout: child traps SIGTERM, must still die via SIGKILL within grace
  - auto-disable: action invoked exactly 5 times; `hook_disabled` emitted once with hook name + last error; subsequent events skip the disabled hook
  - success resets the failure counter (10 calls, 3 fail then 7 ok → not disabled)
  - `hooks test` CLI: command action runs, output rendered, eventlog untouched
  - `hooks test` CLI: unknown hook name returns a clear error