### PR TITLE
hooks: graceful degradation when no hooks configured (#273)

### DIFF
--- a/internal/app/hooks_api.go
+++ b/internal/app/hooks_api.go
@@ -11,10 +11,13 @@
 //	                                         auto-disable, emit hooks_reloaded
 //
 // These are the read/write counterparts of `workbuddy hooks list` (which is
-// purely client-side and reads the YAML, not the running dispatcher). Without
-// the dispatcher attached the endpoints respond with 503 so operators can
-// distinguish "no hooks configured" from "this binary doesn't know about
-// hooks".
+// purely client-side and reads the YAML, not the running dispatcher). When the
+// dispatcher isn't bound — typical on a fresh install with no
+// ~/.config/workbuddy/hooks.yaml — the list/status surfaces return an empty
+// 200 and reload returns {"reloaded": false, "reason": "no config"} so the
+// webui can render an empty state instead of an error banner. Per-hook
+// resources (invocations, config) still 404 because the named hook genuinely
+// isn't registered.
 package app
 
 import (
@@ -87,7 +90,13 @@ func (h *HooksAPI) HandleStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if h.dispatcher == nil {
-		writeHooksJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "hooks dispatcher not configured"})
+		// Fresh install with no hooks.yaml: dispatcher was never built.
+		// Return an empty 200 so the webui renders the empty state rather
+		// than an error banner (issue #273).
+		writeHooksJSON(w, http.StatusOK, HooksStatusResponse{
+			ConfigPath: h.configPath,
+			Hooks:      []HookStatusEntry{},
+		})
 		return
 	}
 	resp := HooksStatusResponse{
@@ -290,7 +299,12 @@ func (h *HooksAPI) HandleHookSubtree(w http.ResponseWriter, r *http.Request) {
 }
 
 // HooksReloadResponse is the JSON shape returned by POST /api/v1/hooks/reload.
+// Reloaded is false when the dispatcher isn't bound (e.g. no hooks YAML at
+// startup); Reason explains why so callers don't have to special-case the
+// nil-dispatcher state.
 type HooksReloadResponse struct {
+	Reloaded   bool     `json:"reloaded"`
+	Reason     string   `json:"reason,omitempty"`
 	ConfigPath string   `json:"config_path"`
 	HookCount  int      `json:"hook_count"`
 	Warnings   []string `json:"warnings,omitempty"`
@@ -306,7 +320,14 @@ func (h *HooksAPI) HandleReload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if h.dispatcher == nil {
-		writeHooksJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "hooks dispatcher not configured"})
+		// Nothing to reload — fresh install with no hooks.yaml. Report it
+		// truthfully so the webui can show "no hooks configured" instead of
+		// an error (issue #273).
+		writeHooksJSON(w, http.StatusOK, HooksReloadResponse{
+			Reloaded:   false,
+			Reason:     "no config",
+			ConfigPath: h.configPath,
+		})
 		return
 	}
 	cfg, parseWarnings, err := hooks.LoadConfig(h.configPath)
@@ -337,6 +358,7 @@ func (h *HooksAPI) HandleReload(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 	writeHooksJSON(w, http.StatusOK, HooksReloadResponse{
+		Reloaded:   true,
 		ConfigPath: h.configPath,
 		HookCount:  count,
 		Warnings:   all,

--- a/internal/app/hooks_api_test.go
+++ b/internal/app/hooks_api_test.go
@@ -133,13 +133,120 @@ func TestHooksAPIStatusReportsCounters(t *testing.T) {
 	}
 }
 
-func TestHooksAPIStatusReturns503WhenDispatcherMissing(t *testing.T) {
-	api := NewHooksAPI(nil, nil, "")
+// When the dispatcher isn't bound (no hooks YAML at startup) the list /
+// status endpoint must return an empty 200 rather than a 5xx, so the webui
+// renders the empty state instead of an error banner. See issue #273.
+func TestHooksAPIStatusReturnsEmptyListWhenDispatcherMissing(t *testing.T) {
+	api := NewHooksAPI(nil, nil, "/etc/workbuddy/hooks.yaml")
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/hooks/status", nil)
 	rr := httptest.NewRecorder()
 	api.HandleStatus(rr, req)
-	if rr.Code != http.StatusServiceUnavailable {
-		t.Fatalf("status=%d want 503", rr.Code)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s want 200", rr.Code, rr.Body.String())
+	}
+	var resp HooksStatusResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Hooks == nil {
+		t.Fatalf("hooks should be a non-nil empty slice for stable JSON shape")
+	}
+	if len(resp.Hooks) != 0 {
+		t.Fatalf("hooks=%v want empty", resp.Hooks)
+	}
+	if resp.ConfigPath != "/etc/workbuddy/hooks.yaml" {
+		t.Fatalf("config_path=%q", resp.ConfigPath)
+	}
+}
+
+// When the configured hooks YAML doesn't exist on disk, initHooksDispatcher
+// returns (nil, nil) so the API has no dispatcher to query — same surface as
+// "operator never wrote a hooks file." Verify the canonical /api/v1/hooks
+// path still degrades to an empty 200. See issue #273.
+func TestHooksAPIListReturnsEmptyListWhenConfigFileMissing(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist.yaml")
+	if _, err := os.Stat(missing); !os.IsNotExist(err) {
+		t.Fatalf("precondition: %s should not exist (err=%v)", missing, err)
+	}
+	api := NewHooksAPI(nil, nil, missing)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/hooks", nil)
+	rr := httptest.NewRecorder()
+	api.HandleStatus(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s want 200", rr.Code, rr.Body.String())
+	}
+	var resp HooksStatusResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Hooks) != 0 {
+		t.Fatalf("hooks=%v want empty", resp.Hooks)
+	}
+	if resp.ConfigPath != missing {
+		t.Fatalf("config_path=%q want %q", resp.ConfigPath, missing)
+	}
+}
+
+// Reload with no dispatcher must succeed (200) with reloaded=false and a
+// human-readable reason so the webui Reload button doesn't surface a 5xx on
+// fresh installs. See issue #273.
+func TestHooksAPIReloadReturnsNoConfigWhenDispatcherMissing(t *testing.T) {
+	api := NewHooksAPI(nil, nil, "/etc/workbuddy/hooks.yaml")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/reload", nil)
+	rr := httptest.NewRecorder()
+	api.HandleReload(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s want 200", rr.Code, rr.Body.String())
+	}
+	var resp HooksReloadResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Reloaded {
+		t.Fatalf("reloaded=true want false")
+	}
+	if resp.Reason != "no config" {
+		t.Fatalf("reason=%q want %q", resp.Reason, "no config")
+	}
+	if resp.ConfigPath != "/etc/workbuddy/hooks.yaml" {
+		t.Fatalf("config_path=%q", resp.ConfigPath)
+	}
+}
+
+// Symmetric to the list-endpoint test: when the hooks YAML doesn't exist,
+// reload reports {"reloaded": false, "reason": "no config"} instead of 500.
+func TestHooksAPIReloadReturnsNoConfigWhenConfigFileMissing(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist.yaml")
+	api := NewHooksAPI(nil, nil, missing)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/reload", nil)
+	rr := httptest.NewRecorder()
+	api.HandleReload(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s want 200", rr.Code, rr.Body.String())
+	}
+	var resp HooksReloadResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Reloaded || resp.Reason != "no config" {
+		t.Fatalf("got reloaded=%v reason=%q want false / %q", resp.Reloaded, resp.Reason, "no config")
+	}
+}
+
+// AC#2: per-hook invocations must still 404 when the hook isn't registered,
+// even after the empty-list/reload graceful-degradation changes.
+func TestHooksAPIInvocationsStill404sForMissingHook(t *testing.T) {
+	cfg := &hooks.Config{SchemaVersion: 1}
+	d, _, err := hooks.NewDispatcher(cfg, hooks.DefaultActionRegistry())
+	if err != nil {
+		t.Fatalf("dispatcher: %v", err)
+	}
+	api := NewHooksAPI(d, nil, "")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/hooks/missing/invocations", nil)
+	rr := httptest.NewRecorder()
+	api.HandleInvocations(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status=%d want 404", rr.Code)
 	}
 }
 

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -3752,3 +3752,31 @@ requirements:
       - REQ-101
       - REQ-104
       - REQ-105
+  - id: REQ-107
+    title: hooks API graceful degradation when no hooks configured (#273)
+    description: >
+      The hooks list and reload endpoints used to return 503 + an "error"
+      payload when the dispatcher wasn't bound (typical fresh install with no
+      `~/.config/workbuddy/hooks.yaml`). The webui /hooks page surfaced this
+      as an error banner even though there was nothing wrong. Make the surface
+      report "no config" instead so a brand-new install renders an empty state.
+    rationale: >
+      The CLI `workbuddy hooks list` already prints `no hooks configured at
+      <path>` in the same situation. The webui contract should match — there
+      is no operator action required, so the API must not look like a failure.
+    priority: P2
+    version: v0.5.0
+    status: tested
+    acceptance_criteria:
+      - "AC-107-1: GET /api/v1/hooks returns 200 with hooks=[] (and the configured path) when the dispatcher is nil or the hooks YAML is missing on disk."
+      - "AC-107-2: GET /api/v1/hooks/{name}/invocations still returns 404 for an unknown hook (regression guard)."
+      - "AC-107-3: POST /api/v1/hooks/reload returns 200 with {reloaded:false, reason:\"no config\"} when the dispatcher is nil or the hooks YAML is missing — never 5xx."
+      - "AC-107-4: Webui /hooks renders 'No hooks configured. See docs/hooks.md.' on an empty list and the Reload button reports 'nothing to reload — no config' instead of an error banner."
+    code:
+      - internal/app/hooks_api.go
+      - web/src/api/hooks.ts
+      - web/src/pages/Hooks.tsx
+    tests:
+      - internal/app/hooks_api_test.go
+    deps:
+      - REQ-106

--- a/web/src/api/hooks.ts
+++ b/web/src/api/hooks.ts
@@ -56,6 +56,9 @@ export interface HookConfigResponse {
 }
 
 export interface HookReloadResponse {
+  reloaded: boolean;
+  // Present when reloaded is false (e.g. "no config" on fresh installs).
+  reason?: string;
   config_path: string;
   hook_count: number;
   warnings?: string[];

--- a/web/src/pages/Hooks.tsx
+++ b/web/src/pages/Hooks.tsx
@@ -54,10 +54,18 @@ export function Hooks() {
     setReloadStatus('reloading…');
     try {
       const resp = await reloadHooks();
-      const warnings = resp.warnings?.length
-        ? ` (with ${resp.warnings.length} warning${resp.warnings.length === 1 ? '' : 's'})`
-        : '';
-      setReloadStatus(`reloaded ${resp.hook_count} hook(s)${warnings}`);
+      if (!resp.reloaded) {
+        // Fresh install or missing config — keep the message neutral so
+        // operators don't think something failed (issue #273).
+        setReloadStatus(
+          `nothing to reload — ${resp.reason ?? 'no config'}`,
+        );
+      } else {
+        const warnings = resp.warnings?.length
+          ? ` (with ${resp.warnings.length} warning${resp.warnings.length === 1 ? '' : 's'})`
+          : '';
+        setReloadStatus(`reloaded ${resp.hook_count} hook(s)${warnings}`);
+      }
       await load();
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'reload failed';
@@ -84,7 +92,9 @@ export function Hooks() {
         {state.loading && !data ? (
           <div class="empty">Loading…</div>
         ) : !data || data.hooks.length === 0 ? (
-          <div class="empty">No hooks registered. Add entries to your hooks YAML and click Reload.</div>
+          <div class="empty">
+            No hooks configured. See <code class="code-chip">docs/hooks.md</code>.
+          </div>
         ) : (
           <HookList
             hooks={data.hooks}


### PR DESCRIPTION
Fixes #273.

## Summary
- `GET /api/v1/hooks` and `/api/v1/hooks/status` now return `200` with `hooks: []` (and the configured `config_path`) when the dispatcher isn't bound — typical fresh install with no `~/.config/workbuddy/hooks.yaml`.
- `POST /api/v1/hooks/reload` now returns `200` with `{"reloaded": false, "reason": "no config"}` in the same scenario, instead of 503.
- Per-hook resources (`/{name}/invocations`, `/{name}/config`) keep their existing 404-for-unknown-hook behavior — that's a regression guard called out in the AC.
- Webui `/hooks` renders **"No hooks configured. See `docs/hooks.md`."** on an empty list, and the Reload button reports **"nothing to reload — no config"** instead of surfacing an error.

## Why
`workbuddy hooks list` already prints `no hooks configured at <path>` in this case. The webui contract should match — there is no operator action required, so the API must not look like a failure on a brand-new install.

## Test plan
- [x] `go build ./... && go vet ./...`
- [x] `go test ./internal/app/... -count=1 -run Hooks` — all hooks API tests pass, including the four new ones (`TestHooksAPIStatusReturnsEmptyListWhenDispatcherMissing`, `TestHooksAPIListReturnsEmptyListWhenConfigFileMissing`, `TestHooksAPIReloadReturnsNoConfigWhenDispatcherMissing`, `TestHooksAPIReloadReturnsNoConfigWhenConfigFileMissing`) plus the regression guard `TestHooksAPIInvocationsStill404sForMissingHook`.
- [x] `npm run test` in `web/` — 47/47 vitest cases pass.
- [x] `go run . validate-docs --strict` — clean.
- [x] `python3 ~/.autoharness/scripts/validate_index.py project-index.yaml` — `pass: true` (added REQ-107).

🤖 Generated with [Claude Code](https://claude.com/claude-code)