### PR TITLE
hooks: phase 1c — match filters, metrics, hooks status/reload, lifecycle eventlog (#266)

### DIFF
--- a/cmd/coordinator.go
+++ b/cmd/coordinator.go
@@ -436,9 +436,10 @@ func runCoordinatorWithOpts(opts *coordinatorOpts, ghReader poller.GHReader, par
 		return err
 	}
 
+	hooksConfigPath := ResolveHooksConfigPath(opts.hooksConfig)
 	srv := &http.Server{
 		Addr:    resolveListenAddr(opts.listenAddr, port),
-		Handler: buildCoordinatorMux(api, st, evlog, opts.dbPath, taskHub),
+		Handler: buildCoordinatorMux(api, st, evlog, opts.dbPath, taskHub, hooksDispatcher, hooksConfigPath),
 	}
 
 	var wg sync.WaitGroup
@@ -450,6 +451,8 @@ func runCoordinatorWithOpts(opts *coordinatorOpts, ghReader poller.GHReader, par
 		}
 	}()
 
+	emitCoordinatorStarted(evlog, "coordinator", srv.Addr)
+
 	if sigCh != nil {
 		select {
 		case sig := <-sigCh:
@@ -459,6 +462,8 @@ func runCoordinatorWithOpts(opts *coordinatorOpts, ghReader poller.GHReader, par
 	} else {
 		<-ctx.Done()
 	}
+
+	emitCoordinatorStopping(evlog, "coordinator", srv.Addr)
 
 	cancel()
 	api.Pollers.Shutdown()
@@ -569,7 +574,7 @@ func resolveListenAddr(listenAddr string, port int) string {
 	return listenAddr
 }
 
-func buildCoordinatorMux(api *app.FullCoordinatorServer, st *store.Store, evlog *eventlog.EventLogger, dbPath string, taskHub *tasknotify.Hub) *http.ServeMux {
+func buildCoordinatorMux(api *app.FullCoordinatorServer, st *store.Store, evlog *eventlog.EventLogger, dbPath string, taskHub *tasknotify.Hub, hooksDispatcher *hooks.Dispatcher, hooksConfigPath string) *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", api.HandleHealth)
 
@@ -588,8 +593,16 @@ func buildCoordinatorMux(api *app.FullCoordinatorServer, st *store.Store, evlog 
 	mux.Handle("/issues/{owner}/{repo}/{num}/state", api.WrapAuth(readOnlyAuditMux))
 
 	metricsMux := http.NewServeMux()
-	metrics.NewHandler(st).WithEventLogger(evlog).Register(metricsMux)
+	metricsHandler := metrics.NewHandler(st).WithEventLogger(evlog)
+	if hooksDispatcher != nil {
+		metricsHandler = metricsHandler.WithHooks(hooksDispatcher)
+	}
+	metricsHandler.Register(metricsMux)
 	mux.Handle("/metrics", api.WrapAuth(metricsMux))
+
+	hooksAPI := app.NewHooksAPI(hooksDispatcher, evlog, hooksConfigPath)
+	mux.Handle("/api/v1/hooks/status", api.WrapAuth(http.HandlerFunc(hooksAPI.HandleStatus)))
+	mux.Handle("/api/v1/hooks/reload", api.WrapAuth(http.HandlerFunc(hooksAPI.HandleReload)))
 
 	dashboardAPI := auditapi.NewHandler(st)
 	sessionsDir := filepath.Join(filepath.Dir(dbPath), "sessions")

--- a/cmd/coordinator_lifecycle.go
+++ b/cmd/coordinator_lifecycle.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/Lincyaw/workbuddy/internal/eventlog"
+)
+
+// emitCoordinatorStarted records a coordinator_started event at the tail of
+// startup so operator hooks (and the audit trail) can detect process
+// restarts. Called from both `workbuddy serve` (after coordinator/worker are
+// up) and `workbuddy coordinator` (after the HTTP listener is reserved).
+func emitCoordinatorStarted(evlog *eventlog.EventLogger, mode, listenAddr string) {
+	if evlog == nil {
+		return
+	}
+	evlog.Log(eventlog.TypeCoordinatorStarted, "", 0, map[string]interface{}{
+		"mode":        mode,
+		"listen":      listenAddr,
+		"pid":         os.Getpid(),
+		"version":     versionString(),
+	})
+}
+
+// emitCoordinatorStopping records a coordinator_stopping event at the head of
+// the graceful-shutdown path so hooks can react before workers/pollers drain.
+func emitCoordinatorStopping(evlog *eventlog.EventLogger, mode, listenAddr string) {
+	if evlog == nil {
+		return
+	}
+	evlog.Log(eventlog.TypeCoordinatorStopping, "", 0, map[string]interface{}{
+		"mode":   mode,
+		"listen": listenAddr,
+		"pid":    os.Getpid(),
+	})
+}

--- a/cmd/coordinator_lifecycle_test.go
+++ b/cmd/coordinator_lifecycle_test.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Lincyaw/workbuddy/internal/eventlog"
+	"github.com/Lincyaw/workbuddy/internal/store"
+)
+
+// emitCoordinatorStarted/Stopping must produce eventlog entries with
+// payload fields the operator dashboards rely on.
+func TestEmitCoordinatorLifecycleEvents(t *testing.T) {
+	dir := t.TempDir()
+	st, err := store.NewStore(filepath.Join(dir, "lc.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+	evlog := eventlog.NewEventLogger(st)
+
+	emitCoordinatorStarted(evlog, "coordinator", "127.0.0.1:9999")
+	emitCoordinatorStopping(evlog, "coordinator", "127.0.0.1:9999")
+
+	// Wait for both — Log() is synchronous against SQLite, but allow a beat
+	// for the dispatcher publish path that may run on a goroutine.
+	deadline := time.Now().Add(time.Second)
+	var started, stopping []store.Event
+	for time.Now().Before(deadline) {
+		started, _ = evlog.Query(eventlog.EventFilter{Type: eventlog.TypeCoordinatorStarted})
+		stopping, _ = evlog.Query(eventlog.EventFilter{Type: eventlog.TypeCoordinatorStopping})
+		if len(started) > 0 && len(stopping) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(started) == 0 {
+		t.Fatalf("coordinator_started not recorded")
+	}
+	if len(stopping) == 0 {
+		t.Fatalf("coordinator_stopping not recorded")
+	}
+	for _, want := range []string{`"listen":"127.0.0.1:9999"`, `"pid":`} {
+		if !contains(started[0].Payload, want) {
+			t.Errorf("started payload missing %s: %s", want, started[0].Payload)
+		}
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && (haystack == needle || stringContains(haystack, needle))
+}
+
+// stringContains is a tiny re-roll to avoid importing strings just for tests
+// that already pull eventlog/store.
+func stringContains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/coordinator_sessions_spa_test.go
+++ b/cmd/coordinator_sessions_spa_test.go
@@ -48,7 +48,7 @@ func TestCoordinatorRoutesSessionsThroughSPAFallback(t *testing.T) {
 	}
 
 	api := &app.FullCoordinatorServer{Store: st, AuthEnabled: true, AuthToken: "spa-secret"}
-	mux := buildCoordinatorMux(api, st, eventlog.NewEventLogger(st), dbPath, nil)
+	mux := buildCoordinatorMux(api, st, eventlog.NewEventLogger(st), dbPath, nil, nil, "")
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
@@ -11,6 +13,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/Lincyaw/workbuddy/internal/app"
 	"github.com/Lincyaw/workbuddy/internal/hooks"
 	"github.com/spf13/cobra"
 )
@@ -33,6 +36,26 @@ var (
 	hooksTestEventFixture string
 )
 
+var hooksStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show per-hook invocation stats from a running coordinator",
+	Long: `Query the coordinator's /api/v1/hooks/status endpoint and render per-hook
+counts (success/failure/filtered/disabled), the last error, and whether the
+hook is auto-disabled. Requires --coordinator and a bearer token (env
+WORKBUDDY_AUTH_TOKEN or --token).`,
+	RunE: runHooksStatus,
+}
+
+var hooksReloadCmd = &cobra.Command{
+	Use:   "reload",
+	Short: "Reload the coordinator's hooks YAML, clearing auto-disable state",
+	Long: `POST to the coordinator's /api/v1/hooks/reload endpoint. The coordinator
+re-reads its hooks YAML, rebuilds dispatcher bindings (which clears
+auto-disable), and emits a hooks_reloaded event. Requires --coordinator and
+a bearer token.`,
+	RunE: runHooksReload,
+}
+
 var hooksTestCmd = &cobra.Command{
 	Use:   "test",
 	Short: "Fire a hook once with a fixture event (does NOT write eventlog)",
@@ -50,6 +73,19 @@ func init() {
 	_ = hooksTestCmd.MarkFlagRequired("hook")
 	_ = hooksTestCmd.MarkFlagRequired("event-fixture")
 	hooksCmd.AddCommand(hooksTestCmd)
+
+	hooksStatusCmd.Flags().String("coordinator", "", "Coordinator base URL")
+	addCoordinatorAuthFlags(hooksStatusCmd.Flags(), "t", "Bearer token for coordinator auth")
+	hooksStatusCmd.Flags().Duration("timeout", 15*time.Second, "HTTP timeout")
+	addOutputFormatFlag(hooksStatusCmd)
+	hooksCmd.AddCommand(hooksStatusCmd)
+
+	hooksReloadCmd.Flags().String("coordinator", "", "Coordinator base URL")
+	addCoordinatorAuthFlags(hooksReloadCmd.Flags(), "t", "Bearer token for coordinator auth")
+	hooksReloadCmd.Flags().Duration("timeout", 15*time.Second, "HTTP timeout")
+	addOutputFormatFlag(hooksReloadCmd)
+	hooksCmd.AddCommand(hooksReloadCmd)
+
 	rootCmd.AddCommand(hooksCmd)
 
 	// Make --hooks-config available on serve and coordinator so the loaded
@@ -210,6 +246,135 @@ func runHooksTest(cmd *cobra.Command, _ []string) error {
 		fmt.Fprintln(out, "result: ok")
 		return nil
 	}
+}
+
+type hooksRemoteOpts struct {
+	coordinator string
+	token       string
+	timeout     time.Duration
+	format      string
+}
+
+func parseHooksRemoteFlags(cmd *cobra.Command, name string) (*hooksRemoteOpts, error) {
+	coordURL, _ := cmd.Flags().GetString("coordinator")
+	if strings.TrimSpace(coordURL) == "" {
+		return nil, fmt.Errorf("%s: --coordinator is required", name)
+	}
+	timeout, _ := cmd.Flags().GetDuration("timeout")
+	token, err := resolveCoordinatorAuthToken(cmd, name)
+	if err != nil {
+		return nil, err
+	}
+	format, err := resolveOutputFormat(cmd, name)
+	if err != nil {
+		return nil, err
+	}
+	return &hooksRemoteOpts{
+		coordinator: strings.TrimRight(strings.TrimSpace(coordURL), "/"),
+		token:       token,
+		timeout:     timeout,
+		format:      format,
+	}, nil
+}
+
+func runHooksStatus(cmd *cobra.Command, _ []string) error {
+	opts, err := parseHooksRemoteFlags(cmd, "hooks status")
+	if err != nil {
+		return err
+	}
+	body, err := callHooksAPI(cmd.Context(), opts, http.MethodGet, "/api/v1/hooks/status")
+	if err != nil {
+		return err
+	}
+	if isJSONOutput(opts.format) {
+		_, err = cmdStdout(cmd).Write(body)
+		return err
+	}
+	var resp app.HooksStatusResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return fmt.Errorf("hooks status: decode response: %w", err)
+	}
+	out := cmdStdout(cmd)
+	fmt.Fprintf(out, "config: %s\n", displayHooksPath(resp.ConfigPath))
+	fmt.Fprintf(out, "overflow: %d  dropped: %d\n\n", resp.OverflowTotal, resp.DroppedTotal)
+	if len(resp.Hooks) == 0 {
+		fmt.Fprintln(out, "no hooks registered")
+		return nil
+	}
+	tw := tabwriter.NewWriter(out, 0, 8, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "NAME\tEVENTS\tACTION\tENABLED\tDISABLED\tOK\tFAIL\tFILTERED\tLAST_ERROR")
+	rows := append([]app.HookStatusEntry(nil), resp.Hooks...)
+	sort.Slice(rows, func(i, j int) bool { return rows[i].Name < rows[j].Name })
+	for _, h := range rows {
+		enabled := "yes"
+		if !h.Enabled {
+			enabled = "no"
+		}
+		disabled := "no"
+		if h.AutoDisabled {
+			disabled = "yes"
+		}
+		lastErr := h.LastError
+		if len(lastErr) > 60 {
+			lastErr = lastErr[:57] + "..."
+		}
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%d\t%d\t%d\t%s\n",
+			h.Name, strings.Join(h.Events, ","), h.ActionType, enabled, disabled,
+			h.Successes, h.Failures, h.Filtered, lastErr)
+	}
+	return tw.Flush()
+}
+
+func runHooksReload(cmd *cobra.Command, _ []string) error {
+	opts, err := parseHooksRemoteFlags(cmd, "hooks reload")
+	if err != nil {
+		return err
+	}
+	if err := requireWritable(cmd, "hooks reload"); err != nil {
+		return err
+	}
+	body, err := callHooksAPI(cmd.Context(), opts, http.MethodPost, "/api/v1/hooks/reload")
+	if err != nil {
+		return err
+	}
+	if isJSONOutput(opts.format) {
+		_, err = cmdStdout(cmd).Write(body)
+		return err
+	}
+	var resp app.HooksReloadResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return fmt.Errorf("hooks reload: decode response: %w", err)
+	}
+	out := cmdStdout(cmd)
+	fmt.Fprintf(out, "reloaded %d hook(s) from %s\n", resp.HookCount, displayHooksPath(resp.ConfigPath))
+	for _, w := range resp.Warnings {
+		fmt.Fprintf(out, "warning: %s\n", w)
+	}
+	return nil
+}
+
+func callHooksAPI(ctx context.Context, opts *hooksRemoteOpts, method, path string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, method, opts.coordinator+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	if opts.token != "" {
+		req.Header.Set("Authorization", "Bearer "+opts.token)
+	}
+	client := &http.Client{Timeout: opts.timeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode/100 != 2 {
+		return nil, &cliExitError{
+			msg:  fmt.Sprintf("coordinator returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body))),
+			code: exitCodeFailure,
+		}
+	}
+	return body, nil
 }
 
 func displayHooksPath(p string) string {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -276,7 +276,7 @@ func TestServeAuthWrapsNonHealthRoutes(t *testing.T) {
 		AuthEnabled: true,
 		AuthToken:   "serve-secret",
 	}
-	mux := buildCoordinatorMux(api, st, eventlog.NewEventLogger(st), filepath.Join(t.TempDir(), "serve.db"), nil)
+	mux := buildCoordinatorMux(api, st, eventlog.NewEventLogger(st), filepath.Join(t.TempDir(), "serve.db"), nil, nil, "")
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 

--- a/internal/app/hooks_api.go
+++ b/internal/app/hooks_api.go
@@ -1,0 +1,161 @@
+// Package app — hooks_api.go exposes the runtime hook surface over HTTP.
+//
+// Endpoints (registered under /api/v1/hooks/ in the coordinator mux):
+//
+//   GET  /api/v1/hooks/status — JSON of per-hook stats, last failure, disabled
+//   POST /api/v1/hooks/reload — re-read hooks YAML, clear auto-disable, emit
+//                                a hooks_reloaded event so dashboards can
+//                                correlate.
+//
+// These are the read/write counterparts of `workbuddy hooks list` (which is
+// purely client-side and reads the YAML, not the running dispatcher). Without
+// the dispatcher attached the endpoints respond with 503 so operators can
+// distinguish "no hooks configured" from "this binary doesn't know about
+// hooks".
+package app
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/Lincyaw/workbuddy/internal/eventlog"
+	"github.com/Lincyaw/workbuddy/internal/hooks"
+)
+
+// HooksAPI is the operational surface for the running dispatcher.
+type HooksAPI struct {
+	dispatcher *hooks.Dispatcher
+	evlog      *eventlog.EventLogger
+	configPath string
+}
+
+// NewHooksAPI binds the dispatcher and config path. Either may be nil; the
+// handlers degrade gracefully (503 when there is nothing to report on).
+func NewHooksAPI(d *hooks.Dispatcher, evlog *eventlog.EventLogger, configPath string) *HooksAPI {
+	return &HooksAPI{dispatcher: d, evlog: evlog, configPath: configPath}
+}
+
+// HookStatusEntry is the JSON projection of one hook's runtime state.
+type HookStatusEntry struct {
+	Name             string    `json:"name"`
+	Events           []string  `json:"events"`
+	ActionType       string    `json:"action_type"`
+	Enabled          bool      `json:"enabled"`
+	AutoDisabled     bool      `json:"auto_disabled"`
+	Successes        uint64    `json:"successes"`
+	Failures         uint64    `json:"failures"`
+	Filtered         uint64    `json:"filtered"`
+	DisabledDrops    uint64    `json:"disabled_drops"`
+	ConsecutiveFails int       `json:"consecutive_failures"`
+	LastError        string    `json:"last_error,omitempty"`
+	LastFailureAt    time.Time `json:"last_failure_at,omitempty"`
+	LastInvokedAt    time.Time `json:"last_invoked_at,omitempty"`
+	DurationCount    uint64    `json:"duration_count"`
+	DurationSumNs    uint64    `json:"duration_sum_ns"`
+}
+
+// HooksStatusResponse is the JSON shape returned by GET /api/v1/hooks/status.
+type HooksStatusResponse struct {
+	ConfigPath    string            `json:"config_path,omitempty"`
+	OverflowTotal uint64            `json:"overflow_total"`
+	DroppedTotal  uint64            `json:"dropped_total"`
+	Hooks         []HookStatusEntry `json:"hooks"`
+}
+
+// HandleStatus serves GET /api/v1/hooks/status.
+func (h *HooksAPI) HandleStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeHooksJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	if h.dispatcher == nil {
+		writeHooksJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "hooks dispatcher not configured"})
+		return
+	}
+	resp := HooksStatusResponse{
+		ConfigPath:    h.configPath,
+		OverflowTotal: h.dispatcher.OverflowCount(),
+		DroppedTotal:  h.dispatcher.DroppedCount(),
+	}
+	for _, s := range h.dispatcher.Stats() {
+		resp.Hooks = append(resp.Hooks, HookStatusEntry{
+			Name:             s.Name,
+			Events:           s.Events,
+			ActionType:       s.ActionType,
+			Enabled:          s.Enabled,
+			AutoDisabled:     s.Disabled,
+			Successes:        s.Successes,
+			Failures:         s.Failures,
+			Filtered:         s.Filtered,
+			DisabledDrops:    s.DisabledDrops,
+			ConsecutiveFails: s.ConsecutiveFail,
+			LastError:        s.LastError,
+			LastFailureAt:    s.LastFailureAt,
+			LastInvokedAt:    s.LastInvokedAt,
+			DurationCount:    s.DurationCount,
+			DurationSumNs:    s.DurationSumNs,
+		})
+	}
+	writeHooksJSON(w, http.StatusOK, resp)
+}
+
+// HooksReloadResponse is the JSON shape returned by POST /api/v1/hooks/reload.
+type HooksReloadResponse struct {
+	ConfigPath string   `json:"config_path"`
+	HookCount  int      `json:"hook_count"`
+	Warnings   []string `json:"warnings,omitempty"`
+}
+
+// HandleReload serves POST /api/v1/hooks/reload. Reload re-reads the YAML,
+// rebuilds the dispatcher's hook bindings (clearing auto-disable along the
+// way), and emits a hooks_reloaded event so external consumers can
+// correlate the action with subsequent successes/failures.
+func (h *HooksAPI) HandleReload(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeHooksJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	if h.dispatcher == nil {
+		writeHooksJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "hooks dispatcher not configured"})
+		return
+	}
+	cfg, parseWarnings, err := hooks.LoadConfig(h.configPath)
+	if err != nil {
+		writeHooksJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	buildWarnings, err := h.dispatcher.Reload(cfg, hooks.DefaultActionRegistry())
+	if err != nil {
+		writeHooksJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	all := append([]string(nil), parseWarnings...)
+	all = append(all, buildWarnings...)
+	count := 0
+	if cfg != nil {
+		for i := range cfg.Hooks {
+			if cfg.Hooks[i].IsEnabled() {
+				count++
+			}
+		}
+	}
+	if h.evlog != nil {
+		h.evlog.Log(eventlog.TypeHooksReloaded, "", 0, map[string]interface{}{
+			"config_path": h.configPath,
+			"hook_count":  count,
+			"warnings":    all,
+		})
+	}
+	writeHooksJSON(w, http.StatusOK, HooksReloadResponse{
+		ConfigPath: h.configPath,
+		HookCount:  count,
+		Warnings:   all,
+	})
+}
+
+func writeHooksJSON(w http.ResponseWriter, status int, body interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/internal/app/hooks_api_test.go
+++ b/internal/app/hooks_api_test.go
@@ -1,0 +1,144 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Lincyaw/workbuddy/internal/eventlog"
+	"github.com/Lincyaw/workbuddy/internal/hooks"
+	"github.com/Lincyaw/workbuddy/internal/store"
+)
+
+// freshStore opens a temp SQLite store for tests. Returned cleanup runs the
+// store.Close on test end.
+func freshStore(t *testing.T) (*store.Store, string) {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	st, err := store.NewStore(dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return st, dbPath
+}
+
+// Reload via HTTP must emit a hooks_reloaded event with the config path so
+// dashboards can correlate the reload with subsequent activity.
+func TestHooksAPIReloadEmitsEvent(t *testing.T) {
+	st, _ := freshStore(t)
+	evlog := eventlog.NewEventLogger(st)
+
+	yaml := []byte(`hooks:
+  - name: t
+    events: [alert]
+    action:
+      type: webhook
+      url: https://example.invalid/hook
+`)
+	cfgPath := filepath.Join(t.TempDir(), "hooks.yaml")
+	if err := os.WriteFile(cfgPath, yaml, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := hooks.LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	d, _, err := hooks.NewDispatcher(cfg, hooks.DefaultActionRegistry())
+	if err != nil {
+		t.Fatalf("dispatcher: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d.Start(ctx)
+	defer d.Stop()
+
+	api := NewHooksAPI(d, evlog, cfgPath)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/reload", nil)
+	rr := httptest.NewRecorder()
+	api.HandleReload(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d body=%s", rr.Code, rr.Body.String())
+	}
+	var resp HooksReloadResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.HookCount != 1 {
+		t.Fatalf("hook_count=%d want 1", resp.HookCount)
+	}
+
+	// hooks_reloaded event must be in the eventlog.
+	deadline := time.Now().Add(2 * time.Second)
+	var got []store.Event
+	for time.Now().Before(deadline) {
+		got, _ = evlog.Query(eventlog.EventFilter{Type: eventlog.TypeHooksReloaded})
+		if len(got) > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if len(got) == 0 {
+		t.Fatalf("hooks_reloaded event not recorded")
+	}
+	if !strings.Contains(got[0].Payload, "hook_count") {
+		t.Fatalf("payload missing hook_count: %s", got[0].Payload)
+	}
+}
+
+func TestHooksAPIStatusReportsCounters(t *testing.T) {
+	st, _ := freshStore(t)
+	evlog := eventlog.NewEventLogger(st)
+
+	enabled := true
+	cfg := &hooks.Config{
+		SchemaVersion: 1,
+		Hooks: []hooks.Hook{{
+			Name:    "t",
+			Enabled: &enabled,
+			Events:  []string{"alert"},
+			Action:  hooks.ActionConfig{Type: "webhook", URL: "https://example.invalid/hook"},
+		}},
+	}
+	d, _, err := hooks.NewDispatcher(cfg, hooks.DefaultActionRegistry())
+	if err != nil {
+		t.Fatalf("dispatcher: %v", err)
+	}
+	api := NewHooksAPI(d, evlog, "/etc/workbuddy/hooks.yaml")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/hooks/status", nil)
+	rr := httptest.NewRecorder()
+	api.HandleStatus(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d body=%s", rr.Code, rr.Body.String())
+	}
+	var resp HooksStatusResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.ConfigPath != "/etc/workbuddy/hooks.yaml" {
+		t.Fatalf("config_path=%q", resp.ConfigPath)
+	}
+	if len(resp.Hooks) != 1 || resp.Hooks[0].Name != "t" {
+		t.Fatalf("unexpected hooks: %+v", resp.Hooks)
+	}
+}
+
+func TestHooksAPIStatusReturns503WhenDispatcherMissing(t *testing.T) {
+	api := NewHooksAPI(nil, nil, "")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/hooks/status", nil)
+	rr := httptest.NewRecorder()
+	api.HandleStatus(rr, req)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d want 503", rr.Code)
+	}
+}

--- a/internal/eventlog/eventlog.go
+++ b/internal/eventlog/eventlog.go
@@ -64,6 +64,18 @@ const (
 	// gate cannot release downstream work. Idempotent per (labels+depends_on)
 	// fingerprint. See REQ #255.
 	TypeIssueDependencyUnentered = "issue_dependency_unentered"
+	// TypeCoordinatorStarted is emitted at the tail of coordinator/serve startup
+	// (after the HTTP listener is reserved). Payload carries listen address,
+	// pid, and version so operator hook actions can detect process restarts.
+	// See issue #266.
+	TypeCoordinatorStarted = "coordinator_started"
+	// TypeCoordinatorStopping is emitted at the head of the graceful-shutdown
+	// handler so hooks can react before workers/pollers drain. See issue #266.
+	TypeCoordinatorStopping = "coordinator_stopping"
+	// TypeHooksReloaded is emitted by `workbuddy hooks reload` so operator
+	// dashboards can correlate auto-disable resets with the reload action.
+	// See issue #266.
+	TypeHooksReloaded = "hooks_reloaded"
 )
 
 // AllEventTypes lists every recognised event type.
@@ -108,6 +120,9 @@ var AllEventTypes = []string{
 	TypeLongFlightStuck,
 	TypeIssueNoWorkflowMatch,
 	TypeIssueDependencyUnentered,
+	TypeCoordinatorStarted,
+	TypeCoordinatorStopping,
+	TypeHooksReloaded,
 }
 
 // EventFilter specifies optional criteria for querying events.

--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -10,6 +10,7 @@ package hooks
 import (
 	"fmt"
 	"os"
+	"path"
 	"regexp"
 	"strings"
 	"time"
@@ -37,7 +38,13 @@ type Hook struct {
 	Action  ActionConfig  `yaml:"action"`
 }
 
-// MatchFilter is parsed but not enforced in Phase 1a.
+// MatchFilter narrows the events a hook receives. Filters AND together: an
+// event must satisfy every set filter to be delivered.
+//
+//   - Severity is honoured only when the event_type is `alert`. Configuring it
+//     for any other event surfaces a startup warning (see ParseConfig).
+//   - Repo is a glob (path.Match syntax) tested against the event's repo
+//     field. Empty/missing repo filter is match-all.
 type MatchFilter struct {
 	Severity []string `yaml:"severity,omitempty"`
 	Repo     string   `yaml:"repo,omitempty"`
@@ -115,8 +122,102 @@ func ParseConfig(raw []byte) (*Config, []string, error) {
 			return nil, nil, err
 		}
 		warnings = append(warnings, w...)
+		if mw, err := validateMatchFilter(h); err != nil {
+			return nil, nil, err
+		} else {
+			warnings = append(warnings, mw...)
+		}
 	}
 	return &cfg, warnings, nil
+}
+
+// validateMatchFilter returns startup warnings (e.g. severity on non-alert
+// events) and an error if the filter is structurally invalid (e.g. malformed
+// repo glob).
+func validateMatchFilter(h *Hook) ([]string, error) {
+	if h == nil || h.Match == nil {
+		return nil, nil
+	}
+	var warnings []string
+	if len(h.Match.Severity) > 0 {
+		// severity only applies when the hook subscribes solely to alert
+		// events. If the event list contains anything non-alert (or `*`),
+		// the filter cannot be enforced for those — surface a warning.
+		nonAlert := false
+		for _, ev := range h.Events {
+			if ev != "alert" {
+				nonAlert = true
+				break
+			}
+		}
+		if nonAlert {
+			warnings = append(warnings, fmt.Sprintf("hook %q: match.severity only applies to event_type=alert; ignored for other events", h.Name))
+		}
+	}
+	if strings.TrimSpace(h.Match.Repo) != "" {
+		// Validate the glob early — path.Match returns ErrBadPattern only when
+		// the pattern is matched, so probe with an arbitrary input.
+		if _, err := path.Match(h.Match.Repo, "owner/repo"); err != nil {
+			return nil, fmt.Errorf("hooks: hook %q: invalid match.repo glob %q: %w", h.Name, h.Match.Repo, err)
+		}
+	}
+	return warnings, nil
+}
+
+// MatchesEvelope reports whether the hook's match filter accepts the event.
+// The dispatcher calls this after the event-type subscription check; the
+// filter is the second-stage gate.
+//
+// Semantics:
+//   - severity: applies only to event_type=alert. The payload must carry a
+//     top-level `severity` JSON string and it must appear in the allow-list
+//     (case-insensitive). On non-alert events this filter is a no-op (with a
+//     startup warning surfaced via ParseConfig).
+//   - repo: glob via path.Match against the event's Repo field. Empty filter
+//     matches everything (including events with no repo).
+func (h *Hook) MatchesFilter(ev Event) bool {
+	if h == nil || h.Match == nil {
+		return true
+	}
+	if h.Match.Repo != "" {
+		ok, err := path.Match(h.Match.Repo, ev.Repo)
+		if err != nil || !ok {
+			return false
+		}
+	}
+	if len(h.Match.Severity) > 0 && ev.Type == "alert" {
+		sev := extractSeverity(ev.Payload)
+		if sev == "" {
+			return false
+		}
+		matched := false
+		for _, allowed := range h.Match.Severity {
+			if strings.EqualFold(strings.TrimSpace(allowed), sev) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	return true
+}
+
+// extractSeverity pulls the `severity` string from a JSON payload using a
+// shallow regex so we don't need to fully unmarshal every event. Returns
+// the empty string when the field is absent or malformed.
+var severityFieldPattern = regexp.MustCompile(`"severity"\s*:\s*"([^"]*)"`)
+
+func extractSeverity(payload []byte) string {
+	if len(payload) == 0 {
+		return ""
+	}
+	m := severityFieldPattern.FindSubmatch(payload)
+	if len(m) < 2 {
+		return ""
+	}
+	return string(m[1])
 }
 
 var hookNamePattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)

--- a/internal/hooks/dispatcher.go
+++ b/internal/hooks/dispatcher.go
@@ -2,6 +2,7 @@ package hooks
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log"
 	"sync"
@@ -26,16 +27,32 @@ const AutoDisableThreshold = 5
 const HookDisabledEvent = HookEventPrefix + "disabled"
 
 // boundHook pairs a parsed Hook with its constructed Action and tracks the
-// per-hook auto-disable state.
+// per-hook auto-disable state and observability counters.
 type boundHook struct {
 	hook   *Hook
 	action Action
 
-	mu       sync.Mutex
-	failures int
-	disabled bool
-	lastErr  string
+	mu              sync.Mutex
+	failures        int
+	disabled        bool
+	lastErr         string
+	lastFailureAt   time.Time
+	successCount    uint64
+	failureCount    uint64
+	filteredCount   uint64
+	disabledDrops   uint64
+	durationSumNs   uint64
+	durationCount   uint64
+	durationBuckets [hookDurationBucketCount]uint64
+	lastInvokedAt   time.Time
 }
+
+// hookDurationBuckets defines the histogram bucket upper bounds (seconds).
+// Aligned with Prometheus default-style ladder for sub-second→multi-second
+// hook actions.
+var hookDurationBuckets = [...]float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
+
+const hookDurationBucketCount = 11
 
 // EventEmitter is the optional callback the dispatcher uses to surface
 // hook-system self-events (notably hook_disabled) back into the eventlog.
@@ -241,13 +258,22 @@ func (d *Dispatcher) runFanIn(ctx context.Context) {
 
 func (d *Dispatcher) fanOut(ev Event) {
 	for _, b := range d.hooks {
+		if !b.hook.MatchesEvent(ev.Type) {
+			continue
+		}
 		b.mu.Lock()
 		disabled := b.disabled
 		b.mu.Unlock()
 		if disabled {
+			b.mu.Lock()
+			b.disabledDrops++
+			b.mu.Unlock()
 			continue
 		}
-		if !b.hook.MatchesEvent(ev.Type) {
+		if !b.hook.MatchesFilter(ev) {
+			b.mu.Lock()
+			b.filteredCount++
+			b.mu.Unlock()
 			continue
 		}
 		ch := d.subQueue[b.hook.Name]
@@ -289,14 +315,19 @@ func (d *Dispatcher) executeOne(ctx context.Context, b *boundHook, ev Event) {
 	if timeout <= 0 {
 		timeout = DefaultHookTimeout
 	}
+	start := time.Now()
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	err = b.action.Execute(runCtx, ev, payload)
 	cancel()
+	elapsed := time.Since(start)
 
 	if err == nil {
 		b.mu.Lock()
 		b.failures = 0
 		b.lastErr = ""
+		b.successCount++
+		b.lastInvokedAt = time.Now()
+		b.observeDurationLocked(elapsed)
 		b.mu.Unlock()
 		return
 	}
@@ -306,6 +337,10 @@ func (d *Dispatcher) executeOne(ctx context.Context, b *boundHook, ev Event) {
 	b.mu.Lock()
 	b.failures++
 	b.lastErr = err.Error()
+	b.failureCount++
+	b.lastFailureAt = time.Now()
+	b.lastInvokedAt = b.lastFailureAt
+	b.observeDurationLocked(elapsed)
 	tripped := false
 	if !b.disabled && b.failures >= AutoDisableThreshold {
 		b.disabled = true
@@ -333,6 +368,144 @@ func (d *Dispatcher) emitDisabled(hookName, lastErr string) {
 		"last_error":      lastErr,
 		"requires_reload": true,
 	})
+}
+
+// observeDurationLocked records an action duration in the histogram. Caller
+// must hold b.mu.
+func (b *boundHook) observeDurationLocked(d time.Duration) {
+	b.durationCount++
+	b.durationSumNs += uint64(d.Nanoseconds())
+	secs := d.Seconds()
+	for i, upper := range hookDurationBuckets {
+		if secs <= upper {
+			b.durationBuckets[i]++
+		}
+	}
+}
+
+// HookStats is a snapshot of one hook's runtime counters and disable state.
+type HookStats struct {
+	Name            string
+	Events          []string
+	ActionType      string
+	Enabled         bool
+	Disabled        bool
+	Successes       uint64
+	Failures        uint64
+	Filtered        uint64
+	DisabledDrops   uint64
+	ConsecutiveFail int
+	LastError       string
+	LastFailureAt   time.Time
+	LastInvokedAt   time.Time
+	DurationCount   uint64
+	DurationSumNs   uint64
+	DurationBuckets [hookDurationBucketCount]uint64
+}
+
+// DurationBucketUpperBounds exposes the histogram bucket layout for renderers
+// (CLI, Prometheus). Index aligns with HookStats.DurationBuckets.
+func DurationBucketUpperBounds() []float64 {
+	out := make([]float64, len(hookDurationBuckets))
+	copy(out, hookDurationBuckets[:])
+	return out
+}
+
+// Stats returns a per-hook snapshot for status/metrics surfaces. Safe to call
+// from any goroutine. The order matches Hooks().
+func (d *Dispatcher) Stats() []HookStats {
+	if d == nil {
+		return nil
+	}
+	out := make([]HookStats, 0, len(d.hooks))
+	for _, b := range d.hooks {
+		b.mu.Lock()
+		stats := HookStats{
+			Name:            b.hook.Name,
+			Events:          append([]string(nil), b.hook.Events...),
+			ActionType:      b.hook.Action.Type,
+			Enabled:         b.hook.IsEnabled() && !b.disabled,
+			Disabled:        b.disabled,
+			Successes:       b.successCount,
+			Failures:        b.failureCount,
+			Filtered:        b.filteredCount,
+			DisabledDrops:   b.disabledDrops,
+			ConsecutiveFail: b.failures,
+			LastError:       b.lastErr,
+			LastFailureAt:   b.lastFailureAt,
+			LastInvokedAt:   b.lastInvokedAt,
+			DurationCount:   b.durationCount,
+			DurationSumNs:   b.durationSumNs,
+			DurationBuckets: b.durationBuckets,
+		}
+		b.mu.Unlock()
+		out = append(out, stats)
+	}
+	return out
+}
+
+// Reload swaps the dispatcher's hook bindings. Called by `workbuddy hooks
+// reload`. Reload preserves nothing — auto-disable state is cleared (the
+// design's explicit re-enable path) and metrics counters reset to 0 so
+// "since reload" semantics are unambiguous on the status surface.
+//
+// Reload is safe to call concurrently with Publish: the central channel
+// keeps draining; any in-flight executeOne on a still-running worker
+// completes against the prior boundHook copy. New events route through the
+// new bindings as soon as the worker pool is replaced.
+func (d *Dispatcher) Reload(cfg *Config, registry *ActionRegistry) ([]string, error) {
+	if d == nil {
+		return nil, fmt.Errorf("hooks: dispatcher is nil")
+	}
+	if registry == nil {
+		registry = DefaultActionRegistry()
+	}
+	var newHooks []*boundHook
+	var warnings []string
+	if cfg != nil {
+		for i := range cfg.Hooks {
+			h := &cfg.Hooks[i]
+			if !h.IsEnabled() {
+				continue
+			}
+			action, w, err := registry.Build(h)
+			if err != nil {
+				return nil, err
+			}
+			warnings = append(warnings, w...)
+			newHooks = append(newHooks, &boundHook{hook: h, action: action})
+		}
+	}
+
+	d.mu.Lock()
+	wasStarted := d.started
+	// Tear down the old worker pool by closing stopCh, then build a fresh one
+	// and start it under the same dispatcher context if we were running.
+	if d.started && !d.stopped {
+		close(d.stopCh)
+		d.stopped = true
+	}
+	d.mu.Unlock()
+	if wasStarted {
+		d.wg.Wait()
+	}
+
+	d.mu.Lock()
+	d.hooks = newHooks
+	d.subQueue = map[string]chan Event{}
+	d.stopCh = make(chan struct{})
+	d.stopped = false
+	if wasStarted {
+		// reuse the dispatcher's existing in channel so buffered events are
+		// not lost across reload; only workers are rebuilt.
+		d.started = false
+	}
+	d.mu.Unlock()
+
+	if wasStarted {
+		d.Start(context.Background())
+	}
+	return warnings, nil
 }
 
 // PublishFromRaw is a convenience for callers that already have a JSON-encoded

--- a/internal/hooks/match_test.go
+++ b/internal/hooks/match_test.go
@@ -1,0 +1,134 @@
+package hooks
+
+import (
+	"strings"
+	"testing"
+)
+
+// Severity filter on a non-alert event must be flagged at parse time so the
+// operator notices the misconfig at boot rather than getting silently ignored
+// at runtime.
+func TestParseConfigWarnsOnSeverityForNonAlert(t *testing.T) {
+	yaml := []byte(`hooks:
+  - name: bad
+    events: [report]
+    match:
+      severity: [warning]
+    action:
+      type: webhook
+      url: https://example.invalid/hook
+`)
+	_, warnings, err := ParseConfig(yaml)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "match.severity only applies to event_type=alert") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected severity warning, got %v", warnings)
+	}
+}
+
+func TestParseConfigNoSeverityWarningOnAlert(t *testing.T) {
+	yaml := []byte(`hooks:
+  - name: ok
+    events: [alert]
+    match:
+      severity: [warning, critical]
+    action:
+      type: webhook
+      url: https://example.invalid/hook
+`)
+	_, warnings, err := ParseConfig(yaml)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	for _, w := range warnings {
+		if strings.Contains(w, "match.severity") {
+			t.Fatalf("did not expect severity warning, got %v", warnings)
+		}
+	}
+}
+
+func TestParseConfigRejectsInvalidRepoGlob(t *testing.T) {
+	// path.Match treats `[` as a character-class opener; an unclosed class is
+	// ErrBadPattern.
+	yaml := []byte(`hooks:
+  - name: bad
+    events: [alert]
+    match:
+      repo: "owner/[unclosed"
+    action:
+      type: webhook
+      url: https://example.invalid/hook
+`)
+	_, _, err := ParseConfig(yaml)
+	if err == nil {
+		t.Fatalf("expected invalid repo glob error, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid match.repo glob") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestMatchesFilterRepoGlob(t *testing.T) {
+	enabled := true
+	h := &Hook{
+		Name:    "g",
+		Events:  []string{"alert"},
+		Enabled: &enabled,
+		Match:   &MatchFilter{Repo: "owner/*"},
+	}
+	cases := []struct {
+		repo    string
+		matched bool
+	}{
+		{"owner/repo1", true},
+		{"owner/anything", true},
+		{"other/repo", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := h.MatchesFilter(Event{Type: "alert", Repo: c.repo}); got != c.matched {
+			t.Errorf("repo=%q got %v want %v", c.repo, got, c.matched)
+		}
+	}
+}
+
+func TestMatchesFilterSeverityAlertOnly(t *testing.T) {
+	h := &Hook{
+		Name:   "s",
+		Events: []string{"alert"},
+		Match:  &MatchFilter{Severity: []string{"warning", "critical"}},
+	}
+	// Hits.
+	if !h.MatchesFilter(Event{Type: "alert", Payload: []byte(`{"severity":"warning"}`)}) {
+		t.Fatalf("severity warning should match")
+	}
+	if !h.MatchesFilter(Event{Type: "alert", Payload: []byte(`{"severity":"CRITICAL"}`)}) {
+		t.Fatalf("severity should be case-insensitive")
+	}
+	// Misses.
+	if h.MatchesFilter(Event{Type: "alert", Payload: []byte(`{"severity":"info"}`)}) {
+		t.Fatalf("severity info should NOT match")
+	}
+	if h.MatchesFilter(Event{Type: "alert", Payload: []byte(`{}`)}) {
+		t.Fatalf("missing severity field should NOT match alert filter")
+	}
+	// Severity is a no-op on non-alert events (warning at config time).
+	if !h.MatchesFilter(Event{Type: "report", Payload: []byte(`{"severity":"info"}`)}) {
+		t.Fatalf("severity filter must not gate non-alert events at runtime")
+	}
+}
+
+func TestMatchesFilterEmptyIsMatchAll(t *testing.T) {
+	h := &Hook{Events: []string{"*"}} // no Match block at all
+	if !h.MatchesFilter(Event{Type: "alert", Repo: "x/y"}) {
+		t.Fatalf("nil match must be match-all")
+	}
+}

--- a/internal/hooks/reload_test.go
+++ b/internal/hooks/reload_test.go
@@ -1,0 +1,110 @@
+package hooks
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Reload must clear auto-disable state and route subsequent events to the
+// new bindings.
+func TestDispatcherReloadClearsAutoDisable(t *testing.T) {
+	// Build a dispatcher with a hook bound to a failing action so we can
+	// trip auto-disable, then reload and confirm the hook is healthy again.
+	enabled := true
+	cfg1 := &Config{
+		SchemaVersion: 1,
+		Hooks: []Hook{{
+			Name:    "h1",
+			Enabled: &enabled,
+			Events:  []string{"alert"},
+			Action:  ActionConfig{Type: "fail"},
+		}},
+	}
+	reg := NewActionRegistry()
+	reg.Register("fail", func(h *Hook) (Action, []string, error) { return &alwaysFailAction{}, nil, nil })
+	d, _, err := NewDispatcher(cfg1, reg)
+	if err != nil {
+		t.Fatalf("dispatcher: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d.Start(ctx)
+	defer d.Stop()
+
+	// Trip auto-disable. Publish one at a time and wait for processing
+	// (per-hook channel cap is 1, so back-to-back publishes get dropped).
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) && !d.IsDisabled("h1") {
+		d.Publish(Event{Type: "alert"})
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !d.IsDisabled("h1") {
+		t.Fatalf("hook should be auto-disabled before reload")
+	}
+
+	// Reload with a healthy action — auto-disable must clear.
+	cfg2 := &Config{
+		SchemaVersion: 1,
+		Hooks: []Hook{{
+			Name:    "h1",
+			Enabled: &enabled,
+			Events:  []string{"alert"},
+			Action:  ActionConfig{Type: "count"},
+		}},
+	}
+	reg2 := NewActionRegistry()
+	counter := &countingAction{done: make(chan struct{})}
+	reg2.Register("count", func(h *Hook) (Action, []string, error) { return counter, nil, nil })
+	if _, err := d.Reload(cfg2, reg2); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if d.IsDisabled("h1") {
+		t.Fatalf("reload must clear auto-disable")
+	}
+	d.Publish(Event{Type: "alert"})
+	select {
+	case <-counter.done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("post-reload event was not delivered")
+	}
+}
+
+func TestDispatcherReloadFiltersOutDisabledHooks(t *testing.T) {
+	disabled := false
+	cfg := &Config{
+		SchemaVersion: 1,
+		Hooks: []Hook{{
+			Name:    "h",
+			Enabled: &disabled,
+			Events:  []string{"alert"},
+			Action:  ActionConfig{Type: "count"},
+		}},
+	}
+	reg := NewActionRegistry()
+	reg.Register("count", func(h *Hook) (Action, []string, error) { return &countingAction{done: make(chan struct{})}, nil, nil })
+	d, _, err := NewDispatcher(cfg, reg)
+	if err != nil {
+		t.Fatalf("dispatcher: %v", err)
+	}
+	if got := len(d.Stats()); got != 0 {
+		t.Fatalf("disabled hook must not be bound; got %d stats", got)
+	}
+}
+
+type alwaysFailAction struct {
+	calls atomic.Int64
+}
+
+func (a *alwaysFailAction) Type() string { return "fail" }
+func (a *alwaysFailAction) Execute(ctx context.Context, _ Event, _ []byte) error {
+	a.calls.Add(1)
+	return errAlwaysFail
+}
+
+type sentinelErr string
+
+func (e sentinelErr) Error() string { return string(e) }
+
+const errAlwaysFail = sentinelErr("always fail")

--- a/internal/metrics/handler.go
+++ b/internal/metrics/handler.go
@@ -9,8 +9,18 @@ import (
 	"time"
 
 	"github.com/Lincyaw/workbuddy/internal/eventlog"
+	"github.com/Lincyaw/workbuddy/internal/hooks"
 	"github.com/Lincyaw/workbuddy/internal/store"
 )
+
+// HookStatsSource is satisfied by *hooks.Dispatcher and exposes the
+// per-hook counters needed for `workbuddy_hook_*` metrics. Defining it
+// here keeps the metrics package decoupled from a concrete dispatcher.
+type HookStatsSource interface {
+	Stats() []hooks.HookStats
+	OverflowCount() uint64
+	DroppedCount() uint64
+}
 
 const stuckThreshold = time.Hour
 
@@ -31,6 +41,7 @@ type Source interface {
 type Handler struct {
 	src   Source
 	evlog *eventlog.EventLogger
+	hooks HookStatsSource
 	now   func() time.Time
 }
 
@@ -48,6 +59,14 @@ func NewHandler(src Source) *Handler {
 // metrics. Passing nil is a no-op. Returns the receiver for chaining.
 func (h *Handler) WithEventLogger(ev *eventlog.EventLogger) *Handler {
 	h.evlog = ev
+	return h
+}
+
+// WithHooks attaches a hooks dispatcher whose per-hook stats are exposed as
+// `workbuddy_hook_invocations_total`, `workbuddy_hook_duration_seconds`, and
+// `workbuddy_hook_overflow_total`. Passing nil is a no-op.
+func (h *Handler) WithHooks(src HookStatsSource) *Handler {
+	h.hooks = src
 	return h
 }
 
@@ -86,7 +105,78 @@ func (h *Handler) writeMetrics(b *strings.Builder, now time.Time) error {
 		return err
 	}
 	h.writeEventlogHealth(b)
+	h.writeHookMetrics(b)
 	return h.writeIssueCounters(b, now)
+}
+
+func (h *Handler) writeHookMetrics(b *strings.Builder) {
+	if h.hooks == nil {
+		return
+	}
+	stats := h.hooks.Stats()
+
+	_, _ = b.WriteString("# HELP workbuddy_hook_invocations_total Hook invocations by hook and result (success/failure/filtered/disabled/overflow).\n")
+	_, _ = b.WriteString("# TYPE workbuddy_hook_invocations_total counter\n")
+
+	type pair struct {
+		hook   string
+		result string
+		count  uint64
+	}
+	var rows []pair
+	for _, s := range stats {
+		rows = append(rows,
+			pair{s.Name, "success", s.Successes},
+			pair{s.Name, "failure", s.Failures},
+			pair{s.Name, "filtered", s.Filtered},
+			pair{s.Name, "disabled", s.DisabledDrops},
+		)
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].hook == rows[j].hook {
+			return rows[i].result < rows[j].result
+		}
+		return rows[i].hook < rows[j].hook
+	})
+	for _, r := range rows {
+		_, _ = b.WriteString(fmt.Sprintf(`workbuddy_hook_invocations_total{hook=%s,result=%s} %d`+"\n",
+			promLabel(r.hook, "hook"), promLabel(r.result, "result"), r.count))
+	}
+	// Aggregate overflow as a separate counter — central buffer overflow is
+	// hook-agnostic. Per-hook slot drops are surfaced as result=overflow.
+	_, _ = b.WriteString("# HELP workbuddy_hook_overflow_total Central dispatcher buffer overflows since process start.\n")
+	_, _ = b.WriteString("# TYPE workbuddy_hook_overflow_total counter\n")
+	_, _ = b.WriteString(fmt.Sprintf("workbuddy_hook_overflow_total %d\n", h.hooks.OverflowCount()))
+
+	// Per-hook overflow attribution: per-hook slot drops live in
+	// DispatcherDroppedCount() in aggregate; we surface that here as a
+	// hook-labelled metric where possible. Without per-hook drop tracking we
+	// expose the aggregate under hook="*".
+	_, _ = b.WriteString(fmt.Sprintf(`workbuddy_hook_invocations_total{hook=%s,result=%s} %d`+"\n",
+		promLabel("*", "hook"), promLabel("overflow", "result"), h.hooks.DroppedCount()))
+
+	// Histogram: workbuddy_hook_duration_seconds{hook=...}
+	_, _ = b.WriteString("# HELP workbuddy_hook_duration_seconds Histogram of hook action durations in seconds.\n")
+	_, _ = b.WriteString("# TYPE workbuddy_hook_duration_seconds histogram\n")
+	bounds := hooks.DurationBucketUpperBounds()
+	sortedStats := append([]hooks.HookStats(nil), stats...)
+	sort.Slice(sortedStats, func(i, j int) bool { return sortedStats[i].Name < sortedStats[j].Name })
+	for _, s := range sortedStats {
+		hookLabel := promLabel(s.Name, "hook")
+		var cumulative uint64
+		for i, upper := range bounds {
+			cumulative = s.DurationBuckets[i]
+			_, _ = b.WriteString(fmt.Sprintf(`workbuddy_hook_duration_seconds_bucket{hook=%s,le="%g"} %d`+"\n",
+				hookLabel, upper, cumulative))
+			_ = cumulative
+		}
+		_, _ = b.WriteString(fmt.Sprintf(`workbuddy_hook_duration_seconds_bucket{hook=%s,le="+Inf"} %d`+"\n",
+			hookLabel, s.DurationCount))
+		_, _ = b.WriteString(fmt.Sprintf(`workbuddy_hook_duration_seconds_sum{hook=%s} %g`+"\n",
+			hookLabel, float64(s.DurationSumNs)/1e9))
+		_, _ = b.WriteString(fmt.Sprintf(`workbuddy_hook_duration_seconds_count{hook=%s} %d`+"\n",
+			hookLabel, s.DurationCount))
+	}
 }
 
 func (h *Handler) writeEventlogHealth(b *strings.Builder) {

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -3652,3 +3652,49 @@ requirements:
       - cmd/hooks_test.go
     deps:
       - REQ-101
+  - id: REQ-105
+    title: hook system phase 1c — match filters, metrics, status/reload, eventlog gap fill (#266)
+    description: >
+      Phase 1c of the operator-owned hook system (#262). Adds `match.severity`
+      and `match.repo` filters with config-time warnings and runtime drop
+      counters, Prometheus metrics for invocations/duration/overflow,
+      `workbuddy hooks status` and `workbuddy hooks reload` CLI surfaces
+      backed by /api/v1/hooks/{status,reload}, and fills the eventlog
+      coverage gap by emitting `coordinator_started`, `coordinator_stopping`,
+      and `hooks_reloaded`. See docs/decisions/2026-04-30-hook-system.md.
+    rationale: >
+      Without filters, `*`-bound hooks fan-out indiscriminately and operators
+      have no way to narrow severity-aware paging without a wrapper script.
+      Without metrics + status, auto-disable becomes a silent failure mode.
+      Without reload, the only recovery from auto-disable is a coordinator
+      restart. The three lifecycle events close eventlog blind spots so
+      restart noise and reload events line up with subsequent hook activity.
+    priority: P1
+    version: v0.5.0
+    status: tested
+    acceptance_criteria:
+      - "AC-105-1: match.severity is enforced only when event_type=alert; configuring it for other event types emits a startup warning surfaced via ParseConfig."
+      - "AC-105-2: match.repo uses path.Match; an empty filter is match-all; a malformed glob fails ParseConfig with a clear error."
+      - "AC-105-3: Prometheus /metrics exposes workbuddy_hook_invocations_total{hook,result} (success/failure/filtered/disabled/overflow), workbuddy_hook_duration_seconds histogram, and workbuddy_hook_overflow_total."
+      - "AC-105-4: `workbuddy hooks status --coordinator URL` queries /api/v1/hooks/status and renders per-hook successes/failures/filtered, last error, and auto-disabled state."
+      - "AC-105-5: `workbuddy hooks reload --coordinator URL` POSTs /api/v1/hooks/reload, which re-reads the YAML, clears auto-disable, and emits a `hooks_reloaded` eventlog entry."
+      - "AC-105-6: cmd/coordinator.go emits `coordinator_started` after the HTTP listener is reserved (payload contains listen / pid / version) and `coordinator_stopping` at the head of the graceful-shutdown handler."
+      - "AC-105-7: internal/eventlog/eventlog.go declares constants TypeCoordinatorStarted, TypeCoordinatorStopping, TypeHooksReloaded and registers them in AllEventTypes."
+      - "AC-105-8: Unit tests cover all three filter cases (severity hit/miss/non-alert no-op, repo glob hit/miss, malformed glob), the reload-clears-auto-disable behavior, and the three new eventlog emit paths."
+    code:
+      - internal/eventlog/eventlog.go
+      - internal/hooks/config.go
+      - internal/hooks/dispatcher.go
+      - internal/metrics/handler.go
+      - internal/app/hooks_api.go
+      - cmd/hooks.go
+      - cmd/coordinator.go
+      - cmd/coordinator_lifecycle.go
+    tests:
+      - internal/hooks/match_test.go
+      - internal/hooks/reload_test.go
+      - internal/app/hooks_api_test.go
+      - cmd/coordinator_lifecycle_test.go
+    deps:
+      - REQ-101
+      - REQ-104


### PR DESCRIPTION
Fixes #266

Builds on #265 (Phase 1b) to make the hook system production-usable.

## Summary

- **match filters** — `match.severity` (alert-only; non-alert use warns at parse time) and `match.repo` (`path.Match` glob; malformed pattern is a hard parse error). Empty filters are match-all.
- **metrics** — `/metrics` exposes `workbuddy_hook_invocations_total{hook,result}` (success / failure / filtered / disabled / overflow), `workbuddy_hook_duration_seconds` histogram, and `workbuddy_hook_overflow_total`.
- **CLI / HTTP** — `workbuddy hooks status` and `workbuddy hooks reload` hit the coordinator's new `/api/v1/hooks/{status,reload}`. Reload re-reads YAML, clears auto-disable, and emits `hooks_reloaded`.
- **eventlog gap fill** — new `coordinator_started`, `coordinator_stopping`, `hooks_reloaded` types. Coordinator emits started after the HTTP listener is reserved (payload: listen / pid / version) and stopping at the head of graceful-shutdown. `config_reloaded` was already wired.

## Test plan

- [x] `go test ./internal/hooks/... ./internal/eventlog/... ./internal/app/... ./internal/metrics/... ./cmd/...` (pre-existing `TestParseWorkerFlags_MgmtPublicURLRequiresSharedAuth` failure inherited from #265 base)
- [x] `go build ./... && go vet ./...`
- [x] `python3 ~/.autoharness/scripts/validate_index.py project-index.yaml`
- [x] `go run . validate-docs --strict`
- [x] match filters: severity hit / miss / non-alert no-op; repo glob hit / miss; invalid glob rejected
- [x] reload clears auto-disable and routes new events to the rebuilt bindings
- [x] `coordinator_started` / `coordinator_stopping` payload fields verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)