### PR TITLE
auditapi+webui: surface aborted-before-start sessions as degraded

### DIFF
--- a/internal/auditapi/handler.go
+++ b/internal/auditapi/handler.go
@@ -25,6 +25,19 @@ import (
 // HTTP handler's 1-hour rule.
 const stuckThresholdSeconds = int64(3600)
 
+// StatusAbortedBeforeStart is the synthesized status reported for sessions
+// where the runtime aborted before any events were recorded, so neither the
+// agent_sessions DB row nor the events-v1.jsonl file ever materialized. The
+// API surfaces it (instead of "completed"/"running") whenever degraded
+// fallback to disk metadata is the only available signal.
+const StatusAbortedBeforeStart = "aborted_before_start"
+
+// degradedReason values populate the SessionDetail.DegradedReason field.
+const (
+	degradedReasonNoDBRow      = "no_db_row"
+	degradedReasonNoEventsFile = "no_events_file"
+)
+
 // badRequestError wraps parameter-validation errors so callers can distinguish
 // them from backend/DB errors returned by queryEvents.
 type badRequestError struct {
@@ -218,6 +231,12 @@ type sessionListResponse struct {
 	CreatedAt    time.Time  `json:"created_at"`
 	FinishedAt   *time.Time `json:"finished_at"`
 	Summary      string     `json:"summary,omitempty"`
+	// Degraded marks rows whose persisted artefacts indicate the agent
+	// never produced a normal session: either no DB row at all (the response
+	// is synthesized from disk metadata.json) or the events-v1.jsonl file is
+	// missing/empty for a non-running status. Issue #275.
+	Degraded       bool   `json:"degraded,omitempty"`
+	DegradedReason string `json:"degraded_reason,omitempty"`
 }
 
 type sessionDetailResponse struct {
@@ -238,6 +257,14 @@ type sessionDetailResponse struct {
 	StdoutSummary string               `json:"stdout_summary,omitempty"`
 	StderrSummary string               `json:"stderr_summary,omitempty"`
 	ArtifactPaths SessionArtifactPaths `json:"artifact_paths"`
+	// Degraded is true when the API could not produce a fully-normal response
+	// for this session — typically because the agent_sessions DB row never
+	// got written (we fell back to disk metadata.json) or because no
+	// events-v1.jsonl file was ever produced. The frontend uses this to
+	// surface a "this session never produced any events" warning instead of
+	// rendering an empty-but-otherwise-normal-looking timeline. Issue #275.
+	Degraded       bool   `json:"degraded,omitempty"`
+	DegradedReason string `json:"degraded_reason,omitempty"`
 }
 
 type metricsResponse struct {
@@ -431,6 +458,15 @@ func (h *Handler) serveSessionDetail(w http.ResponseWriter, sessionID string) {
 		return
 	}
 	if record == nil {
+		// Issue #275: if no agent_sessions DB row exists, attempt to
+		// reconstruct a degraded response from the on-disk metadata.json
+		// so the operator can still see what happened. The response is
+		// flagged degraded=true so the SPA renders a "never produced any
+		// events" warning instead of an empty-looking normal session.
+		if resp, ok := h.buildDegradedFromDisk(sessionID); ok {
+			writeJSON(w, http.StatusOK, resp)
+			return
+		}
 		writeError(w, http.StatusNotFound, "session not found")
 		return
 	}
@@ -1030,8 +1066,10 @@ func (h *Handler) listSessions(p sessionListParams) ([]sessionListResponse, erro
 	}
 
 	out := make([]sessionListResponse, 0, len(records))
+	seen := make(map[string]struct{}, len(records))
 	for i := range records {
 		record := records[i]
+		seen[record.SessionID] = struct{}{}
 		exitCode, _, finishedAt, err := h.sessionTaskStats(record)
 		if err != nil {
 			return nil, err
@@ -1064,9 +1102,97 @@ func (h *Handler) listSessions(p sessionListParams) ([]sessionListResponse, erro
 				row.CurrentState = labelToState(currentLabel(decodeLabels(cache.Labels)))
 			}
 		}
+		// Issue #275: flag rows whose events-v1.jsonl artefact never
+		// materialized AND the session is already in a terminal-ish state.
+		// Running sessions are excluded — they may legitimately not have
+		// streamed any events yet.
+		if isTerminalSessionStatus(row.TaskStatus) || isTerminalSessionStatus(row.Status) {
+			eventsPath := record.Dir
+			if eventsPath == "" && h.sessionsDir != "" {
+				eventsPath = filepath.Join(h.sessionsDir, record.SessionID)
+			}
+			if eventsPath != "" {
+				eventsPath = filepath.Join(eventsPath, "events-v1.jsonl")
+			}
+			if eventsPath != "" && !eventsFileHasContent(eventsPath) {
+				row.Degraded = true
+				row.DegradedReason = degradedReasonNoEventsFile
+			}
+		}
 		out = append(out, row)
 	}
+	// Issue #275: surface disk-only sessions (metadata.json with no DB row)
+	// so the operator can find and drill into them. They are always tagged
+	// degraded=no_db_row. Skipped when sessionsDir is unset (tests / split
+	// deployments without a sessions directory) or when filters were used —
+	// disk-walk filtering would be lossy and surprising.
+	if h.sessionsDir != "" && p.Repo == "" && p.AgentName == "" && p.IssueNum == 0 {
+		out = append(out, h.listDiskOnlySessions(seen)...)
+	}
 	return out, nil
+}
+
+// listDiskOnlySessions enumerates sessionsDir for per-session metadata.json
+// files whose session_id is not present in `seen` (the DB-backed listing).
+// Each match becomes a degraded sessionListResponse row. Errors are
+// swallowed: a missing/unreadable directory simply returns no extra rows.
+func (h *Handler) listDiskOnlySessions(seen map[string]struct{}) []sessionListResponse {
+	if h.sessionsDir == "" {
+		return nil
+	}
+	entries, err := os.ReadDir(h.sessionsDir)
+	if err != nil {
+		return nil
+	}
+	out := make([]sessionListResponse, 0)
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		sessionID := entry.Name()
+		if !isValidSessionID(sessionID) {
+			continue
+		}
+		if _, ok := seen[sessionID]; ok {
+			continue
+		}
+		meta, ok := readDiskSessionMetadata(filepath.Join(h.sessionsDir, sessionID, "metadata.json"))
+		if !ok {
+			continue
+		}
+		row := sessionListResponse{
+			SessionID:      sessionID,
+			TaskID:         meta.TaskID,
+			Repo:           meta.Repo,
+			IssueNum:       meta.IssueNum,
+			AgentName:      meta.AgentName,
+			Runtime:        meta.Runtime,
+			WorkerID:       meta.WorkerID,
+			Attempt:        meta.Attempt,
+			Status:         StatusAbortedBeforeStart,
+			TaskStatus:     StatusAbortedBeforeStart,
+			ExitCode:       firstNonZeroExitCode(meta.ExitCode, -1),
+			Duration:       sessionDuration(meta.CreatedAt, nullableMetaTime(meta.ClosedAt)),
+			CreatedAt:      meta.CreatedAt,
+			FinishedAt:     nullableMetaTime(meta.ClosedAt),
+			Summary:        meta.Summary,
+			Degraded:       true,
+			DegradedReason: degradedReasonNoDBRow,
+		}
+		out = append(out, row)
+	}
+	return out
+}
+
+// firstNonZeroExitCode returns `recorded` when it is non-zero (so an
+// explicitly-recorded -1 or other failure code wins) and falls back to
+// `fallback` otherwise. Used to default disk-only rows to -1 instead of a
+// misleading 0.
+func firstNonZeroExitCode(recorded, fallback int) int {
+	if recorded != 0 {
+		return recorded
+	}
+	return fallback
 }
 
 func (h *Handler) buildSessionDetail(record store.SessionRecord) (sessionDetailResponse, error) {
@@ -1087,7 +1213,7 @@ func (h *Handler) buildSessionDetail(record store.SessionRecord) (sessionDetailR
 	if artifactPaths.EventsV1 == "" && artifactPaths.SessionDir != "" {
 		artifactPaths.EventsV1 = filepath.Join(artifactPaths.SessionDir, "events-v1.jsonl")
 	}
-	return sessionDetailResponse{
+	resp := sessionDetailResponse{
 		SessionID:     record.SessionID,
 		TaskID:        record.TaskID,
 		Repo:          record.Repo,
@@ -1105,7 +1231,188 @@ func (h *Handler) buildSessionDetail(record store.SessionRecord) (sessionDetailR
 		StdoutSummary: readArtifactSummary(record.StdoutPath, 4096),
 		StderrSummary: readArtifactSummary(record.StderrPath, 4096),
 		ArtifactPaths: artifactPaths,
-	}, nil
+	}
+	// Issue #275: even when a DB row exists, mark the session degraded if
+	// the events-v1.jsonl artefact never materialized AND the session is
+	// already in a non-running terminal-ish state — that combination is the
+	// same "looks completed, actually aborted" failure mode operators have
+	// been hitting in production. Running/pending sessions are excluded
+	// because absence-of-events is normal for them.
+	if isTerminalSessionStatus(resp.Status) && !eventsFileHasContent(artifactPaths.EventsV1) {
+		resp.Degraded = true
+		resp.DegradedReason = degradedReasonNoEventsFile
+	}
+	return resp, nil
+}
+
+// buildDegradedFromDisk reconstructs a sessionDetailResponse from a
+// per-session metadata.json on disk when the agent_sessions DB row is
+// missing. Returns ok=false (so the caller can return 404) when the on-disk
+// metadata is unreadable or unusable. Issue #275.
+func (h *Handler) buildDegradedFromDisk(sessionID string) (sessionDetailResponse, bool) {
+	if h.sessionsDir == "" {
+		return sessionDetailResponse{}, false
+	}
+	dir := filepath.Join(h.sessionsDir, sessionID)
+	meta, ok := readDiskSessionMetadata(filepath.Join(dir, "metadata.json"))
+	if !ok {
+		return sessionDetailResponse{}, false
+	}
+	stdoutPath := meta.StdoutPath
+	if stdoutPath == "" {
+		stdoutPath = filepath.Join(dir, "stdout")
+	}
+	stderrPath := meta.StderrPath
+	if stderrPath == "" {
+		stderrPath = filepath.Join(dir, "stderr")
+	}
+	artifactPaths := SessionArtifactPaths{
+		SessionDir: dir,
+		EventsV1:   filepath.Join(dir, "events-v1.jsonl"),
+	}
+	stderrSummary := readArtifactSummary(stderrPath, 4096)
+	summary := strings.TrimSpace(meta.Summary)
+	if summary == "" {
+		summary = synthesizeDegradedSummary(meta, stderrSummary)
+	}
+	exitCode := meta.ExitCode
+	// When SessionManager.Create wrote metadata.json but Close() never ran,
+	// status remains "running" and exit_code defaults to zero. Surface a
+	// distinct -1 placeholder so the UI does not display a misleading
+	// "exit 0 / completed" pair.
+	if exitCode == 0 && !isTerminalSessionStatus(meta.Status) {
+		exitCode = -1
+	}
+	finishedAt := nullableMetaTime(meta.ClosedAt)
+	resp := sessionDetailResponse{
+		SessionID:      sessionID,
+		TaskID:         meta.TaskID,
+		Repo:           meta.Repo,
+		IssueNum:       meta.IssueNum,
+		AgentName:      meta.AgentName,
+		Runtime:        meta.Runtime,
+		WorkerID:       meta.WorkerID,
+		Attempt:        meta.Attempt,
+		Status:         StatusAbortedBeforeStart,
+		ExitCode:       exitCode,
+		Duration:       sessionDuration(meta.CreatedAt, finishedAt),
+		CreatedAt:      meta.CreatedAt,
+		FinishedAt:     finishedAt,
+		Summary:        summary,
+		StdoutSummary:  readArtifactSummary(stdoutPath, 4096),
+		StderrSummary:  stderrSummary,
+		ArtifactPaths:  artifactPaths,
+		Degraded:       true,
+		DegradedReason: degradedReasonNoDBRow,
+	}
+	return resp, true
+}
+
+// diskSessionMetadata mirrors the runtime SessionManager's metadata.json
+// schema. Defined locally to avoid an import cycle with internal/runtime
+// and to insulate the API from future schema changes.
+type diskSessionMetadata struct {
+	SessionID  string    `json:"session_id"`
+	TaskID     string    `json:"task_id,omitempty"`
+	Repo       string    `json:"repo"`
+	IssueNum   int       `json:"issue_num"`
+	AgentName  string    `json:"agent_name"`
+	Runtime    string    `json:"runtime,omitempty"`
+	WorkerID   string    `json:"worker_id,omitempty"`
+	Attempt    int       `json:"attempt"`
+	Status     string    `json:"status"`
+	CreatedAt  time.Time `json:"created_at"`
+	ClosedAt   time.Time `json:"closed_at,omitempty"`
+	StdoutPath string    `json:"stdout_path,omitempty"`
+	StderrPath string    `json:"stderr_path,omitempty"`
+	// ExitCode and Summary are not part of the canonical metadata schema
+	// today, but the fields are reserved here so writers (the supervisor /
+	// session manager) can populate them in the future and the API will
+	// surface them automatically.
+	ExitCode int    `json:"exit_code,omitempty"`
+	Summary  string `json:"summary,omitempty"`
+}
+
+func readDiskSessionMetadata(path string) (diskSessionMetadata, bool) {
+	if path == "" {
+		return diskSessionMetadata{}, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return diskSessionMetadata{}, false
+	}
+	var meta diskSessionMetadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return diskSessionMetadata{}, false
+	}
+	if meta.SessionID == "" && meta.Repo == "" && meta.AgentName == "" {
+		return diskSessionMetadata{}, false
+	}
+	return meta, true
+}
+
+func nullableMetaTime(t time.Time) *time.Time {
+	if t.IsZero() {
+		return nil
+	}
+	ts := t.UTC()
+	return &ts
+}
+
+// synthesizeDegradedSummary builds a markdown summary mirroring the shape
+// produced by audit.buildMinimalSummary so the SPA's warning card has
+// something useful to render even when the metadata.json itself does not
+// carry an explicit summary field.
+func synthesizeDegradedSummary(meta diskSessionMetadata, stderrExcerpt string) string {
+	var b strings.Builder
+	b.WriteString("## Session Summary (no session file)\n\n")
+	b.WriteString("- DB row: missing — response synthesized from metadata.json\n")
+	if meta.Status != "" {
+		fmt.Fprintf(&b, "- Recorded status: %s\n", meta.Status)
+	}
+	if meta.ExitCode != 0 {
+		fmt.Fprintf(&b, "- Exit code: %d\n", meta.ExitCode)
+	} else {
+		b.WriteString("- Exit code: -1 (unknown — runtime aborted before reporting)\n")
+	}
+	if !meta.CreatedAt.IsZero() {
+		fmt.Fprintf(&b, "- Created at: %s\n", meta.CreatedAt.UTC().Format(time.RFC3339))
+	}
+	if !meta.ClosedAt.IsZero() {
+		fmt.Fprintf(&b, "- Closed at: %s\n", meta.ClosedAt.UTC().Format(time.RFC3339))
+	}
+	if stderrExcerpt != "" {
+		b.WriteString("\n### Stderr (excerpt)\n```\n")
+		b.WriteString(stderrExcerpt)
+		b.WriteString("\n```\n")
+	}
+	return b.String()
+}
+
+func isTerminalSessionStatus(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case store.TaskStatusCompleted, store.TaskStatusFailed, store.TaskStatusTimeout, StatusAbortedBeforeStart:
+		return true
+	}
+	return false
+}
+
+// eventsFileHasContent reports whether the events-v1.jsonl artefact at
+// `path` exists and contains at least one byte. Missing files return false;
+// any other I/O error is treated as "no usable content" so the caller can
+// degrade gracefully.
+func eventsFileHasContent(path string) bool {
+	if path == "" {
+		return false
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	if info.IsDir() {
+		return false
+	}
+	return info.Size() > 0
 }
 
 func (h *Handler) sessionTaskStats(record store.SessionRecord) (int, string, *time.Time, error) {

--- a/internal/auditapi/handler_test.go
+++ b/internal/auditapi/handler_test.go
@@ -1083,6 +1083,233 @@ func TestDashboardStatusEndpoint_AddedFields(t *testing.T) {
 	}
 }
 
+// Issue #275: a session with only a metadata.json (no DB row, no events
+// file) must surface as degraded so operators can tell it apart from a
+// session that ran normally and happened to emit nothing.
+func TestDashboardSessionDetail_DegradedFromDiskMetadata(t *testing.T) {
+	st := newTestStore(t)
+	sessionsDir := filepath.Join(t.TempDir(), "sessions")
+	sessionID := "session-aborted-before-start"
+	dir := filepath.Join(sessionsDir, sessionID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	metadata := map[string]any{
+		"session_id":  sessionID,
+		"task_id":     "task-aborted",
+		"repo":        "owner/repo",
+		"issue_num":   77,
+		"agent_name":  "dev-agent",
+		"runtime":     "claude-oneshot",
+		"worker_id":   "worker-x",
+		"attempt":     1,
+		"status":      "running",
+		"created_at":  "2026-04-30T08:00:00Z",
+		"stdout_path": filepath.Join(dir, "stdout"),
+		"stderr_path": filepath.Join(dir, "stderr"),
+	}
+	metaJSON, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "metadata.json"), metaJSON, 0o644); err != nil {
+		t.Fatalf("write metadata.json: %v", err)
+	}
+	stderrExcerpt := "runtime: claude-oneshot: start: post /agents: Post \"http://127.0.0.1:36597/agents\": context canceled\n"
+	if err := os.WriteFile(filepath.Join(dir, "stderr"), []byte(stderrExcerpt), 0o644); err != nil {
+		t.Fatalf("write stderr: %v", err)
+	}
+
+	h := NewHandler(st)
+	h.SetSessionsDir(sessionsDir)
+	mux := http.NewServeMux()
+	h.RegisterDashboard(mux)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	resp, err := http.Get(server.URL + "/api/v1/sessions/" + sessionID)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d body=%s", resp.StatusCode, string(body))
+	}
+	var body sessionDetailResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body.Degraded {
+		t.Fatalf("degraded = false, want true")
+	}
+	if body.DegradedReason != "no_db_row" {
+		t.Fatalf("degraded_reason = %q, want %q", body.DegradedReason, "no_db_row")
+	}
+	if body.Status != StatusAbortedBeforeStart {
+		t.Fatalf("status = %q, want %q", body.Status, StatusAbortedBeforeStart)
+	}
+	if body.ExitCode != -1 {
+		t.Fatalf("exit_code = %d, want -1", body.ExitCode)
+	}
+	if body.SessionID != sessionID {
+		t.Fatalf("session_id = %q", body.SessionID)
+	}
+	if body.Repo != "owner/repo" || body.IssueNum != 77 {
+		t.Fatalf("repo/issue = %q/%d", body.Repo, body.IssueNum)
+	}
+	if body.AgentName != "dev-agent" {
+		t.Fatalf("agent_name = %q", body.AgentName)
+	}
+	if !strings.Contains(body.StderrSummary, "context canceled") {
+		t.Fatalf("stderr_summary missing canceled marker: %q", body.StderrSummary)
+	}
+	if !strings.Contains(body.Summary, "no session file") {
+		t.Fatalf("summary missing degraded marker: %q", body.Summary)
+	}
+	if !strings.Contains(body.Summary, "context canceled") {
+		t.Fatalf("summary missing stderr excerpt: %q", body.Summary)
+	}
+}
+
+// TestDashboardSessionDetail_NoMetadataReturns404 keeps the existing 404
+// behavior for sessions where neither the DB nor disk has anything.
+func TestDashboardSessionDetail_NoMetadataReturns404(t *testing.T) {
+	fixture := newDashboardFixture(t)
+	resp, err := http.Get(fixture.server.URL + "/api/v1/sessions/totally-missing")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+// Issue #275: a DB-backed session whose events-v1.jsonl is empty AND whose
+// status is terminal should also be flagged degraded so the SPA surfaces
+// the warning even when the row exists.
+func TestDashboardSessionDetail_DegradedForEmptyEventsFile(t *testing.T) {
+	st := newTestStore(t)
+	sessionsDir := filepath.Join(t.TempDir(), "sessions")
+	dir := filepath.Join(sessionsDir, "session-empty-events")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "events-v1.jsonl"), []byte{}, 0o644); err != nil {
+		t.Fatalf("write events: %v", err)
+	}
+	if err := st.InsertTask(store.TaskRecord{
+		ID:        "task-empty",
+		Repo:      "owner/repo",
+		IssueNum:  78,
+		AgentName: "dev-agent",
+		Status:    store.TaskStatusFailed,
+	}); err != nil {
+		t.Fatalf("InsertTask: %v", err)
+	}
+	if _, err := st.CreateSession(store.SessionRecord{
+		SessionID: "session-empty-events",
+		TaskID:    "task-empty",
+		Repo:      "owner/repo",
+		IssueNum:  78,
+		AgentName: "dev-agent",
+		Status:    store.TaskStatusFailed,
+		Dir:       dir,
+	}); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	h := NewHandler(st)
+	h.SetSessionsDir(sessionsDir)
+	mux := http.NewServeMux()
+	h.RegisterDashboard(mux)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	resp, err := http.Get(server.URL + "/api/v1/sessions/session-empty-events")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	var body sessionDetailResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body.Degraded {
+		t.Fatalf("degraded = false, want true (empty events + terminal status)")
+	}
+	if body.DegradedReason != "no_events_file" {
+		t.Fatalf("degraded_reason = %q, want no_events_file", body.DegradedReason)
+	}
+}
+
+// Issue #275: the listing endpoint should surface disk-only sessions and
+// flag them degraded so they appear in /sessions with the ⚠️ badge.
+func TestDashboardSessionsList_IncludesDegradedDiskOnlyRow(t *testing.T) {
+	st := newTestStore(t)
+	sessionsDir := filepath.Join(t.TempDir(), "sessions")
+	sessionID := "session-disk-only"
+	dir := filepath.Join(sessionsDir, sessionID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	metadata := map[string]any{
+		"session_id": sessionID,
+		"repo":       "owner/repo",
+		"issue_num":  79,
+		"agent_name": "dev-agent",
+		"attempt":    1,
+		"status":     "running",
+		"created_at": "2026-04-30T09:00:00Z",
+	}
+	metaJSON, _ := json.MarshalIndent(metadata, "", "  ")
+	if err := os.WriteFile(filepath.Join(dir, "metadata.json"), metaJSON, 0o644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+
+	h := NewHandler(st)
+	h.SetSessionsDir(sessionsDir)
+	mux := http.NewServeMux()
+	h.RegisterDashboard(mux)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	resp, err := http.Get(server.URL + "/api/v1/sessions?limit=10")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var rows []sessionListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rows); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	var disk *sessionListResponse
+	for i := range rows {
+		if rows[i].SessionID == sessionID {
+			disk = &rows[i]
+		}
+	}
+	if disk == nil {
+		t.Fatalf("disk-only session missing from listing: %+v", rows)
+	}
+	if !disk.Degraded {
+		t.Fatalf("degraded = false, want true")
+	}
+	if disk.DegradedReason != "no_db_row" {
+		t.Fatalf("degraded_reason = %q, want no_db_row", disk.DegradedReason)
+	}
+	if disk.Status != StatusAbortedBeforeStart {
+		t.Fatalf("status = %q, want %q", disk.Status, StatusAbortedBeforeStart)
+	}
+	if disk.ExitCode != -1 {
+		t.Fatalf("exit_code = %d, want -1", disk.ExitCode)
+	}
+}
+
 func TestDeprecatedSessionPath_AddsHeaderAndKeepsBody(t *testing.T) {
 	st := newTestStore(t)
 	sessionsDir := filepath.Join(t.TempDir(), "sessions")

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -3845,3 +3845,44 @@ requirements:
       - web/src/utils/sessionEvents.test.ts
     deps:
       - REQ-091
+
+  - id: REQ-110
+    title: "Surface aborted-before-start sessions as degraded in API + SPA (#275)"
+    description: >
+      The auditapi /api/v1/sessions/:id endpoint returns degraded=true +
+      degraded_reason when no agent_sessions DB row exists (response
+      synthesized from disk metadata.json) or when the events-v1.jsonl
+      artefact is missing on a session that is already in a terminal
+      status. Status is rewritten to `aborted_before_start` and exit_code
+      defaults to -1 when the session never reported a real exit. The
+      sessions list endpoint enumerates disk-only sessions with the same
+      degraded marker. The SPA shows a red warning card on SessionDetail
+      and a warning badge on the Sessions list so operators can tell apart
+      "ran-and-emitted-nothing" from "aborted-before-start".
+    rationale: >
+      Issue #275: a session whose runtime aborted before start was being
+      rendered identically to a normal-but-empty session (status:
+      completed, exit_code 0, empty timeline). Operators had to dig into
+      raw metadata.json by hand to see the truth. The degraded marker
+      makes the failure mode visible at a glance.
+    priority: P2
+    version: v0.5.0
+    status: tested
+    acceptance_criteria:
+      - "AC-110-1: GET /api/v1/sessions/:id falls back to <sessionsDir>/<id>/metadata.json when no DB row exists, sets degraded=true and degraded_reason=no_db_row, status=aborted_before_start, exit_code=-1 (when metadata did not record a real exit)."
+      - "AC-110-2: GET /api/v1/sessions/:id flags an in-DB session degraded=true with degraded_reason=no_events_file when its events-v1.jsonl is missing/empty AND its status is terminal (completed/failed/timeout/aborted_before_start)."
+      - "AC-110-3: GET /api/v1/sessions enumerates disk-only sessions and returns them with degraded=true + degraded_reason=no_db_row + status=aborted_before_start so operators can see them in the list."
+      - "AC-110-4: SPA SessionDetail renders a red wb-degraded-card alert with the synthesized summary / stderr excerpt when the API flagged degraded=true OR when events.total === 0 on a finished session."
+      - "AC-110-5: SPA Sessions list shows a wb-degraded-marker plus a wb-badge-degraded pill for any row whose API response carried degraded=true."
+    code:
+      - internal/auditapi/handler.go
+      - web/src/api/sessions.ts
+      - web/src/components/DegradedSessionCard.tsx
+      - web/src/pages/SessionDetail.tsx
+      - web/src/pages/Sessions.tsx
+      - web/src/styles.css
+    tests:
+      - internal/auditapi/handler_test.go
+      - web/src/components/DegradedSessionCard.test.tsx
+    deps:
+      - REQ-105

--- a/web/src/api/sessions.ts
+++ b/web/src/api/sessions.ts
@@ -18,6 +18,11 @@ export interface SessionListItem {
   created_at: string;
   finished_at?: string | null;
   summary?: string;
+  // Issue #275: degraded rows are sessions with no events file (or no DB
+  // row at all). The SPA renders a ⚠️ badge so operators can spot
+  // never-actually-ran sessions in the list at a glance.
+  degraded?: boolean;
+  degraded_reason?: string;
 }
 
 export interface SessionDetail {
@@ -42,6 +47,14 @@ export interface SessionDetail {
     events_v1?: string;
     raw?: string;
   };
+  // Issue #275: degraded === true means the API could not produce a normal
+  // response — typically because the agent_sessions DB row was missing
+  // (response synthesized from disk metadata.json) or because no
+  // events-v1.jsonl file was ever produced. The SPA surfaces a red warning
+  // card with the summary/stderr instead of an empty-but-otherwise-normal
+  // timeline.
+  degraded?: boolean;
+  degraded_reason?: string;
 }
 
 export interface SessionEvent {

--- a/web/src/components/DegradedSessionCard.test.tsx
+++ b/web/src/components/DegradedSessionCard.test.tsx
@@ -1,0 +1,135 @@
+import { render } from '@testing-library/preact';
+import { describe, expect, it } from 'vitest';
+import {
+  DegradedSessionCard,
+  SessionStatusBadge,
+} from './DegradedSessionCard';
+import type { SessionDetail, SessionListItem } from '../api/sessions';
+
+function makeMeta(overrides: Partial<SessionDetail> = {}): SessionDetail {
+  return {
+    session_id: 'session-test',
+    repo: 'owner/repo',
+    issue_num: 1,
+    agent_name: 'dev-agent',
+    attempt: 1,
+    status: 'aborted_before_start',
+    exit_code: -1,
+    duration: 0,
+    created_at: '2026-04-30T08:00:00Z',
+    artifact_paths: {},
+    ...overrides,
+  };
+}
+
+describe('DegradedSessionCard', () => {
+  it('renders nothing when meta is null', () => {
+    const { container } = render(
+      <DegradedSessionCard meta={null} eventsTotal={null} />,
+    );
+    expect(container.querySelector('.wb-degraded-card')).toBeNull();
+  });
+
+  it('renders nothing for a normal completed session with events', () => {
+    const meta = makeMeta({ status: 'completed', exit_code: 0 });
+    const { container } = render(
+      <DegradedSessionCard meta={meta} eventsTotal={42} />,
+    );
+    expect(container.querySelector('.wb-degraded-card')).toBeNull();
+  });
+
+  it('renders the warning when API flagged degraded=true with no_db_row', () => {
+    const meta = makeMeta({
+      degraded: true,
+      degraded_reason: 'no_db_row',
+      summary: '## Session Summary (no session file)\n\n- Exit code: -1\n',
+      stderr_summary: 'runtime: claude-oneshot: context canceled',
+    });
+    const { container, getByRole } = render(
+      <DegradedSessionCard meta={meta} eventsTotal={0} />,
+    );
+    expect(getByRole('alert')).not.toBeNull();
+    expect(container.textContent).toContain('never produced any events');
+    expect(container.textContent).toContain(
+      'No agent_sessions row exists',
+    );
+    expect(container.textContent).toContain('aborted_before_start');
+    expect(container.textContent).toContain('-1');
+    expect(container.textContent).toContain('Session Summary (no session file)');
+  });
+
+  it('renders the warning for inferred-empty (zero events on a finished session)', () => {
+    const meta = makeMeta({ status: 'completed', exit_code: 0, degraded: false });
+    const { container } = render(
+      <DegradedSessionCard meta={meta} eventsTotal={0} />,
+    );
+    expect(container.querySelector('.wb-degraded-card')).not.toBeNull();
+    expect(container.textContent).toContain(
+      'Zero events recorded for a session that already finished',
+    );
+  });
+
+  it('does not warn for running sessions with no events yet', () => {
+    const meta = makeMeta({ status: 'running', exit_code: 0, degraded: false });
+    const { container } = render(
+      <DegradedSessionCard meta={meta} eventsTotal={0} />,
+    );
+    expect(container.querySelector('.wb-degraded-card')).toBeNull();
+  });
+
+  it('describes no_events_file reason', () => {
+    const meta = makeMeta({
+      degraded: true,
+      degraded_reason: 'no_events_file',
+      status: 'failed',
+      exit_code: 1,
+    });
+    const { container } = render(
+      <DegradedSessionCard meta={meta} eventsTotal={0} />,
+    );
+    expect(container.textContent).toContain(
+      'No events-v1.jsonl file was ever written',
+    );
+  });
+});
+
+describe('SessionStatusBadge', () => {
+  function makeRow(
+    overrides: Partial<SessionListItem> = {},
+  ): SessionListItem {
+    return {
+      session_id: 'session-x',
+      repo: 'owner/repo',
+      issue_num: 1,
+      agent_name: 'dev-agent',
+      attempt: 1,
+      status: 'completed',
+      exit_code: 0,
+      duration: 0,
+      created_at: '2026-04-30T08:00:00Z',
+      ...overrides,
+    };
+  }
+
+  it('shows the warning marker when degraded=true', () => {
+    const row = makeRow({
+      degraded: true,
+      degraded_reason: 'no_db_row',
+      status: 'aborted_before_start',
+    });
+    const { container } = render(<SessionStatusBadge row={row} />);
+    const marker = container.querySelector('.wb-degraded-marker');
+    expect(marker).not.toBeNull();
+    expect(marker?.textContent).toContain('⚠️');
+    const badge = container.querySelector('.wb-badge');
+    expect(badge?.classList.contains('wb-badge-degraded')).toBe(true);
+    expect(badge?.textContent).toBe('aborted_before_start');
+  });
+
+  it('renders a normal badge with no marker when not degraded', () => {
+    const row = makeRow({ status: 'completed', task_status: 'completed' });
+    const { container } = render(<SessionStatusBadge row={row} />);
+    expect(container.querySelector('.wb-degraded-marker')).toBeNull();
+    expect(container.querySelector('.wb-badge')?.textContent).toBe('completed');
+  });
+});

--- a/web/src/components/DegradedSessionCard.tsx
+++ b/web/src/components/DegradedSessionCard.tsx
@@ -1,0 +1,119 @@
+import type { JSX } from 'preact';
+import type { SessionDetail, SessionListItem } from '../api/sessions';
+import { statusBadgeClass } from '../lib/format';
+
+// DegradedSessionCard renders a red warning banner for sessions that never
+// produced any events. Issue #275: surfaces the difference between "session
+// ran and emitted nothing" and "session was aborted before it could write a
+// single event" so operators stop confusing the two.
+//
+// The banner appears when:
+//   * the API explicitly tagged the response degraded=true (no DB row, or
+//     no events file with a terminal status), OR
+//   * we got zero events back from a non-running session — the same
+//     "looks normal but actually empty" scenario the issue describes.
+export function DegradedSessionCard({
+  meta,
+  eventsTotal,
+}: {
+  meta: SessionDetail | null;
+  eventsTotal: number | null;
+}): JSX.Element | null {
+  if (!meta) return null;
+  const apiDegraded = meta.degraded === true;
+  const status = (meta.status || '').toLowerCase();
+  const inferredEmpty =
+    eventsTotal !== null &&
+    eventsTotal === 0 &&
+    status !== '' &&
+    status !== 'running' &&
+    status !== 'pending';
+  if (!apiDegraded && !inferredEmpty) return null;
+
+  const reasonLabel = describeDegradedReason(
+    meta.degraded_reason,
+    apiDegraded,
+    inferredEmpty,
+  );
+  const stderrExcerpt = (meta.stderr_summary || '').trim();
+  const summary = (meta.summary || '').trim();
+
+  return (
+    <div class="wb-degraded-card" role="alert">
+      <h2>⚠️ This session never produced any events</h2>
+      <p>
+        Reason: <strong>{reasonLabel}</strong>
+      </p>
+      <p>
+        Reported status:{' '}
+        <span class={statusBadgeClass(meta.status || 'aborted_before_start')}>
+          {meta.status || 'aborted_before_start'}
+        </span>{' '}
+        · exit code <code>{meta.exit_code}</code>
+      </p>
+      {summary && <pre>{summary}</pre>}
+      {!summary && stderrExcerpt && (
+        <>
+          <p>Stderr (excerpt):</p>
+          <pre>{stderrExcerpt}</pre>
+        </>
+      )}
+      {!summary && !stderrExcerpt && (
+        <p>
+          No summary or stderr was captured for this session — the timeline below is
+          empty by design, not a UI bug.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function describeDegradedReason(
+  reason: string | undefined,
+  apiDegraded: boolean,
+  inferredEmpty: boolean,
+): string {
+  if (reason === 'no_db_row') {
+    return 'No agent_sessions row exists — response synthesized from disk metadata.json';
+  }
+  if (reason === 'no_events_file') {
+    return 'No events-v1.jsonl file was ever written for this session';
+  }
+  if (apiDegraded) return reason || 'API flagged this session as degraded';
+  if (inferredEmpty) return 'Zero events recorded for a session that already finished';
+  return 'unknown';
+}
+
+// SessionStatusBadge renders the per-row status pill plus a ⚠️ marker for
+// degraded sessions so operators can spot rows where the API explicitly
+// flagged degraded=true. Issue #275.
+export function SessionStatusBadge({
+  row,
+}: {
+  row: SessionListItem;
+}): JSX.Element {
+  const statusText =
+    row.status === 'aborted_before_start'
+      ? 'aborted_before_start'
+      : row.task_status || row.status || 'unknown';
+  const cls = row.degraded
+    ? 'wb-badge wb-badge-degraded'
+    : statusBadgeClass(row.task_status || row.status);
+  const title = row.degraded
+    ? `degraded: ${row.degraded_reason || 'no events captured'}`
+    : undefined;
+  return (
+    <span title={title}>
+      {row.degraded && (
+        <span
+          class="wb-degraded-marker"
+          aria-label="degraded session"
+          title={title}
+        >
+          ⚠️
+        </span>
+      )}
+      <span class={cls}>{statusText}</span>
+    </span>
+  );
+}

--- a/web/src/pages/SessionDetail.tsx
+++ b/web/src/pages/SessionDetail.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { useRoute } from 'preact-iso';
 import { Layout } from '../components/Layout';
 import { GitHubIssueLink } from '../components/GitHubIssueLink';
+import { DegradedSessionCard } from '../components/DegradedSessionCard';
 import { splitRepoSlug } from '../utils/github';
 import {
   fetchSession,
@@ -111,6 +112,7 @@ export function SessionDetail() {
   const [meta, setMeta] = useState<SessionDetailMeta | null>(null);
   const [metaError, setMetaError] = useState<string | null>(null);
   const [events, setEvents] = useState<SessionEvent[]>([]);
+  const [eventsTotal, setEventsTotal] = useState<number | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [follow, setFollow] = useState(true);
   const [streamLive, setStreamLive] = useState(false);
@@ -183,6 +185,7 @@ export function SessionDetail() {
         // pushed events 0..N before this fetch resolves. A plain setEvents(next)
         // would clobber them. See issue #277.
         setEvents((prev) => mergeSessionEvents(prev, items, seenRef.current));
+        setEventsTotal(typeof data.total === 'number' ? data.total : 0);
       })
       .catch((err) => {
         if (!aborted) setLoadError(err?.message || 'failed to load events');
@@ -320,6 +323,8 @@ export function SessionDetail() {
       </div>
 
       {metaError && <div class="wb-error">Session metadata: {metaError}</div>}
+
+      <DegradedSessionCard meta={meta} eventsTotal={eventsTotal} />
 
       <div class="wb-card">
         <dl class="wb-meta-grid">

--- a/web/src/pages/Sessions.tsx
+++ b/web/src/pages/Sessions.tsx
@@ -6,12 +6,13 @@ import {
   type SessionListItem,
   type SessionListQuery,
 } from '../api/sessions';
-import { copyText, formatTimestamp, shortID, statusBadgeClass } from '../lib/format';
+import { copyText, formatTimestamp, shortID } from '../lib/format';
 import {
   distinctValues,
   groupSessionsByIssue,
   type DecoratedSession,
 } from '../utils/sessionGroups';
+import { SessionStatusBadge } from '../components/DegradedSessionCard';
 
 const PAGE_LIMIT = 50;
 
@@ -310,9 +311,7 @@ function FlatTable({
             <td>{s.repo}</td>
             <td>#{s.issue_num}</td>
             <td>
-              <span class={statusBadgeClass(s.task_status || s.status)}>
-                {s.task_status || s.status || 'unknown'}
-              </span>
+              <SessionStatusBadge row={s} />
             </td>
             <td>{formatTimestamp(s.created_at)}</td>
           </tr>
@@ -350,9 +349,7 @@ function GroupedTable({
             </td>
             <td>{s.agent_name}</td>
             <td>
-              <span class={statusBadgeClass(s.task_status || s.status)}>
-                {s.task_status || s.status || 'unknown'}
-              </span>
+              <SessionStatusBadge row={s} />
             </td>
             <td>{formatTimestamp(s.created_at)}</td>
           </tr>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -396,6 +396,50 @@ table.clickable tbody tr:hover {
 .wb-badge-failed, .wb-badge-error, .wb-badge-timeout { background: #ffe2e5; color: #a40e26; }
 .wb-badge-pending, .wb-badge-queued { background: #eef1f4; color: #57606a; }
 .wb-badge-default { background: #f0f3f6; color: #24292f; }
+.wb-badge-degraded, .wb-badge-aborted_before_start {
+  background: #ffe2e5;
+  color: #a40e26;
+  border: 1px solid #f4b9c0;
+}
+.wb-degraded-marker {
+  display: inline-block;
+  margin-right: 4px;
+  color: #a40e26;
+  font-weight: 700;
+}
+
+/* Issue #275: Degraded session warning card on the SessionDetail page. */
+.wb-degraded-card {
+  background: #fff5f5;
+  border: 1px solid #f4b9c0;
+  border-left: 4px solid #cf222e;
+  color: #57606a;
+  padding: 14px 18px;
+  border-radius: 8px;
+  margin-bottom: 16px;
+}
+.wb-degraded-card h2 {
+  margin: 0 0 6px 0;
+  font-size: 15px;
+  color: #a40e26;
+  font-weight: 700;
+}
+.wb-degraded-card p {
+  margin: 6px 0;
+  font-size: 13px;
+}
+.wb-degraded-card pre {
+  background: #ffffff;
+  border: 1px solid #f0d0d4;
+  border-radius: 6px;
+  padding: 10px;
+  margin: 8px 0 0;
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 280px;
+  overflow: auto;
+}
 
 .wb-empty { text-align: center; padding: 32px; color: #656d76; font-size: 14px; }
 .wb-error {


### PR DESCRIPTION
Fixes #275.

## Problem

A session whose runtime aborts before it can record any events used to
render identically to a normal session that simply emitted nothing —
green `completed` pill, `exit_code 0`, empty timeline — even though the
`agent_sessions` DB row was never written and only `metadata.json`
existed on disk. Operators had to inspect raw artefacts to learn that
the agent never actually started.

## Change

* `GET /api/v1/sessions/:id` falls back to `<sessionsDir>/<id>/metadata.json`
  when no DB row exists. The response gains `degraded=true`,
  `degraded_reason=no_db_row`, `status="aborted_before_start"`, and
  `exit_code=-1` (when metadata did not record a real exit). A
  `buildMinimalSummary`-style summary is synthesized for the UI.
* In-DB sessions whose `events-v1.jsonl` is missing/empty **and** whose
  status is terminal get flagged `degraded=true` /
  `degraded_reason=no_events_file`.
* `GET /api/v1/sessions` enumerates disk-only sessions and includes them
  with the same degraded marker so the operator can find them.
* SPA `SessionDetail` renders a red `wb-degraded-card` alert with the
  synthesized summary / stderr excerpt when the API flagged degraded or
  when `events.total === 0` on a finished session.
* SPA `Sessions` list shows a `⚠️` marker plus a `wb-badge-degraded`
  pill on degraded rows.

## Tests

* Go: four new auditapi tests cover the disk-metadata fallback
  (`no_db_row`), the empty-events fallback (`no_events_file`), the
  disk-only listing row, and the still-404-on-truly-missing path.
* Vitest: `DegradedSessionCard.test.tsx` covers the warning card
  (degraded API flag, inferred-empty heuristic, running-session
  exclusion, reason text) and the `SessionStatusBadge` (marker visible
  vs hidden, badge class swap).
* `go build ./... && go vet ./... && go test ./internal/auditapi/`,
  `pnpm -C web test`, `pnpm -C web exec tsc -b`, and `go run .
  validate-docs --strict` all clean. The pre-existing
  `cmd/TestParseWorkerFlags_MgmtPublicURLRequiresSharedAuth` failure is
  unrelated to this change (reproduces on `main`).

## Out of scope

* The supervisor recovery path that lets a session reach this state in
  the first place — covered by the issue's explicit non-goal and a
  separate root-cause fix.
* Synthesizing an `events-v1.jsonl` so the timeline "looks normal" — also
  explicitly listed as a non-goal; users need to see the failure as a
  failure.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/auditapi/ -count=1`
- [x] `pnpm -C web test` (8 files, 55 tests)
- [x] `pnpm -C web exec tsc -b`
- [x] `go run . validate-docs --strict`
- [x] `python3 ~/.autoharness/scripts/validate_index.py project-index.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)