### PR TITLE
webui: drop server-side payload truncation (#276)

### DIFF
--- a/internal/webui/handler.go
+++ b/internal/webui/handler.go
@@ -141,9 +141,10 @@ func markDeprecated(w http.ResponseWriter, r *http.Request, oldPath, newPath str
 //	tail   ("1" to take last N)   — when set, returns the last `limit` events;
 //	                                `offset` is ignored.
 //
-// Bulky string fields inside payload/raw are truncated server-side to keep
-// the response small. Clients can request the full event via the stream or
-// by re-querying without truncation (not yet implemented — intentional).
+// Each returned event mirrors the on-disk record verbatim — no per-string or
+// per-array truncation. The `limit` cap is the only size guard, since fields
+// like `payload.line` are themselves JSON strings the SPA re-parses, and
+// truncating them mid-string broke `JSON.parse(line)` on the client (#276).
 func (h *Handler) handleEventsJSON(w http.ResponseWriter, r *http.Request, sessionID string) {
 	path := h.eventsPath(sessionID)
 	if path == "" {
@@ -406,7 +407,9 @@ type eventsResponse struct {
 }
 
 // trimmedEvent is the on-the-wire shape: a thin projection of
-// launcherevents.Event that strips Raw and truncates bulky strings in Payload.
+// launcherevents.Event that strips Raw. Payload is returned verbatim — see
+// parseAndTrim. The Truncated field is retained for backward compatibility
+// with older SPA bundles but is never set to true (#276).
 type trimmedEvent struct {
 	Index     int    `json:"index"`
 	Kind      string `json:"kind"`
@@ -418,8 +421,11 @@ type trimmedEvent struct {
 	Truncated bool   `json:"truncated,omitempty"`
 }
 
-const maxStringLen = 4000
-
+// parseAndTrim decodes one events-v1.jsonl line into trimmedEvent. Despite
+// the historical name, it no longer trims — fields like payload.line are
+// themselves JSON strings the SPA re-parses, and any mid-string cut breaks
+// `JSON.parse(line)` on the client (#276). The only size guard is the
+// `limit` query param on the events endpoint.
 func parseAndTrim(line string, idx int) (trimmedEvent, bool) {
 	line = strings.TrimSpace(line)
 	if line == "" {
@@ -439,17 +445,13 @@ func parseAndTrim(line string, idx int) (trimmedEvent, bool) {
 			Kind:  "unparseable",
 			Payload: map[string]string{
 				"error": err.Error(),
-				"line":  truncString(line, maxStringLen),
+				"line":  line,
 			},
-			Truncated: len(line) > maxStringLen,
 		}, true
 	}
 	var payload any
-	truncated := false
 	if len(raw.Payload) > 0 {
-		if err := json.Unmarshal(raw.Payload, &payload); err == nil {
-			payload, truncated = trimValue(payload)
-		} else {
+		if err := json.Unmarshal(raw.Payload, &payload); err != nil {
 			payload = string(raw.Payload)
 		}
 	}
@@ -461,51 +463,7 @@ func parseAndTrim(line string, idx int) (trimmedEvent, bool) {
 		TurnID:    raw.TurnID,
 		Seq:       raw.Seq,
 		Payload:   payload,
-		Truncated: truncated,
 	}, true
-}
-
-// trimValue recursively walks decoded JSON and truncates long strings in place.
-// Returns (possibly-new) value and whether any truncation occurred.
-func trimValue(v any) (any, bool) {
-	switch x := v.(type) {
-	case string:
-		if len(x) > maxStringLen {
-			return x[:maxStringLen] + "… [truncated]", true
-		}
-		return x, false
-	case map[string]any:
-		trunc := false
-		for k, val := range x {
-			nv, t := trimValue(val)
-			x[k] = nv
-			trunc = trunc || t
-		}
-		return x, trunc
-	case []any:
-		trunc := false
-		// Cap array length so a 10k-line tool output doesn't blow the wire.
-		const maxArr = 200
-		if len(x) > maxArr {
-			x = append(x[:maxArr], "… [truncated "+strconv.Itoa(len(x)-maxArr)+" more]")
-			trunc = true
-		}
-		for i, val := range x {
-			nv, t := trimValue(val)
-			x[i] = nv
-			trunc = trunc || t
-		}
-		return x, trunc
-	default:
-		return v, false
-	}
-}
-
-func truncString(s string, n int) string {
-	if len(s) <= n {
-		return s
-	}
-	return s[:n] + "… [truncated]"
 }
 
 // SessionURL returns the URL path for a session detail page in the SPA.

--- a/internal/webui/handler_test.go
+++ b/internal/webui/handler_test.go
@@ -2,6 +2,7 @@ package webui
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"log"
 	"net/http"
@@ -151,5 +152,135 @@ func TestAPISessionEventsParity(t *testing.T) {
 	// Modern path must NOT carry the deprecation header.
 	if got := modern.Header.Get("Deprecation"); got != "" {
 		t.Fatalf("modern path Deprecation = %q, want empty", got)
+	}
+}
+
+// TestEventsAPINoTruncation is the #276 regression: server-side per-string
+// and per-array truncation broke the SPA's `JSON.parse(payload.line)` because
+// payload.line is itself a JSON document. The contract is now: each event in
+// the response mirrors the on-disk record byte-for-byte (modulo encoding
+// re-formatting), and `truncated` is never true.
+func TestEventsAPINoTruncation(t *testing.T) {
+	st, err := store.NewStore(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	sessionsDir := filepath.Join(t.TempDir(), "sessions")
+	sessionID := "session-276"
+	dir := filepath.Join(sessionsDir, sessionID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Build a payload that previously tripped both guards:
+	//   - `line` is a 64 KB JSON string (the kind Claude Code stream-json
+	//     emits — itself a JSON document the SPA re-parses).
+	//   - `calls` is a 500-element array (>200, the old maxArr).
+	innerObj := map[string]any{"text": strings.Repeat("y", 64*1024-200)}
+	innerJSON, err := json.Marshal(innerObj)
+	if err != nil {
+		t.Fatalf("marshal inner: %v", err)
+	}
+	if len(innerJSON) <= 4000 {
+		t.Fatalf("inner JSON length %d not large enough to trigger old truncation", len(innerJSON))
+	}
+	calls := make([]map[string]int, 500)
+	for i := range calls {
+		calls[i] = map[string]int{"i": i}
+	}
+	payloadObj := map[string]any{
+		"line":  string(innerJSON),
+		"calls": calls,
+	}
+	payloadBytes, err := json.Marshal(payloadObj)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	eventLine := append([]byte(`{"kind":"log","seq":1,"payload":`), payloadBytes...)
+	eventLine = append(eventLine, '}', '\n')
+	if err := os.WriteFile(filepath.Join(dir, "events-v1.jsonl"), eventLine, 0o644); err != nil {
+		t.Fatalf("write events: %v", err)
+	}
+
+	if _, err := st.CreateSession(store.SessionRecord{
+		SessionID: sessionID,
+		Repo:      "owner/repo",
+		IssueNum:  276,
+		AgentName: "dev-agent",
+		Status:    store.TaskStatusRunning,
+		Dir:       dir,
+	}); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	h := NewHandler(st)
+	h.SetSessionsDir(sessionsDir)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/sessions/", func(w http.ResponseWriter, r *http.Request) {
+		rest := strings.TrimPrefix(r.URL.Path, "/api/v1/sessions/")
+		_, suffix, _ := strings.Cut(rest, "/")
+		switch suffix {
+		case "events":
+			h.HandleAPISessionEvents(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	resp, err := http.Get(server.URL + "/api/v1/sessions/" + sessionID + "/events?limit=10")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	var got struct {
+		Events []struct {
+			Kind      string         `json:"kind"`
+			Payload   map[string]any `json:"payload"`
+			Truncated bool           `json:"truncated"`
+		} `json:"events"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(got.Events) != 1 {
+		t.Fatalf("events len = %d, want 1", len(got.Events))
+	}
+	ev := got.Events[0]
+	if ev.Truncated {
+		t.Fatalf("truncated = true, want false (#276)")
+	}
+
+	// 1) `line` must come back at exactly the input length.
+	gotLine, ok := ev.Payload["line"].(string)
+	if !ok {
+		t.Fatalf("payload.line not a string: %T", ev.Payload["line"])
+	}
+	if len(gotLine) != len(innerJSON) {
+		t.Fatalf("payload.line length = %d, want %d", len(gotLine), len(innerJSON))
+	}
+	// 2) The frontend does `JSON.parse(line)`. Simulate it: the returned
+	//    string must still be parseable as JSON.
+	var roundtrip map[string]any
+	if err := json.Unmarshal([]byte(gotLine), &roundtrip); err != nil {
+		t.Fatalf("client-side JSON.parse(line) would fail: %v", err)
+	}
+
+	// 3) `calls` must keep all 500 elements (no array cap).
+	gotCalls, ok := ev.Payload["calls"].([]any)
+	if !ok {
+		t.Fatalf("payload.calls not a slice: %T", ev.Payload["calls"])
+	}
+	if len(gotCalls) != 500 {
+		t.Fatalf("payload.calls length = %d, want 500", len(gotCalls))
 	}
 }

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -3780,3 +3780,36 @@ requirements:
       - internal/app/hooks_api_test.go
     deps:
       - REQ-106
+
+  - id: REQ-108
+    title: webui session events — drop server-side payload truncation (#276)
+    description: >
+      The /api/v1/sessions/{id}/events endpoint previously truncated any string
+      longer than 4000 bytes and any array longer than 200 elements inside the
+      decoded payload. That broke `kind=log` events whose `payload.line` is
+      itself a JSON document the SPA re-parses (Claude Code stream-json), since
+      the server cut mid-string and the client's `JSON.parse(line)` failed with
+      "Unterminated string". This requirement removes both guards so each event
+      mirrors the on-disk record verbatim. The `truncated` field is retained on
+      the wire for backward compatibility with older SPA bundles but is never
+      set to true.
+    rationale: >
+      The original truncation was added as a wire-size guard, but `payload.line`
+      and tool-call arrays are exactly the artefacts an operator opens the
+      session detail page to read. The single remaining size guard is the
+      `limit` query parameter (default 200, capped at 1000) so a session page
+      cannot accidentally ask for ten thousand events at once.
+    priority: P1
+    version: v0.5.0
+    status: tested
+    acceptance_criteria:
+      - "AC-108-1: internal/webui/handler.go no longer truncates strings or arrays inside payload — the decoded payload is passed through verbatim."
+      - "AC-108-2: trimmedEvent.Truncated is retained on the wire (json:\"truncated,omitempty\") but is never set to true by the server."
+      - "AC-108-3: The events endpoint still respects the limit query parameter (default 200, capped at 1000); only per-event slimming was removed."
+      - "AC-108-4: TestEventsAPINoTruncation seeds a payload with a 64KB inner JSON string and a 500-element array, asserts the API returns both at exact input length, asserts truncated=false, and asserts the returned `line` is still parseable as JSON (the SPA's JSON.parse(line) contract)."
+    code:
+      - internal/webui/handler.go
+    tests:
+      - internal/webui/handler_test.go
+    deps:
+      - REQ-091


### PR DESCRIPTION
## Summary

- Remove `trimValue` per-string and per-array truncation in `internal/webui/handler.go`. `payload` decoded from `events-v1.jsonl` is now passed through verbatim.
- Keep `trimmedEvent.Truncated` on the wire for backward compatibility with older SPA bundles but never set it to true.
- The `limit` query parameter (default 200, capped at 1000) remains the only size guard.

## Why

Sessions with `kind=log` events were broken in the SPA. `payload.line` is itself a JSON document the SPA re-parses (Claude Code stream-json). The 4000-byte string cut landed inside that nested JSON, so the client's `JSON.parse(line)` failed with "Unterminated string" / "Invalid \\escape" around char 3981–3999. Same pattern for the 200-element array cap on long tool-call records.

## Test plan

- [x] `go test ./internal/webui/ -count=1` — all green, including new `TestEventsAPINoTruncation` (64 KB inner JSON string + 500-element array, asserts exact length round-trip and that the returned `line` is still `JSON.parse`-able).
- [x] `go build ./...` and `go vet ./...` — clean.
- [x] `python3 ~/.autoharness/scripts/validate_index.py project-index.yaml` — pass (added REQ-107 with status `tested`).
- [ ] Manual: open the sample session in the issue (`session-c822e9e0-...`) once deployed and confirm `payload.line` rows render via Pretty without `JSON.parse` errors.

Fixes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)