### PR TITLE
auditapi: don't flag live no-DB-row sessions as degraded (#282)

### DIFF
--- a/internal/auditapi/handler.go
+++ b/internal/auditapi/handler.go
@@ -1160,6 +1160,30 @@ func (h *Handler) listDiskOnlySessions(seen map[string]struct{}) []sessionListRe
 		if !ok {
 			continue
 		}
+		// Issue #282: a session whose DB row hasn't been written yet but is
+		// actively streaming events is *live*, not aborted. Surface it as a
+		// running row so the SPA does not paint a misleading degraded badge.
+		eventsPath := filepath.Join(h.sessionsDir, sessionID, "events-v1.jsonl")
+		if metaStatusRunning(meta.Status) && eventsFileHasContent(eventsPath) {
+			out = append(out, sessionListResponse{
+				SessionID:  sessionID,
+				TaskID:     meta.TaskID,
+				Repo:       meta.Repo,
+				IssueNum:   meta.IssueNum,
+				AgentName:  meta.AgentName,
+				Runtime:    meta.Runtime,
+				WorkerID:   meta.WorkerID,
+				Attempt:    meta.Attempt,
+				Status:     store.TaskStatusRunning,
+				TaskStatus: store.TaskStatusRunning,
+				ExitCode:   0,
+				Duration:   sessionDuration(meta.CreatedAt, nullableMetaTime(meta.ClosedAt)),
+				CreatedAt:  meta.CreatedAt,
+				FinishedAt: nullableMetaTime(meta.ClosedAt),
+				Summary:    meta.Summary,
+			})
+			continue
+		}
 		row := sessionListResponse{
 			SessionID:      sessionID,
 			TaskID:         meta.TaskID,
@@ -1271,6 +1295,31 @@ func (h *Handler) buildDegradedFromDisk(sessionID string) (sessionDetailResponse
 		EventsV1:   filepath.Join(dir, "events-v1.jsonl"),
 	}
 	stderrSummary := readArtifactSummary(stderrPath, 4096)
+	// Issue #282: a session whose DB row hasn't been written yet but is
+	// actively streaming events to events-v1.jsonl is still live. Surface
+	// it as running/non-degraded so the SPA renders the timeline normally
+	// instead of the red "aborted_before_start" warning card.
+	if metaStatusRunning(meta.Status) && eventsFileHasContent(artifactPaths.EventsV1) {
+		return sessionDetailResponse{
+			SessionID:     sessionID,
+			TaskID:        meta.TaskID,
+			Repo:          meta.Repo,
+			IssueNum:      meta.IssueNum,
+			AgentName:     meta.AgentName,
+			Runtime:       meta.Runtime,
+			WorkerID:      meta.WorkerID,
+			Attempt:       meta.Attempt,
+			Status:        store.TaskStatusRunning,
+			ExitCode:      0,
+			Duration:      sessionDuration(meta.CreatedAt, nullableMetaTime(meta.ClosedAt)),
+			CreatedAt:     meta.CreatedAt,
+			FinishedAt:    nullableMetaTime(meta.ClosedAt),
+			Summary:       strings.TrimSpace(meta.Summary),
+			StdoutSummary: readArtifactSummary(stdoutPath, 4096),
+			StderrSummary: stderrSummary,
+			ArtifactPaths: artifactPaths,
+		}, true
+	}
 	summary := strings.TrimSpace(meta.Summary)
 	if summary == "" {
 		summary = synthesizeDegradedSummary(meta, stderrSummary)
@@ -1395,6 +1444,14 @@ func isTerminalSessionStatus(status string) bool {
 		return true
 	}
 	return false
+}
+
+// metaStatusRunning reports whether a metadata.json status field marks the
+// session as still in flight. Issue #282: used together with
+// eventsFileHasContent to distinguish a live no-DB-row session from a real
+// aborted-before-start one.
+func metaStatusRunning(status string) bool {
+	return strings.ToLower(strings.TrimSpace(status)) == store.TaskStatusRunning
 }
 
 // eventsFileHasContent reports whether the events-v1.jsonl artefact at

--- a/internal/auditapi/handler_test.go
+++ b/internal/auditapi/handler_test.go
@@ -1416,3 +1416,143 @@ func TestHandleIssuesInFlight_Golden(t *testing.T) {
 	}
 	t.Fatal("issue 40 row not found in response")
 }
+
+// Issue #282: a session whose DB row hasn't been written yet but is actively
+// streaming events to disk must be reported as live (status=running,
+// degraded=false), not as aborted_before_start.
+func TestSessionDetailNoDBRowRunningWithEventsIsNotDegraded(t *testing.T) {
+	st := newTestStore(t)
+	sessionsDir := filepath.Join(t.TempDir(), "sessions")
+	sessionID := "session-running-with-events"
+	dir := filepath.Join(sessionsDir, sessionID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	metadata := map[string]any{
+		"session_id": sessionID,
+		"task_id":    "task-live",
+		"repo":       "owner/repo",
+		"issue_num":  281,
+		"agent_name": "dev-agent",
+		"runtime":    "claude-oneshot",
+		"worker_id":  "worker-z",
+		"attempt":    1,
+		"status":     "running",
+		"created_at": "2026-04-30T08:00:00Z",
+	}
+	metaJSON, _ := json.MarshalIndent(metadata, "", "  ")
+	if err := os.WriteFile(filepath.Join(dir, "metadata.json"), metaJSON, 0o644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "events-v1.jsonl"),
+		[]byte(`{"type":"tool_use"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write events: %v", err)
+	}
+
+	h := NewHandler(st)
+	h.SetSessionsDir(sessionsDir)
+	mux := http.NewServeMux()
+	h.RegisterDashboard(mux)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	resp, err := http.Get(server.URL + "/api/v1/sessions/" + sessionID)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d body=%s", resp.StatusCode, string(body))
+	}
+	var body sessionDetailResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Degraded {
+		t.Fatalf("degraded = true, want false (live session with streaming events)")
+	}
+	if body.DegradedReason != "" {
+		t.Fatalf("degraded_reason = %q, want empty", body.DegradedReason)
+	}
+	if body.Status != store.TaskStatusRunning {
+		t.Fatalf("status = %q, want %q", body.Status, store.TaskStatusRunning)
+	}
+	if body.ExitCode != 0 {
+		t.Fatalf("exit_code = %d, want 0", body.ExitCode)
+	}
+	if body.Repo != "owner/repo" || body.IssueNum != 281 {
+		t.Fatalf("repo/issue mismatch: %q/%d", body.Repo, body.IssueNum)
+	}
+}
+
+// Issue #282 (list-side AC-3): a live in-flight session enumerated from disk
+// must appear as a running, non-degraded row in /api/v1/sessions so it does
+// not get a wb-badge-degraded pill.
+func TestDashboardSessionsList_LiveDiskOnlyRowIsNotDegraded(t *testing.T) {
+	st := newTestStore(t)
+	sessionsDir := filepath.Join(t.TempDir(), "sessions")
+	sessionID := "session-disk-only-live"
+	dir := filepath.Join(sessionsDir, sessionID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	metadata := map[string]any{
+		"session_id": sessionID,
+		"repo":       "owner/repo",
+		"issue_num":  281,
+		"agent_name": "dev-agent",
+		"attempt":    1,
+		"status":     "running",
+		"created_at": "2026-04-30T09:00:00Z",
+	}
+	metaJSON, _ := json.MarshalIndent(metadata, "", "  ")
+	if err := os.WriteFile(filepath.Join(dir, "metadata.json"), metaJSON, 0o644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "events-v1.jsonl"),
+		[]byte(`{"type":"tool_use"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write events: %v", err)
+	}
+
+	h := NewHandler(st)
+	h.SetSessionsDir(sessionsDir)
+	mux := http.NewServeMux()
+	h.RegisterDashboard(mux)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	resp, err := http.Get(server.URL + "/api/v1/sessions?limit=10")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var rows []sessionListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rows); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	var row *sessionListResponse
+	for i := range rows {
+		if rows[i].SessionID == sessionID {
+			row = &rows[i]
+		}
+	}
+	if row == nil {
+		t.Fatalf("live disk-only session missing from listing: %+v", rows)
+	}
+	if row.Degraded {
+		t.Fatalf("degraded = true, want false")
+	}
+	if row.DegradedReason != "" {
+		t.Fatalf("degraded_reason = %q, want empty", row.DegradedReason)
+	}
+	if row.Status != store.TaskStatusRunning {
+		t.Fatalf("status = %q, want %q", row.Status, store.TaskStatusRunning)
+	}
+	if row.TaskStatus != store.TaskStatusRunning {
+		t.Fatalf("task_status = %q, want %q", row.TaskStatus, store.TaskStatusRunning)
+	}
+	if row.ExitCode != 0 {
+		t.Fatalf("exit_code = %d, want 0", row.ExitCode)
+	}
+}

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -3886,3 +3886,35 @@ requirements:
       - web/src/components/DegradedSessionCard.test.tsx
     deps:
       - REQ-105
+
+  - id: REQ-111
+    title: "Live no-DB-row sessions are not flagged degraded (#282)"
+    description: >
+      The auditapi /api/v1/sessions/:id and /api/v1/sessions endpoints
+      distinguish a still-running session whose agent_sessions DB row has
+      not been inserted yet from a real aborted-before-start session by
+      checking metadata.json.Status together with events-v1.jsonl content.
+      When meta.Status == "running" AND events-v1.jsonl is non-empty, the
+      synthesized response carries status="running", degraded=false,
+      exit_code=0. The empty-events / terminal-status cases keep the
+      degraded behavior introduced for REQ-110.
+    rationale: >
+      Issue #282: REQ-110's buildDegradedFromDisk() unconditionally flagged
+      every disk-only session as degraded with status=aborted_before_start,
+      so operators viewing a healthy in-flight session detail page saw a
+      red warning card despite events streaming live to disk. The fix is a
+      pure file-system heuristic so the endpoint stays cheap and testable.
+    priority: P2
+    version: v0.5.0
+    status: tested
+    acceptance_criteria:
+      - "AC-111-1: GET /api/v1/sessions/:id returns status=running + degraded=false when metadata.json.Status==\"running\" AND events-v1.jsonl is non-empty."
+      - "AC-111-2: GET /api/v1/sessions/:id keeps degraded=true + degraded_reason=no_db_row + status=aborted_before_start when metadata.json.Status==\"running\" AND events-v1.jsonl is empty/missing (the original REQ-110 case)."
+      - "AC-111-3: GET /api/v1/sessions/:id keeps the REQ-110 degraded behavior when metadata.json.Status is terminal (completed/failed/timeout/aborted_before_start)."
+      - "AC-111-4: GET /api/v1/sessions applies the same heuristic when enumerating disk-only sessions — a live in-flight row carries status=running + degraded=false."
+    code:
+      - internal/auditapi/handler.go
+    tests:
+      - internal/auditapi/handler_test.go
+    deps:
+      - REQ-110


### PR DESCRIPTION
Fixes #282

## Summary
- `buildDegradedFromDisk` and `listDiskOnlySessions` no longer unconditionally tag every disk-only session as `aborted_before_start` + `degraded=no_db_row`. A live session has no DB row yet (the row is only written at finish), so the previous behavior painted the red "this session never produced any events" warning on healthy in-flight detail pages.
- New rule: `metadata.json.status == "running"` AND `events-v1.jsonl` non-empty → return `status=running`, `degraded=false`, `exit_code=0`. Empty events / terminal status keep the original REQ-110 degraded behavior.
- Adds `REQ-111` (v0.5.0, `tested`) referencing REQ-110.

## Test plan
- [x] `go test ./internal/auditapi/... -count=1`
- [x] `pnpm -C web test`
- [x] `python3 ~/.autoharness/scripts/validate_index.py project-index.yaml`
- [x] Existing `TestDashboardSessionDetail_DegradedFromDiskMetadata` (no events file, status=running) still flags degraded.
- [x] New `TestSessionDetailNoDBRowRunningWithEventsIsNotDegraded` covers AC-1 / AC-2.
- [x] New `TestDashboardSessionsList_LiveDiskOnlyRowIsNotDegraded` covers AC-3.