### PR TITLE
webui: fix SessionDetail event flicker on slow networks (#277)

### DIFF
--- a/project-index.yaml
+++ b/project-index.yaml
@@ -3813,3 +3813,35 @@ requirements:
       - internal/webui/handler_test.go
     deps:
       - REQ-091
+
+  - id: REQ-109
+    title: SessionDetail event-stream race fix — fetch must merge with SSE-arrived events
+    description: >
+      On slow networks the session detail page intermittently flashed events
+      and then blanked them: the initial REST fetch and the SSE subscription
+      both started in the same render, and when SSE arrived first the fetch
+      handler called `setEvents(next)` with a fresh array whose dedupe filter
+      had already eaten 0..N — wiping the SSE-rendered events out of state.
+      A new `mergeSessionEvents` utility funnels both code paths through one
+      functional update that dedupes by `index` (using the shared `seenRef`
+      set) and sorts by `index`, so out-of-order arrivals stay monotonic and
+      neither path can clobber the other. The clearTimeline re-subscribe
+      path uses the same helper. Vitest covers the SSE-before-fetch race,
+      the fetch-then-SSE flow, overlapping-batch dedupe, out-of-order sort,
+      and input-array immutability.
+    priority: P1
+    version: v0.5.0
+    status: tested
+    acceptance_criteria:
+      - "AC-109-1: `web/src/utils/sessionEvents.ts` exports `mergeSessionEvents(prev, incoming, seen)` that dedupes by `index` against a caller-owned `Set<number>`, returns a new sorted array, and never mutates `prev`."
+      - "AC-109-2: `web/src/pages/SessionDetail.tsx` initial-fetch handler uses a functional `setEvents` update that runs through `mergeSessionEvents` instead of `setEvents(next)`; SSE handlers and the clearTimeline re-subscribe path use the same helper."
+      - "AC-109-3: vitest in `web/src/utils/sessionEvents.test.ts` simulates SSE pushing events 0/1/2 before fetch resolves with 0/1/2/3/4 and asserts the final state has length 5 with strictly monotonic indices."
+      - "AC-109-4: vitest covers fetch-resolve-first then SSE pushes 5/6 with no duplicates and no loss; also covers out-of-order arrival sorting and dedupe across overlapping batches."
+      - "AC-109-5: `pnpm -C web build` and `pnpm -C web test` both succeed."
+    code:
+      - web/src/pages/SessionDetail.tsx
+      - web/src/utils/sessionEvents.ts
+    tests:
+      - web/src/utils/sessionEvents.test.ts
+    deps:
+      - REQ-091

--- a/web/src/pages/SessionDetail.tsx
+++ b/web/src/pages/SessionDetail.tsx
@@ -14,6 +14,7 @@ import {
 import { copyText, formatTimestamp, shortID, statusBadgeClass } from '../lib/format';
 import { parseLine, type ParsedMessage, type Runtime } from '../lib/streamMessages';
 import { StreamMessageView } from '../components/StreamMessage';
+import { mergeSessionEvents } from '../utils/sessionEvents';
 
 const KIND_OPTIONS = ['tool_call', 'tool_result', 'message', 'system'] as const;
 type ViewMode = 'pretty' | 'raw';
@@ -164,20 +165,24 @@ export function SessionDetail() {
       .then((data) => {
         if (aborted) return;
         const items = data.events || [];
-        const next: SessionEvent[] = [];
         for (const ev of items) {
-          if (seenRef.current.has(ev.index)) continue;
-          seenRef.current.add(ev.index);
-          next.push(ev);
           if (ev.index > lastIndexRef.current) lastIndexRef.current = ev.index;
         }
-        // Default-expand a few kinds by populating the map.
-        const exp: Record<number, boolean> = {};
-        for (const ev of next) {
-          if (defaultExpanded(ev.kind)) exp[ev.index] = true;
-        }
-        setExpanded(exp);
-        setEvents(next);
+        // Default-expand a few kinds; merge into existing map so events the SSE
+        // already added before this resolve keep their toggle state.
+        setExpanded((prev) => {
+          const exp = { ...prev };
+          for (const ev of items) {
+            if (exp[ev.index] === undefined && defaultExpanded(ev.kind)) {
+              exp[ev.index] = true;
+            }
+          }
+          return exp;
+        });
+        // Functional update + dedupe + sort: the SSE handler may have already
+        // pushed events 0..N before this fetch resolves. A plain setEvents(next)
+        // would clobber them. See issue #277.
+        setEvents((prev) => mergeSessionEvents(prev, items, seenRef.current));
       })
       .catch((err) => {
         if (!aborted) setLoadError(err?.message || 'failed to load events');
@@ -207,9 +212,8 @@ export function SessionDetail() {
       try {
         const ev: SessionEvent = JSON.parse(e.data);
         if (seenRef.current.has(ev.index)) return;
-        seenRef.current.add(ev.index);
         if (ev.index > lastIndexRef.current) lastIndexRef.current = ev.index;
-        setEvents((prev) => [...prev, ev]);
+        setEvents((prev) => mergeSessionEvents(prev, [ev], seenRef.current));
         if (followRef.current) {
           requestAnimationFrame(() => {
             const el = timelineRef.current;
@@ -260,9 +264,8 @@ export function SessionDetail() {
         try {
           const ev: SessionEvent = JSON.parse(e.data);
           if (seenRef.current.has(ev.index)) return;
-          seenRef.current.add(ev.index);
           if (ev.index > lastIndexRef.current) lastIndexRef.current = ev.index;
-          setEvents((prev) => [...prev, ev]);
+          setEvents((prev) => mergeSessionEvents(prev, [ev], seenRef.current));
         } catch {
           /* ignore */
         }

--- a/web/src/utils/sessionEvents.test.ts
+++ b/web/src/utils/sessionEvents.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import type { SessionEvent } from '../api/sessions';
+import { mergeSessionEvents } from './sessionEvents';
+
+function ev(index: number, kind = 'log'): SessionEvent {
+  return { index, kind, seq: index };
+}
+
+describe('mergeSessionEvents', () => {
+  it('SSE arrives before fetch resolves: fetch must merge, not clobber', () => {
+    // The slow-network race from issue #277. Order of operations:
+    //  1. The detail page mounts; both initial fetch and SSE start.
+    //  2. SSE replays events 0,1,2 first (fetch is still pending).
+    //  3. Initial fetch resolves with events 0..4 (replay + the next two).
+    // Before the fix this clobbered the SSE-already-rendered events because
+    // the fetch handler called setEvents(next) with a freshly-built array
+    // whose dedupe filter had already eaten 0/1/2.
+    const seen = new Set<number>();
+
+    // Step 2: SSE pushes 0,1,2 — one event at a time, the way the live
+    // handler sees it.
+    let state: SessionEvent[] = [];
+    state = mergeSessionEvents(state, [ev(0)], seen);
+    state = mergeSessionEvents(state, [ev(1)], seen);
+    state = mergeSessionEvents(state, [ev(2)], seen);
+    expect(state.map((e) => e.index)).toEqual([0, 1, 2]);
+
+    // Step 3: fetch resolves with the trailing 0..4. The whole batch goes
+    // through mergeSessionEvents the same way it does inside setEvents.
+    state = mergeSessionEvents(state, [ev(0), ev(1), ev(2), ev(3), ev(4)], seen);
+
+    expect(state).toHaveLength(5);
+    expect(state.map((e) => e.index)).toEqual([0, 1, 2, 3, 4]);
+    // Indices are strictly monotonic regardless of arrival order.
+    for (let i = 1; i < state.length; i += 1) {
+      expect(state[i].index).toBeGreaterThan(state[i - 1].index);
+    }
+  });
+
+  it('fetch resolves first, then SSE pushes new events: no duplicates, no loss', () => {
+    const seen = new Set<number>();
+    let state: SessionEvent[] = [];
+
+    // Initial fetch returns events 0..4.
+    state = mergeSessionEvents(
+      state,
+      [ev(0), ev(1), ev(2), ev(3), ev(4)],
+      seen,
+    );
+    expect(state.map((e) => e.index)).toEqual([0, 1, 2, 3, 4]);
+
+    // SSE then pushes 5 and 6 — the live tail.
+    state = mergeSessionEvents(state, [ev(5)], seen);
+    state = mergeSessionEvents(state, [ev(6)], seen);
+
+    expect(state).toHaveLength(7);
+    expect(state.map((e) => e.index)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+  });
+
+  it('drops duplicates by index across overlapping batches', () => {
+    const seen = new Set<number>();
+    let state: SessionEvent[] = [];
+    // SSE pushes 3, then fetch returns 1..4 (overlap on 3, plus a stale 1/2).
+    state = mergeSessionEvents(state, [ev(3)], seen);
+    state = mergeSessionEvents(state, [ev(1), ev(2), ev(3), ev(4)], seen);
+    expect(state.map((e) => e.index)).toEqual([1, 2, 3, 4]);
+    // The shared `seen` set carries the dedupe state across calls.
+    expect(seen.has(3)).toBe(true);
+  });
+
+  it('sorts out-of-order arrivals by index so display stays monotonic', () => {
+    const seen = new Set<number>();
+    // SSE delivers events out of order (e.g. retry replay) — the fix sorts
+    // before returning so the timeline UI never shows them backwards.
+    const state = mergeSessionEvents([], [ev(2), ev(0), ev(1)], seen);
+    expect(state.map((e) => e.index)).toEqual([0, 1, 2]);
+  });
+
+  it('does not mutate the input array', () => {
+    const seen = new Set<number>();
+    const prev = [ev(0)];
+    const result = mergeSessionEvents(prev, [ev(1)], seen);
+    expect(prev).toHaveLength(1);
+    expect(result).not.toBe(prev);
+  });
+});

--- a/web/src/utils/sessionEvents.ts
+++ b/web/src/utils/sessionEvents.ts
@@ -1,0 +1,31 @@
+import type { SessionEvent } from '../api/sessions';
+
+/**
+ * Merge a batch of incoming session events into the existing list.
+ *
+ * The SessionDetail page subscribes to two asynchronous sources — the initial
+ * REST fetch and the SSE tail — that can interleave in either order. Both
+ * paths funnel through this helper so:
+ *
+ *   - duplicates (by `index`) are dropped using the shared `seen` set,
+ *   - the result is sorted by `index` so out-of-order arrivals still render
+ *     monotonically,
+ *   - the existing array is preserved by value (no in-place mutation).
+ *
+ * The `seen` set is mutated in place so callers can keep using it as a fast
+ * dedupe guard between calls.
+ */
+export function mergeSessionEvents(
+  prev: SessionEvent[],
+  incoming: SessionEvent[],
+  seen: Set<number>,
+): SessionEvent[] {
+  const merged = prev.slice();
+  for (const ev of incoming) {
+    if (seen.has(ev.index)) continue;
+    seen.add(ev.index);
+    merged.push(ev);
+  }
+  merged.sort((a, b) => a.index - b.index);
+  return merged;
+}


### PR DESCRIPTION
Fixes #277

## Problem

On slow networks the session detail page intermittently flashed events
and then blanked them: the initial REST fetch (`/events?tail=1&limit=200`)
and the SSE subscription (`/stream?after=0`) both started in the same
render. When SSE arrived first, the fetch handler called
`setEvents(next)` with a fresh array whose dedupe filter (`seenRef`)
had already eaten 0..N — wiping the SSE-rendered events out of state
until the next render.

## Fix

A new `web/src/utils/sessionEvents.ts` exports `mergeSessionEvents(prev,
incoming, seen)`:
- dedupes by `index` against the caller-owned `Set<number>`
- sorts by `index` so out-of-order arrivals (retry replay etc.) stay
  monotonic on screen
- never mutates `prev`

Both the initial-fetch handler and the SSE event handler in
`SessionDetail.tsx` now funnel through this helper via functional
`setEvents` updates, so neither side can clobber the other's events.
The `clearTimeline` re-subscribe path uses the same helper.

## Tests

`web/src/utils/sessionEvents.test.ts` covers:
1. SSE pushes 0/1/2 before fetch resolves with 0/1/2/3/4 → final length 5,
   strictly monotonic indices (the issue's named race)
2. Fetch resolves first, then SSE pushes 5/6 → no duplicates, no loss
3. Overlapping-batch dedupe across calls
4. Out-of-order arrivals sorted by index
5. `prev` array is not mutated

`pnpm -C web test` → 8 files / 52 tests pass
`pnpm -C web build` → clean

## Test plan
- [x] `pnpm -C web test`
- [x] `pnpm -C web build`
- [x] `python3 ~/.autoharness/scripts/validate_index.py project-index.yaml`
- [ ] Manual: reproduce on a throttled connection (Chrome DevTools "Slow 3G"),
      open `/sessions/<id>` repeatedly; verify events no longer disappear
      after 1-2s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)