### PR TITLE
statemachine: surface silent skip paths as pipeline hazards (#255)

### DIFF
--- a/internal/audit/http.go
+++ b/internal/audit/http.go
@@ -168,6 +168,17 @@ func (h *HTTPHandler) queryIssueState(repo string, issueNum int) (IssueStateResp
 	if depState != nil && depState.Verdict != "" {
 		dependencyVerdict = depState.Verdict
 	}
+	// REQ #255: a configuration-incompleteness hazard masks the dependency
+	// verdict in the user-facing surfaces — the issue cannot reach the
+	// dependency gate at all. Override DependencyVerdict so `workbuddy
+	// status` and the audit API surface the hazard kind directly.
+	hazard, err := h.store.QueryIssuePipelineHazard(repo, issueNum)
+	if err != nil {
+		return IssueStateResponse{}, err
+	}
+	if hazard != nil {
+		dependencyVerdict = hazard.Kind
+	}
 
 	cycleState, err := h.store.QueryIssueCycleState(repo, issueNum)
 	if err != nil {

--- a/internal/auditapi/handler.go
+++ b/internal/auditapi/handler.go
@@ -274,6 +274,12 @@ type inFlightIssueResponse struct {
 	ClaimedWorkerID  string         `json:"claimed_worker_id,omitempty"`
 	LastSessionID    string         `json:"last_session_id,omitempty"`
 	LastSessionURL   string         `json:"last_session_url,omitempty"`
+	// Hazard, when non-empty, names a configuration-incompleteness condition
+	// that prevents the issue from making progress. Set by the coordinator
+	// from issue_pipeline_hazards (REQ #255). Possible values:
+	//   "no-workflow-match"      — issue has status:* but no workflow trigger
+	//   "awaiting-status-label"  — workflow trigger + depends_on but no status:*
+	Hazard string `json:"hazard,omitempty"`
 }
 
 // issueTransitionResponse is one transition row in the issue-detail endpoint.
@@ -499,6 +505,9 @@ func (h *Handler) buildInFlightRow(ic store.IssueCache, now time.Time) (inFlight
 	if session, err := h.store.LatestSessionForIssue(ic.Repo, ic.IssueNum); err == nil && session != nil {
 		row.LastSessionID = session.SessionID
 		row.LastSessionURL = sessionref.BuildURL(h.reportBaseURL, session.WorkerID, session.SessionID)
+	}
+	if hazard, err := h.store.QueryIssuePipelineHazard(ic.Repo, ic.IssueNum); err == nil && hazard != nil {
+		row.Hazard = hazard.Kind
 	}
 	return row, nil
 }
@@ -762,6 +771,12 @@ func (h *Handler) handleIssueState(w http.ResponseWriter, r *http.Request) {
 			LastReactionBlocked: depState.LastReactionBlocked,
 			LastEvaluatedAt:     depState.LastEvaluatedAt,
 		}
+	}
+	// REQ #255: surface pipeline-incompleteness hazards by overriding the
+	// DependencyVerdict string. The DependencyState block keeps the real
+	// verdict for clients that need both signals.
+	if hazard, err := h.store.QueryIssuePipelineHazard(repo, issueNum); err == nil && hazard != nil {
+		resp.DependencyVerdict = hazard.Kind
 	}
 
 	writeJSON(w, http.StatusOK, resp)

--- a/internal/diagnose/diagnose.go
+++ b/internal/diagnose/diagnose.go
@@ -24,6 +24,10 @@ const (
 	KindMissedRedispatch = "missed_redispatch"
 	KindOrphanedTask     = "orphaned_task"
 	KindRepeatedFailure  = "repeated_failure"
+	// KindPipelineHazard is emitted for issues that the coordinator has
+	// flagged in issue_pipeline_hazards (REQ #255): configuration-
+	// incompleteness conditions that cause silent dispatch skips.
+	KindPipelineHazard = "pipeline_hazard"
 
 	stuckThreshold       = time.Hour
 	defaultAgentTimeout  = 60 * time.Minute
@@ -262,6 +266,21 @@ func analyzeWithConfig(st *store.Store, repo string, now time.Time, cfg diagnose
 				SuggestedFix: "mark task completed so slot is released; restart worker if heartbeat is stuck",
 			})
 		}
+	}
+
+	hazards, err := st.ListIssuePipelineHazards(repo)
+	if err != nil {
+		return nil, fmt.Errorf("diagnose: list pipeline hazards: %w", err)
+	}
+	for _, h := range hazards {
+		findings = append(findings, Finding{
+			Kind:         KindPipelineHazard,
+			Repo:         h.Repo,
+			IssueNum:     h.IssueNum,
+			Severity:     SeverityWarn,
+			Diagnosis:    pipelineHazardDiagnosis(h.Kind),
+			SuggestedFix: pipelineHazardSuggestedFix(h.Kind),
+		})
 	}
 
 	failCounts := consecutiveFailureCounts(tasks, repo)
@@ -573,6 +592,28 @@ func parseFailureKey(raw string) (string, int, string) {
 	issueNum := 0
 	fmt.Sscanf(parts[1], "%d", &issueNum)
 	return parts[0], issueNum, parts[2]
+}
+
+func pipelineHazardDiagnosis(kind string) string {
+	switch kind {
+	case store.HazardKindNoWorkflowMatch:
+		return "issue carries a status:* label but no workflow trigger label matched, so the state machine cannot enter it"
+	case store.HazardKindAwaitingStatusLabel:
+		return "issue declares depends_on but has no status:* label, so the state machine cannot enter it and the dependency gate cannot release downstream work"
+	default:
+		return fmt.Sprintf("pipeline hazard: %s", kind)
+	}
+}
+
+func pipelineHazardSuggestedFix(kind string) string {
+	switch kind {
+	case store.HazardKindNoWorkflowMatch:
+		return "add the workflow trigger label, e.g. `workbuddy`"
+	case store.HazardKindAwaitingStatusLabel:
+		return "add `status:blocked` so the gate can evaluate, or `status:developing` if the deps are already satisfied"
+	default:
+		return "inspect issue labels and body; clear the hazard once the configuration is complete"
+	}
 }
 
 func issueKey(repo string, issueNum int) string {

--- a/internal/eventlog/eventlog.go
+++ b/internal/eventlog/eventlog.go
@@ -53,6 +53,17 @@ const (
 	TypeDevReviewCycleCapReached    = "dev_review_cycle_cap_reached"
 	TypeDevReviewCycleCountReset    = "dev_review_cycle_count_reset"
 	TypeLongFlightStuck             = "long_flight_stuck_detected"
+	// TypeIssueNoWorkflowMatch fires when poller observes an issue carrying a
+	// status:* label but none of the configured workflow trigger labels match,
+	// i.e. the issue cannot enter the state machine. Idempotent per
+	// (labels) fingerprint via the issue_pipeline_hazards table. See REQ #255.
+	TypeIssueNoWorkflowMatch = "issue_no_workflow_match"
+	// TypeIssueDependencyUnentered fires when an issue carries a workflow
+	// trigger label and a workbuddy.depends_on declaration but no status:*
+	// label, so the state machine cannot enter the issue and the dependency
+	// gate cannot release downstream work. Idempotent per (labels+depends_on)
+	// fingerprint. See REQ #255.
+	TypeIssueDependencyUnentered = "issue_dependency_unentered"
 )
 
 // AllEventTypes lists every recognised event type.
@@ -95,6 +106,8 @@ var AllEventTypes = []string{
 	TypeDevReviewCycleCapReached,
 	TypeDevReviewCycleCountReset,
 	TypeLongFlightStuck,
+	TypeIssueNoWorkflowMatch,
+	TypeIssueDependencyUnentered,
 }
 
 // EventFilter specifies optional criteria for querying events.

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -295,6 +295,11 @@ func (p *Poller) poll(ctx context.Context) {
 					log.Printf("[poller] error deleting cache for closed issue %s#%d: %v", p.repo, closedNum, err)
 					return err
 				}
+				// Best-effort: clear any pipeline hazard so a closed
+				// issue doesn't stay in `workbuddy diagnose`.
+				if err := p.store.ClearIssuePipelineHazard(p.repo, closedNum); err != nil {
+					log.Printf("[poller] error clearing pipeline hazard for closed issue %s#%d: %v", p.repo, closedNum, err)
+				}
 				return nil
 			})
 		}

--- a/internal/statemachine/pipeline_hazards_test.go
+++ b/internal/statemachine/pipeline_hazards_test.go
@@ -1,0 +1,169 @@
+package statemachine
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Lincyaw/workbuddy/internal/eventlog"
+	"github.com/Lincyaw/workbuddy/internal/poller"
+	"github.com/Lincyaw/workbuddy/internal/store"
+)
+
+// Scenario A (REQ #255): issue carries status:* but no workflow trigger label
+// matches. The state machine must record an INFO event + persistent hazard so
+// the issue surfaces in `workbuddy status` / `diagnose`. Repeat events with
+// the same labels must NOT log a duplicate event (idempotent).
+func TestHandleEvent_NoWorkflowMatch_LogsHazardIdempotent(t *testing.T) {
+	sm, rec, _ := newTestSM(t)
+	repo := "test/repo"
+	issueNum := 42
+
+	event := ChangeEvent{
+		Type:     poller.EventLabelAdded,
+		Repo:     repo,
+		IssueNum: issueNum,
+		Labels:   []string{"bug", "status:developing"}, // no workflow trigger label
+		Detail:   "status:developing",
+	}
+
+	if err := sm.HandleEvent(context.Background(), event); err != nil {
+		t.Fatalf("HandleEvent: %v", err)
+	}
+
+	got := rec.find(eventlog.TypeIssueNoWorkflowMatch)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 issue_no_workflow_match event, got %d", len(got))
+	}
+
+	hazard, err := sm.store.QueryIssuePipelineHazard(repo, issueNum)
+	if err != nil {
+		t.Fatalf("query hazard: %v", err)
+	}
+	if hazard == nil {
+		t.Fatalf("expected hazard row to be persisted")
+	}
+	if hazard.Kind != store.HazardKindNoWorkflowMatch {
+		t.Errorf("hazard kind = %q, want %q", hazard.Kind, store.HazardKindNoWorkflowMatch)
+	}
+
+	// Reset HandleEvent's per-poll dedup so the same event can flow again
+	// (simulates a subsequent poll cycle observing identical labels).
+	sm.ResetDedup()
+
+	// Same labels — no new event should be logged.
+	event2 := event
+	event2.Type = poller.EventIssueCreated
+	event2.Detail = "ignored"
+	if err := sm.HandleEvent(context.Background(), event2); err != nil {
+		t.Fatalf("HandleEvent (second): %v", err)
+	}
+	got2 := rec.find(eventlog.TypeIssueNoWorkflowMatch)
+	if len(got2) != 1 {
+		t.Fatalf("expected hazard event to remain idempotent, got %d events", len(got2))
+	}
+
+	// Adding a new label changes the fingerprint — a fresh event MUST fire.
+	sm.ResetDedup()
+	event3 := event
+	event3.Labels = append([]string{"newlabel"}, event.Labels...)
+	if err := sm.HandleEvent(context.Background(), event3); err != nil {
+		t.Fatalf("HandleEvent (third): %v", err)
+	}
+	if got3 := rec.find(eventlog.TypeIssueNoWorkflowMatch); len(got3) != 2 {
+		t.Errorf("expected fingerprint change to re-emit hazard event, got %d total", len(got3))
+	}
+
+	// Adding the trigger label clears the hazard.
+	sm.ResetDedup()
+	event4 := event
+	event4.Labels = []string{"workbuddy", "status:developing"}
+	if err := sm.HandleEvent(context.Background(), event4); err != nil {
+		t.Fatalf("HandleEvent (fourth): %v", err)
+	}
+	hazard, err = sm.store.QueryIssuePipelineHazard(repo, issueNum)
+	if err != nil {
+		t.Fatalf("query hazard after recovery: %v", err)
+	}
+	if hazard != nil {
+		t.Errorf("expected hazard cleared after trigger label added, got %+v", hazard)
+	}
+}
+
+// Scenario B (REQ #255): workflow trigger label present + depends_on declared
+// in body, but no status:* label. State machine must record an INFO event +
+// hazard. Repeat events with unchanged labels+body must be idempotent.
+func TestHandleEvent_DependencyUnentered_LogsHazardIdempotent(t *testing.T) {
+	sm, rec, _ := newTestSM(t)
+	repo := "test/repo"
+	issueNum := 7
+
+	body := "Some prelude.\n\n```yaml\nworkbuddy:\n  depends_on:\n    - \"#3\"\n    - \"#5\"\n```\n"
+	if err := sm.store.UpsertIssueCache(store.IssueCache{
+		Repo:     repo,
+		IssueNum: issueNum,
+		Labels:   `["workbuddy"]`,
+		Body:     body,
+		State:    "open",
+	}); err != nil {
+		t.Fatalf("seed issue cache: %v", err)
+	}
+
+	event := ChangeEvent{
+		Type:     poller.EventLabelAdded,
+		Repo:     repo,
+		IssueNum: issueNum,
+		Labels:   []string{"workbuddy"}, // trigger present, no status:* label
+		Detail:   "workbuddy",
+	}
+	if err := sm.HandleEvent(context.Background(), event); err != nil {
+		t.Fatalf("HandleEvent: %v", err)
+	}
+
+	got := rec.find(eventlog.TypeIssueDependencyUnentered)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 issue_dependency_unentered event, got %d", len(got))
+	}
+	payload, _ := got[0].Payload.(map[string]any)
+	deps, _ := payload["depends_on"].([]string)
+	if len(deps) != 2 || !strings.Contains(strings.Join(deps, ","), "#3") {
+		t.Errorf("expected depends_on payload to include parsed refs, got %v", payload["depends_on"])
+	}
+
+	hazard, err := sm.store.QueryIssuePipelineHazard(repo, issueNum)
+	if err != nil {
+		t.Fatalf("query hazard: %v", err)
+	}
+	if hazard == nil || hazard.Kind != store.HazardKindAwaitingStatusLabel {
+		t.Fatalf("expected awaiting-status-label hazard, got %+v", hazard)
+	}
+
+	// Same labels + body — idempotent.
+	sm.ResetDedup()
+	event2 := event
+	event2.Type = poller.EventIssueCreated
+	event2.Detail = "noop"
+	if err := sm.HandleEvent(context.Background(), event2); err != nil {
+		t.Fatalf("HandleEvent (second): %v", err)
+	}
+	if got2 := rec.find(eventlog.TypeIssueDependencyUnentered); len(got2) != 1 {
+		t.Fatalf("expected hazard event to remain idempotent, got %d events", len(got2))
+	}
+
+	// Adding status:developing clears the hazard once the issue enters the
+	// workflow state machine.
+	sm.ResetDedup()
+	event3 := event
+	event3.Labels = []string{"workbuddy", "status:developing"}
+	event3.Detail = "status:developing"
+	if err := sm.HandleEvent(context.Background(), event3); err != nil {
+		t.Fatalf("HandleEvent (third): %v", err)
+	}
+	hazard, err = sm.store.QueryIssuePipelineHazard(repo, issueNum)
+	if err != nil {
+		t.Fatalf("query hazard after recovery: %v", err)
+	}
+	if hazard != nil {
+		t.Errorf("expected hazard cleared after status:* added, got %+v", hazard)
+	}
+}

--- a/internal/statemachine/statemachine.go
+++ b/internal/statemachine/statemachine.go
@@ -2,10 +2,13 @@ package statemachine
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -13,6 +16,7 @@ import (
 
 	"github.com/Lincyaw/workbuddy/internal/alertbus"
 	"github.com/Lincyaw/workbuddy/internal/config"
+	"github.com/Lincyaw/workbuddy/internal/dependency"
 	"github.com/Lincyaw/workbuddy/internal/eventlog"
 	"github.com/Lincyaw/workbuddy/internal/poller"
 	"github.com/Lincyaw/workbuddy/internal/store"
@@ -254,8 +258,21 @@ func (sm *StateMachine) HandleEvent(ctx context.Context, event ChangeEvent) erro
 	matched := sm.findMatchingWorkflows(event)
 
 	if len(matched) == 0 {
-		// No match — skip silently.
+		// REQ #255 scenario A: no workflow trigger label matched. If the
+		// issue carries a status:* label, the user has configured "this
+		// issue should be in a state" but the trigger label is missing,
+		// so the state machine would silently skip it. Surface the
+		// condition as an INFO event + persistent hazard so it shows up
+		// in `workbuddy status` and `workbuddy diagnose`.
+		if event.IssueNum > 0 && event.Type != poller.EventPollCycleDone {
+			sm.detectNoWorkflowMatchHazard(event)
+		}
 		return nil
+	}
+	// A workflow trigger label matched — clear any prior scenario A
+	// hazard for this issue so cleared conditions don't linger.
+	if event.IssueNum > 0 {
+		sm.clearHazardIfKind(event.Repo, event.IssueNum, store.HazardKindNoWorkflowMatch)
 	}
 	if len(matched) > 1 {
 		// Multiple workflows match — log error, skip.
@@ -301,9 +318,21 @@ func (sm *StateMachine) processWorkflowEvent(ctx context.Context, wf *config.Wor
 		return fmt.Errorf("statemachine: ensure workflow instance: %w", err)
 	}
 	if currentState == nil {
-		// Issue has the workflow trigger but no status label matching any state.
-		// Could be initial state or misconfigured. Skip silently.
+		// REQ #255 scenario B: workflow trigger label is present but no
+		// state label matched. If the issue body declares a depends_on
+		// block, the state machine cannot enter the issue and the
+		// dependency gate cannot release downstream work. Surface as a
+		// persistent hazard so the user sees they need to add a status:*
+		// label (or status:blocked) for the gate to evaluate.
+		if event.IssueNum > 0 {
+			sm.detectDependencyUnenteredHazard(wf, event)
+		}
 		return nil
+	}
+	// State label is present — clear any prior scenario B hazard so the
+	// cleared condition doesn't linger in `workbuddy status`.
+	if event.IssueNum > 0 {
+		sm.clearHazardIfKind(event.Repo, event.IssueNum, store.HazardKindAwaitingStatusLabel)
 	}
 
 	// State-entry detection: dispatch the state agents if:
@@ -1269,6 +1298,168 @@ func (sm *StateMachine) stateHasAgents(state *config.State) bool {
 
 func (sm *StateMachine) issueKey(repo string, issueNum int) string {
 	return fmt.Sprintf("%s#%d", repo, issueNum)
+}
+
+// detectNoWorkflowMatchHazard records the scenario A hazard (issue has a
+// status:* label but no workflow trigger label matched) idempotently per
+// labels fingerprint. Caller must already have established len(matched) == 0.
+func (sm *StateMachine) detectNoWorkflowMatchHazard(event ChangeEvent) {
+	if sm.store == nil {
+		return
+	}
+	if !hasStatusLabel(event.Labels) {
+		// No status label → user hasn't asked the issue to enter the
+		// pipeline yet. Not a hazard.
+		return
+	}
+	if !sm.hasAnyWorkflow() {
+		// No workflows configured at all (e.g. tests, fresh deploy
+		// without configs). Treating this as a hazard would just be
+		// noise.
+		return
+	}
+	fingerprint := labelsFingerprint(event.Labels)
+	hazard := store.PipelineHazard{
+		Repo:        event.Repo,
+		IssueNum:    event.IssueNum,
+		Kind:        store.HazardKindNoWorkflowMatch,
+		Fingerprint: fingerprint,
+	}
+	changed, err := sm.store.UpsertIssuePipelineHazard(hazard)
+	if err != nil {
+		log.Printf("[statemachine] upsert no-workflow-match hazard for %s#%d: %v", event.Repo, event.IssueNum, err)
+		return
+	}
+	if !changed {
+		return
+	}
+	triggers := sm.workflowTriggerLabels()
+	sm.eventlog.Log(eventlog.TypeIssueNoWorkflowMatch, event.Repo, event.IssueNum, map[string]any{
+		"labels":             append([]string(nil), event.Labels...),
+		"workflow_triggers":  triggers,
+		"hint":               "add one of the workflow trigger labels (e.g. workbuddy) to opt this issue into the pipeline",
+	})
+}
+
+// detectDependencyUnenteredHazard records the scenario B hazard (workflow
+// trigger label present, depends_on declared in body, but no status:* label
+// so the state machine cannot enter). Idempotent per (labels+depends_on)
+// fingerprint.
+func (sm *StateMachine) detectDependencyUnenteredHazard(wf *config.WorkflowConfig, event ChangeEvent) {
+	if sm.store == nil {
+		return
+	}
+	cache, err := sm.store.QueryIssueCache(event.Repo, event.IssueNum)
+	if err != nil || cache == nil {
+		return
+	}
+	decl := dependency.ParseDeclaration(event.Repo, cache.Body)
+	if !decl.HasBlock {
+		return
+	}
+	deps := make([]string, 0, len(decl.Dependencies))
+	for _, d := range decl.Dependencies {
+		ref := d.Normalized
+		if ref == "" {
+			ref = d.Raw
+		}
+		deps = append(deps, ref)
+	}
+	fingerprint := hazardFingerprint(labelsFingerprint(event.Labels), decl.SourceHash)
+	hazard := store.PipelineHazard{
+		Repo:        event.Repo,
+		IssueNum:    event.IssueNum,
+		Kind:        store.HazardKindAwaitingStatusLabel,
+		Fingerprint: fingerprint,
+	}
+	changed, err := sm.store.UpsertIssuePipelineHazard(hazard)
+	if err != nil {
+		log.Printf("[statemachine] upsert awaiting-status-label hazard for %s#%d: %v", event.Repo, event.IssueNum, err)
+		return
+	}
+	if !changed {
+		return
+	}
+	sm.eventlog.Log(eventlog.TypeIssueDependencyUnentered, event.Repo, event.IssueNum, map[string]any{
+		"workflow":    wf.Name,
+		"labels":      append([]string(nil), event.Labels...),
+		"depends_on":  deps,
+		"hint":        "add status:blocked so the dependency gate can evaluate, or status:developing if the deps are already satisfied",
+	})
+}
+
+// clearHazardIfKind removes a prior hazard row when its kind matches. We do
+// not unconditionally delete: a different hazard kind may legitimately be
+// present (e.g. a still-open scenario B even after a workflow trigger label
+// match for an unrelated workflow), and clearing it would lose state.
+func (sm *StateMachine) clearHazardIfKind(repo string, issueNum int, kind string) {
+	if sm.store == nil {
+		return
+	}
+	prev, err := sm.store.QueryIssuePipelineHazard(repo, issueNum)
+	if err != nil || prev == nil {
+		return
+	}
+	if prev.Kind != kind {
+		return
+	}
+	if err := sm.store.ClearIssuePipelineHazard(repo, issueNum); err != nil {
+		log.Printf("[statemachine] clear pipeline hazard for %s#%d: %v", repo, issueNum, err)
+	}
+}
+
+func (sm *StateMachine) hasAnyWorkflow() bool {
+	for _, wf := range sm.workflows {
+		if wf != nil && strings.TrimSpace(wf.Trigger.IssueLabel) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func (sm *StateMachine) workflowTriggerLabels() []string {
+	out := make([]string, 0, len(sm.workflows))
+	for _, wf := range sm.workflows {
+		if wf == nil {
+			continue
+		}
+		label := strings.TrimSpace(wf.Trigger.IssueLabel)
+		if label == "" {
+			continue
+		}
+		out = append(out, label)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func hasStatusLabel(labels []string) bool {
+	for _, l := range labels {
+		if strings.HasPrefix(l, "status:") {
+			return true
+		}
+	}
+	return false
+}
+
+func labelsFingerprint(labels []string) string {
+	sorted := append([]string(nil), labels...)
+	sort.Strings(sorted)
+	h := sha256.New()
+	for _, l := range sorted {
+		_, _ = h.Write([]byte(l))
+		_, _ = h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func hazardFingerprint(parts ...string) string {
+	h := sha256.New()
+	for _, p := range parts {
+		_, _ = h.Write([]byte(p))
+		_, _ = h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 func parseIssueKey(raw string) (string, int, bool) {

--- a/internal/store/pipeline_hazards.go
+++ b/internal/store/pipeline_hazards.go
@@ -1,0 +1,143 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// Pipeline hazard kinds. These name configuration-incompleteness conditions
+// that cause the coordinator to silently skip an issue. See REQ #255.
+const (
+	// HazardKindNoWorkflowMatch — issue carries a status:* label but no
+	// workflow trigger label matched, so the state machine cannot enter the
+	// issue and the user is left with no audit trail.
+	HazardKindNoWorkflowMatch = "no-workflow-match"
+	// HazardKindAwaitingStatusLabel — issue carries a workflow trigger label
+	// and a depends_on declaration but no status:* label, so the state
+	// machine never enters the issue and the dependency gate cannot release
+	// downstream work.
+	HazardKindAwaitingStatusLabel = "awaiting-status-label"
+)
+
+// PipelineHazard records a per-issue configuration-incompleteness condition.
+type PipelineHazard struct {
+	Repo        string
+	IssueNum    int
+	Kind        string
+	Fingerprint string
+	DetectedAt  time.Time
+}
+
+// UpsertIssuePipelineHazard inserts or updates the hazard row for the given
+// (repo, issue_num). It returns changed=true when the row was created or its
+// kind/fingerprint differs from a prior row, so callers can decide whether to
+// emit a fresh INFO event (idempotency contract).
+func (s *Store) UpsertIssuePipelineHazard(h PipelineHazard) (changed bool, err error) {
+	prev, err := s.QueryIssuePipelineHazard(h.Repo, h.IssueNum)
+	if err != nil {
+		return false, err
+	}
+	now := s.now().UTC().Format("2006-01-02 15:04:05")
+	_, err = s.db.Exec(
+		`INSERT INTO issue_pipeline_hazards
+			(repo, issue_num, kind, fingerprint, detected_at)
+			VALUES (?, ?, ?, ?, ?)
+			ON CONFLICT(repo, issue_num) DO UPDATE SET
+				kind = excluded.kind,
+				fingerprint = excluded.fingerprint,
+				detected_at = CASE
+					WHEN issue_pipeline_hazards.kind = excluded.kind
+						AND issue_pipeline_hazards.fingerprint = excluded.fingerprint
+					THEN issue_pipeline_hazards.detected_at
+					ELSE excluded.detected_at
+				END`,
+		h.Repo, h.IssueNum, h.Kind, h.Fingerprint, now,
+	)
+	if err != nil {
+		return false, fmt.Errorf("store: upsert issue pipeline hazard: %w", err)
+	}
+	if prev == nil {
+		return true, nil
+	}
+	if prev.Kind != h.Kind || prev.Fingerprint != h.Fingerprint {
+		return true, nil
+	}
+	return false, nil
+}
+
+// QueryIssuePipelineHazard returns the hazard for the given issue, or nil if
+// none is recorded.
+func (s *Store) QueryIssuePipelineHazard(repo string, issueNum int) (*PipelineHazard, error) {
+	row := s.db.QueryRow(
+		`SELECT repo, issue_num, kind, fingerprint, detected_at
+			FROM issue_pipeline_hazards WHERE repo = ? AND issue_num = ?`,
+		repo, issueNum,
+	)
+	var (
+		out    PipelineHazard
+		rawTS  string
+	)
+	err := row.Scan(&out.Repo, &out.IssueNum, &out.Kind, &out.Fingerprint, &rawTS)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("store: query issue pipeline hazard: %w", err)
+	}
+	if ts, ok := ParseTimestamp(rawTS, "issue_pipeline_hazards.detected_at"); ok {
+		out.DetectedAt = ts.UTC()
+	}
+	return &out, nil
+}
+
+// ListIssuePipelineHazards returns every hazard for the given repo, or every
+// hazard across all repos when repo is empty.
+func (s *Store) ListIssuePipelineHazards(repo string) ([]PipelineHazard, error) {
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if repo == "" {
+		rows, err = s.db.Query(
+			`SELECT repo, issue_num, kind, fingerprint, detected_at
+				FROM issue_pipeline_hazards ORDER BY repo, issue_num`,
+		)
+	} else {
+		rows, err = s.db.Query(
+			`SELECT repo, issue_num, kind, fingerprint, detected_at
+				FROM issue_pipeline_hazards WHERE repo = ? ORDER BY issue_num`,
+			repo,
+		)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("store: list issue pipeline hazards: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []PipelineHazard
+	for rows.Next() {
+		var h PipelineHazard
+		var rawTS string
+		if err := rows.Scan(&h.Repo, &h.IssueNum, &h.Kind, &h.Fingerprint, &rawTS); err != nil {
+			return nil, fmt.Errorf("store: scan issue pipeline hazard: %w", err)
+		}
+		if ts, ok := ParseTimestamp(rawTS, "issue_pipeline_hazards.detected_at"); ok {
+			h.DetectedAt = ts.UTC()
+		}
+		out = append(out, h)
+	}
+	return out, rows.Err()
+}
+
+// ClearIssuePipelineHazard deletes the hazard row for the given issue. Returns
+// nil when the row does not exist.
+func (s *Store) ClearIssuePipelineHazard(repo string, issueNum int) error {
+	_, err := s.db.Exec(
+		`DELETE FROM issue_pipeline_hazards WHERE repo = ? AND issue_num = ?`,
+		repo, issueNum,
+	)
+	if err != nil {
+		return fmt.Errorf("store: clear issue pipeline hazard: %w", err)
+	}
+	return nil
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -290,6 +290,14 @@ func (s *Store) createTables() error {
 			expires_at DATETIME NOT NULL,
 			PRIMARY KEY (repo, issue_num)
 		)`,
+		`CREATE TABLE IF NOT EXISTS issue_pipeline_hazards (
+				repo TEXT NOT NULL,
+				issue_num INTEGER NOT NULL,
+				kind TEXT NOT NULL,
+				fingerprint TEXT NOT NULL,
+				detected_at DATETIME NOT NULL,
+				PRIMARY KEY (repo, issue_num)
+			)`,
 		`CREATE TABLE IF NOT EXISTS issue_cycle_state (
 			repo TEXT NOT NULL,
 			issue_num INTEGER NOT NULL,

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -3571,3 +3571,46 @@ requirements:
     tests:
       - web/src/components/Layout.test.tsx
     deps: []
+
+  - id: REQ-103
+    title: surface silent state-machine skips as pipeline hazards (#255)
+    description: >
+      Two coordinator skip paths used to be invisible: an issue carrying a
+      status:* label without any workflow trigger label match
+      (findMatchingWorkflows = empty), and an issue carrying a workflow
+      trigger label and depends_on YAML but no status:* label
+      (currentState = nil in processWorkflowEvent). Both produced no log,
+      no event, and no surface in `workbuddy status` / `diagnose`. The
+      state machine now records both conditions as persistent hazards in
+      a new `issue_pipeline_hazards` table, emits INFO eventlog entries
+      (`issue_no_workflow_match`, `issue_dependency_unentered`) idempotent
+      per labels/body fingerprint, and overrides the DependencyVerdict
+      surface in audit/auditapi so `workbuddy status` shows
+      `no-workflow-match` / `awaiting-status-label` in the DEPENDENCY
+      column. `workbuddy diagnose` adds a `pipeline_hazard` finding kind
+      with the user-facing remediation hint. The opt-in nature of the
+      trigger label and status label is preserved — coordinator never
+      auto-adds either.
+    priority: P1
+    version: v0.5.0
+    status: tested
+    acceptance_criteria:
+      - "AC-103-1: HandleEvent records an INFO `issue_no_workflow_match` event + persistent hazard when an issue has any status:* label, workflows are configured, and findMatchingWorkflows returned empty; a second event with identical labels does not duplicate the event (idempotent per labels fingerprint)."
+      - "AC-103-2: processWorkflowEvent records an INFO `issue_dependency_unentered` event + persistent hazard when currentState is nil and the issue body parses a workbuddy.depends_on block; idempotent per (labels + depends_on source-hash) fingerprint."
+      - "AC-103-3: audit `IssueStateResponse.DependencyVerdict` and auditapi `issueStateResponse.DependencyVerdict` both report the hazard kind (`no-workflow-match` / `awaiting-status-label`) when a hazard is recorded, so `workbuddy status` renders it in the DEPENDENCY column."
+      - "AC-103-4: auditapi `inFlightIssueResponse.Hazard` is populated from issue_pipeline_hazards so the webui in-flight view can render the condition."
+      - "AC-103-5: `workbuddy diagnose` emits a `pipeline_hazard` finding with user-facing fix text (`add the workflow trigger label, e.g. workbuddy` / `add status:blocked so the gate can evaluate, or status:developing if the deps are already satisfied`)."
+      - "AC-103-6: hazards clear automatically when the user adds the missing label (workflow trigger or status:*); the row also clears on issue close so closed issues do not linger in the diagnose feed."
+      - "AC-103-7: Two unit tests cover scenario A (status:* without workbuddy trigger) and scenario B (workbuddy + depends_on without status:*); both assert event + hazard creation and idempotent re-emission, plus auto-clear on label fix."
+    code:
+      - internal/eventlog/eventlog.go
+      - internal/store/store.go
+      - internal/store/pipeline_hazards.go
+      - internal/statemachine/statemachine.go
+      - internal/audit/http.go
+      - internal/auditapi/handler.go
+      - internal/diagnose/diagnose.go
+      - internal/poller/poller.go
+    tests:
+      - internal/statemachine/pipeline_hazards_test.go
+    deps: []


### PR DESCRIPTION
## Summary
- Adds an `issue_pipeline_hazards` SQLite table + helpers; the state machine
  now records a hazard row + INFO event (idempotent per labels/body
  fingerprint) for the two silent skip paths called out in #255.
- Scenario A (`status:*` without any workflow trigger label match) emits
  `issue_no_workflow_match`; scenario B (workflow trigger + `depends_on:` but
  no `status:*`) emits `issue_dependency_unentered`.
- audit + auditapi handlers override `DependencyVerdict` with the hazard kind
  so `workbuddy status` shows `no-workflow-match` / `awaiting-status-label`
  in the DEPENDENCY column; `inFlightIssueResponse` gains a `hazard` field
  for the webui in-flight view; `workbuddy diagnose` adds a `pipeline_hazard`
  finding with the user-facing remediation hint.
- Hazards clear automatically when the missing label is added or the issue
  closes. Coordinator never auto-adds a trigger or status label (per the
  issue's non-goals).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/statemachine/...` — two new tests cover scenarios A
      and B, including idempotency on identical labels/body and auto-clear
      when the user adds the missing label.
- [x] `go test ./...` — all pre-existing suites still green (the cmd-package
      `TestParseWorkerFlags_MgmtPublicURLRequiresSharedAuth` failure also
      reproduces on `main` and is unrelated to this change).

Fixes #255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)