### PR TITLE
deploy: make supervisor+coordinator+worker bundle the install default (#281)

### DIFF
--- a/.claude/plugins/workbuddy/skills/deploy/SKILL.md
+++ b/.claude/plugins/workbuddy/skills/deploy/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: deploy
+description: "Workbuddy deployment topology guide — explains the 3-unit bundle (supervisor + coordinator + worker), the rolling-restart property, and the cutover from the legacy single-process `serve` install. Use when the user says 'how should I deploy workbuddy', 'install workbuddy as a service', 'switch to bundle', 'rolling restart', '部署 workbuddy', '升级到 bundle'."
+user_invocable: true
+---
+
+# Deploy
+
+See `docs/upgrade-v0.4-to-v0.5.md` and `workbuddy deploy install --help`.
+
+## Topology
+
+Workbuddy supports two systemd layouts:
+
+- **Bundle (default since v0.5)** — three user units. The supervisor
+  (`Type=notify`, `KillMode=process`, `Restart=always`) owns the agent
+  subprocesses behind a unix-socket IPC, so the worker can be SIGKILL'd /
+  restarted without killing in-flight Claude or Codex runs. The worker
+  re-attaches over the socket and continues `events-v1.jsonl` from the
+  right offset.
+  - `workbuddy-supervisor.service`
+  - `workbuddy-coordinator.service` (`After=workbuddy-supervisor.service`)
+  - `workbuddy-worker.service`     (`After=workbuddy-supervisor.service`)
+- **Legacy single-process `serve`** — one `workbuddy.service`. Preserved for
+  one migration window and for local-dev convenience only. Does **not**
+  preserve in-flight agent runs across restart.
+
+## Greenfield install (recommended)
+
+```bash
+workbuddy deploy install --scope user \
+  --working-directory "$PWD" \
+  --env-file /home/<you>/.config/workbuddy/worker.env \
+  --coordinator-args=--listen=127.0.0.1:8081 --coordinator-args=--auth \
+  --worker-args=--coordinator=http://127.0.0.1:8081 \
+  --worker-args=--token-file=/home/<you>/.config/workbuddy/auth-token \
+  --worker-args=--repos=OWNER/REPO=$PWD
+```
+
+The `--bundle` flag is no longer required — it is accepted as a no-op alias
+for backwards compatibility with existing scripts.
+
+## Cutover from `serve` to bundle
+
+```bash
+systemctl --user stop  workbuddy.service
+systemctl --user disable workbuddy.service
+workbuddy deploy delete --name workbuddy --scope user
+workbuddy deploy install --scope user --working-directory "$PWD" \
+  --env-file <env-file> --coordinator-args=... --worker-args=...
+```
+
+`workbuddy deploy upgrade` (no flags) refuses to silently upgrade a legacy
+`serve` install — it errors with a migration hint. Pass `--legacy-serve` if
+you genuinely want to upgrade the legacy unit in place.
+
+## Rolling-restart upgrade
+
+```bash
+workbuddy deploy upgrade --name workbuddy-worker --version vX.Y.Z
+```
+
+The supervisor stays up across the worker restart, agents keep running, and
+the new worker re-attaches via the supervisor socket. This is the
+operational property issue #281 standardized as the default.
+
+## Flag detail
+
+This skill is a signpost. For full flag detail use the CLI:
+
+```bash
+workbuddy deploy install --help
+workbuddy deploy upgrade --help
+workbuddy deploy uninstall --help
+```

--- a/README.md
+++ b/README.md
@@ -4,8 +4,12 @@ GitHub Issue-driven agent orchestration platform. Workbuddy watches GitHub Issue
 
 Today the repository implements two runtime shapes over one shared core:
 
-- `workbuddy serve` for single-process deployment
-- `workbuddy coordinator` + `workbuddy worker` for distributed deployment
+- `workbuddy coordinator` + `workbuddy worker` (+ `workbuddy supervisor`) for the
+  recommended distributed deployment, installed via `workbuddy deploy install`
+  as the supervisor + coordinator + worker bundle.
+- `workbuddy serve` for legacy single-process / local-dev convenience only —
+  it does **not** preserve in-flight agent runs across restart and is kept
+  for one migration window. New deployments should use the bundle layout.
 
 ## Architecture
 
@@ -117,77 +121,73 @@ Or build from source:
 go build -o workbuddy .
 ```
 
-### Deploy as a service
+### Deploy as a service (recommended: bundle layout)
 
-Install the current `workbuddy` binary into a managed location and optionally
-write a systemd unit in one step:
+`workbuddy deploy install` installs three systemd user units in one step:
 
-```bash
-workbuddy deploy install \
-  --name workbuddy \
-  --scope user \
-  --systemd \
-  --working-directory "$PWD"
-```
+- `workbuddy-supervisor.service` (`Type=notify`, `KillMode=process`, `Restart=always`)
+- `workbuddy-coordinator.service` (`Type=simple`, `After=workbuddy-supervisor.service`)
+- `workbuddy-worker.service` (`Type=simple`, `After=workbuddy-supervisor.service`)
 
-That writes a deployment manifest under the selected scope, so you can later
-redeploy the current binary or upgrade to the latest GitHub release without
-retyping the service definition:
+The supervisor owns the agent subprocesses behind a unix-socket IPC, so
+restarting the worker (e.g. for a binary upgrade) does **not** kill in-flight
+agent runs — the worker re-attaches over the supervisor socket and continues
+the events log from the right offset. This is the rolling-restart property
+you actually want in production.
 
 ```bash
-workbuddy deploy redeploy --name workbuddy --scope user
-workbuddy deploy upgrade --name workbuddy --scope user --version latest
+workbuddy deploy install --scope user \
+  --working-directory "$PWD" \
+  --env-file /home/<you>/.config/workbuddy/worker.env \
+  --coordinator-args=--listen=127.0.0.1:8081 --coordinator-args=--auth \
+  --worker-args=--coordinator=http://127.0.0.1:8081 \
+  --worker-args=--token-file=/home/<you>/.config/workbuddy/auth-token \
+  --worker-args=--repos=owner/repo=$PWD
 ```
 
-Managed deployments can also be paused, resumed, or removed in place:
+The `--bundle` flag is no longer required (the bundle layout became the
+default). It is accepted as a no-op alias so existing automation keeps
+working. Trailing `-- args` are not allowed in bundle mode — use the
+per-unit `--supervisor-args` / `--coordinator-args` / `--worker-args`
+flags (each repeatable).
+
+Upgrade and lifecycle commands operate on the recorded manifests:
 
 ```bash
-workbuddy deploy stop --name workbuddy --scope user
-workbuddy deploy start --name workbuddy --scope user
-workbuddy deploy delete --name workbuddy --scope user
+workbuddy deploy upgrade                                # upgrades binaries; backfills supervisor unit if missing
+workbuddy deploy upgrade --name workbuddy-worker        # rolling upgrade of just the worker
+workbuddy deploy uninstall --scope user --force         # remove the bundle (keeps the binary on disk)
 ```
 
-`deploy delete` removes the recorded manifest and systemd unit, but leaves the
-installed binary in place.
-
-`deploy install` defaults to `workbuddy serve`, but you can record dedicated
-distributed roles by passing the runtime command after `--`.
-
-Coordinator service example:
-
-```bash
-sudo workbuddy deploy install \
-  --name workbuddy-coordinator \
-  --scope system \
-  --systemd \
-  --working-directory /srv/workbuddy \
-  -- coordinator --listen 0.0.0.0:8081 --db /srv/workbuddy/.workbuddy/workbuddy.db
-```
-
-Worker service example:
-
-```bash
-sudo workbuddy deploy install \
-  --name workbuddy-worker-dev \
-  --scope system \
-  --systemd \
-  --working-directory /srv/workbuddy-worker \
-  -- worker \
-     --coordinator http://127.0.0.1:8081 \
-     --token-file /etc/workbuddy/auth-token \
-     --role dev \
-     --repos owner/repo=/srv/workbuddy-worker
-```
+`workbuddy deploy upgrade` (with no flags) refuses to silently upgrade a
+legacy single-process `serve` install — it errors with a migration hint.
+Pass `--legacy-serve` if you genuinely want to keep the legacy layout
+during the migration window.
 
 Prefer `--token-file` (or `WORKBUDDY_AUTH_TOKEN` in the service env) over the
 plain `--token` flag — the plain form leaks into `ps` and shell history and
 now prints a deprecation warning.
 
-This makes the split explicit:
+#### Legacy single-process `serve` install (deprecated)
 
-- `workbuddy deploy install ...` with no trailing command => installs `serve`
-- `workbuddy deploy install ... -- coordinator ...` => installs a coordinator
-- `workbuddy deploy install ... -- worker ...` => installs a worker
+The single-process layout is preserved for one migration window only and
+**does not preserve in-flight agent runs across restart**. Prefer the bundle
+layout for any new deployment.
+
+```bash
+# Single-process serve unit (legacy):
+workbuddy deploy install --legacy-serve \
+  --name workbuddy --scope user --systemd --working-directory "$PWD"
+
+# Dedicated coordinator / worker units (legacy):
+sudo workbuddy deploy install --legacy-serve \
+  --name workbuddy-coordinator --scope system --systemd \
+  --working-directory /srv/workbuddy \
+  -- coordinator --listen 0.0.0.0:8081 --db /srv/workbuddy/.workbuddy/workbuddy.db
+```
+
+See `docs/upgrade-v0.4-to-v0.5.md` for the migration walkthrough and the
+`deploy` skill (Claude Code plugin) for a concise topology briefing.
 
 ### Claude Code Plugin
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -156,28 +156,46 @@ var deployCmd = &cobra.Command{
 
 var deployInstallCmd = &cobra.Command{
 	Use:   "install [-- workbuddy args...]",
-	Short: "Install the current binary and optionally create a systemd unit",
+	Short: "Install the supervisor + coordinator + worker bundle (default) or, with --legacy-serve, a single-process serve unit",
+	Long: strings.TrimSpace(`
+Install the v0.5 supervisor + coordinator + worker user units. This is the
+default and recommended layout: the supervisor owns the agent subprocesses
+(Type=notify, KillMode=process, Restart=always), so restarting the worker —
+e.g. for a binary upgrade — does not kill in-flight agent runs.
+
+Pass --legacy-serve to install the older single-process ` + "`workbuddy serve`" + `
+unit instead. That layout is preserved for one migration window only and
+does not preserve in-flight agent runs across restart; new deployments
+should not use it.
+`),
 	Example: strings.TrimSpace(`
-  # v0.5 bundled install: supervisor + coordinator + worker user units
-  workbuddy deploy install --bundle --scope user \
+  # Default: v0.5 bundled install (supervisor + coordinator + worker user units).
+  # The --bundle flag is no longer required; it is accepted as a no-op alias
+  # for backwards compatibility with existing automation.
+  workbuddy deploy install --scope user \
     --env-file /home/ddq/.config/workbuddy/worker.env \
     --coordinator-args=--listen=127.0.0.1:8081 --coordinator-args=--auth \
     --worker-args=--coordinator=http://127.0.0.1:8081 --worker-args=--token=$WORKBUDDY_TOKEN
 
-  # Single-process deploy (default command is "serve")
-  workbuddy deploy install --name workbuddy --scope user --systemd
+  # Same install, with the explicit --bundle alias (kept for compatibility):
+  workbuddy deploy install --bundle --scope user --env-file /etc/workbuddy/bundle.env
 
-  # Dedicated coordinator service (non-loopback bind requires --report-base-url)
-  # Pair with --env-file pointing at a file that defines WORKBUDDY_REPORT_BASE_URL
-  # so session links posted to GitHub comments are clickable in a browser.
-  workbuddy deploy install --name workbuddy-coordinator --scope system --systemd \
+  # Legacy single-process install (default command is "serve").
+  # Does NOT preserve in-flight agent runs across restart — prefer the bundle layout.
+  workbuddy deploy install --legacy-serve --name workbuddy --scope user --systemd
+
+  # Dedicated coordinator service (legacy layout). Non-loopback bind requires
+  # --report-base-url. Pair with --env-file pointing at a file that defines
+  # WORKBUDDY_REPORT_BASE_URL so session links posted to GitHub comments are
+  # clickable in a browser.
+  workbuddy deploy install --legacy-serve --name workbuddy-coordinator --scope system --systemd \
     --env-file /etc/workbuddy/coordinator.env -- \
     coordinator --listen 0.0.0.0:8081 \
       --report-base-url=https://workbuddy.example.com:8081 \
       --auth --db /srv/workbuddy/.workbuddy/workbuddy.db
 
-  # Dedicated worker service bound to a coordinator
-  workbuddy deploy install --name workbuddy-worker-dev --scope system --systemd -- \
+  # Dedicated worker service bound to a coordinator (legacy layout).
+  workbuddy deploy install --legacy-serve --name workbuddy-worker-dev --scope system --systemd -- \
     worker --coordinator http://127.0.0.1:8081 --token <token> --role dev --repos owner/repo=/srv/workbuddy-worker
 `),
 	Args: cobra.ArbitraryArgs,
@@ -236,6 +254,7 @@ func init() {
 	deployInstallCmd.Flags().String("updater-interval", "5m", "Poll interval used by the updater unit (only consulted with --enable-updater)")
 	deployInstallCmd.Flags().StringSlice("updater-restart-units", []string{"workbuddy-coordinator.service", "workbuddy-worker.service"}, "systemd unit name(s) the updater should restart after a successful upgrade (only consulted with --enable-updater)")
 	deployInstallCmd.Flags().String("updater-name", "workbuddy-updater", "Service name used for the updater unit (only consulted with --enable-updater)")
+	deployInstallCmd.Flags().Bool("legacy-serve", false, "Install the legacy single-process `workbuddy serve` unit instead of the default supervisor+coordinator+worker bundle. Provided for one-version migration; does not preserve in-flight agent runs across restart.")
 
 	deployListCmd.Flags().String("scope", defaultDeployListScope, "Deployment scope: all, user, or system")
 	addOutputFormatFlag(deployListCmd)
@@ -268,7 +287,8 @@ func init() {
 	deployUpgradeCmd.Flags().Bool("all", false, "Operate on every deployment in the requested scope")
 	deployUpgradeCmd.Flags().Bool("force", false, "Skip confirmation prompts for destructive actions")
 	deployUpgradeCmd.Flags().Bool("dry-run", false, "Print the actions that would be taken without executing them")
-	deployUpgradeCmd.Flags().Bool("bundle", false, "After upgrading, ensure the v0.5 supervisor unit is installed (used to migrate a v0.4 install that only has coordinator+worker)")
+	deployUpgradeCmd.Flags().Bool("bundle", false, "Ensure the v0.5 supervisor unit is installed after upgrading. Default behavior since the bundle layout became the default; accepted as a no-op alias for compatibility with existing automation.")
+	deployUpgradeCmd.Flags().Bool("legacy-serve", false, "Treat the deployment as a legacy single-process `workbuddy serve` install. Skips the supervisor backfill and bypasses the default safety check that refuses to silently upgrade a legacy install.")
 
 	deployCmd.AddCommand(deployInstallCmd, deployListCmd, deployRedeployCmd, deployStopCmd, deployStartCmd, deployDeleteCmd, deployUpgradeCmd)
 	rootCmd.AddCommand(deployCmd)
@@ -278,24 +298,33 @@ func runDeployInstallCmd(cmd *cobra.Command, args []string) error {
 	if err := requireWritable(cmd, "deploy install"); err != nil {
 		return err
 	}
-	if bundleEnabled(cmd) {
-		bundleOpts, err := parseBundleInstallFlags(cmd)
+	legacy, _ := cmd.Flags().GetBool("legacy-serve")
+	if legacy {
+		if cmd.Flags().Changed("bundle") {
+			return fmt.Errorf("deploy install: --legacy-serve and --bundle are mutually exclusive")
+		}
+		for _, name := range []string{"supervisor-args", "coordinator-args", "worker-args", "bundle-skip-coordinator", "bundle-skip-worker"} {
+			if cmd.Flags().Changed(name) {
+				return fmt.Errorf("deploy install: --legacy-serve cannot be combined with --%s (that flag belongs to the bundle layout)", name)
+			}
+		}
+		opts, err := parseDeployInstallFlags(cmd, args)
 		if err != nil {
 			return err
 		}
-		if len(args) > 0 {
-			return fmt.Errorf("deploy install: --bundle does not accept trailing -- args (use --supervisor-args/--coordinator-args/--worker-args)")
-		}
-		if cmd.Flags().Changed("name") {
-			return fmt.Errorf("deploy install: --bundle ignores --name; remove the flag")
-		}
-		return runDeployBundleInstallWithOpts(cmd.Context(), bundleOpts, cmdStdout(cmd))
+		return runDeployInstallWithOpts(cmd.Context(), opts, cmdStdout(cmd))
 	}
-	opts, err := parseDeployInstallFlags(cmd, args)
+	bundleOpts, err := parseBundleInstallFlags(cmd)
 	if err != nil {
 		return err
 	}
-	return runDeployInstallWithOpts(cmd.Context(), opts, cmdStdout(cmd))
+	if len(args) > 0 {
+		return fmt.Errorf("deploy install: trailing -- args are not supported with the bundle layout (the default). Use --supervisor-args/--coordinator-args/--worker-args, or pass --legacy-serve to install a single-process serve unit")
+	}
+	if cmd.Flags().Changed("name") {
+		return fmt.Errorf("deploy install: the bundle layout (default) ignores --name (units are workbuddy-supervisor / -coordinator / -worker). Remove --name, or pass --legacy-serve to install a single named unit")
+	}
+	return runDeployBundleInstallWithOpts(cmd.Context(), bundleOpts, cmdStdout(cmd))
 }
 
 func runDeployListCmd(cmd *cobra.Command, _ []string) error {
@@ -360,6 +389,18 @@ func runDeployUpgradeCmd(cmd *cobra.Command, _ []string) error {
 	}
 	version, _ := cmd.Flags().GetString("version")
 	repository, _ := cmd.Flags().GetString("repository")
+	legacy, _ := cmd.Flags().GetBool("legacy-serve")
+
+	// Default behavior: refuse to silently upgrade a legacy single-process
+	// `serve` install. The bundle layout is the supported default; users on
+	// the legacy layout must opt in via --legacy-serve so layout drift is
+	// always explicit.
+	if !legacy && !lookup.all {
+		if record, lookupErr := loadDeploymentRecordForScope(lookup.name, lookup.scope); lookupErr == nil && record != nil && isLegacyServeManifest(record.manifest) {
+			return fmt.Errorf("deploy upgrade: %q is a legacy single-process `serve` install. Pass --legacy-serve to upgrade it as-is, or migrate to the bundle layout via `workbuddy deploy uninstall` + `workbuddy deploy install`", lookup.name)
+		}
+	}
+
 	if err := runDeployUpgradeWithOpts(cmd.Context(), &deployUpgradeOpts{
 		deployLookupOpts: *lookup,
 		version:          strings.TrimSpace(version),
@@ -367,10 +408,27 @@ func runDeployUpgradeCmd(cmd *cobra.Command, _ []string) error {
 	}, cmdStdout(cmd)); err != nil {
 		return err
 	}
-	if bundle, _ := cmd.Flags().GetBool("bundle"); bundle {
-		return ensureSupervisorUnitForUpgrade(cmd.Context(), lookup.scope, cmdStdout(cmd))
+	if legacy {
+		return nil
 	}
-	return nil
+	// --bundle is no longer required: ensuring the supervisor unit is the
+	// default since the bundle layout became the default. The flag is
+	// accepted as a no-op alias for backwards compatibility.
+	return ensureSupervisorUnitForUpgrade(cmd.Context(), lookup.scope, cmdStdout(cmd))
+}
+
+// isLegacyServeManifest reports whether a deployment manifest looks like a
+// legacy single-process `workbuddy serve` install (Command starts with
+// "serve" or is empty, in which case `deploy install` defaulted to "serve").
+func isLegacyServeManifest(m *deploymentManifest) bool {
+	if m == nil {
+		return false
+	}
+	if len(m.Command) == 0 {
+		return true
+	}
+	first := strings.ToLower(strings.TrimSpace(m.Command[0]))
+	return first == "serve"
 }
 
 func parseDeployListFlags(cmd *cobra.Command) (*deployListOpts, error) {

--- a/cmd/deploy_bundle.go
+++ b/cmd/deploy_bundle.go
@@ -82,11 +82,6 @@ func init() {
 	deployCmd.AddCommand(deployUninstallCmd)
 }
 
-func bundleEnabled(cmd *cobra.Command) bool {
-	v, _ := cmd.Flags().GetBool("bundle")
-	return v
-}
-
 func parseBundleInstallFlags(cmd *cobra.Command) (*bundleInstallOpts, error) {
 	scope, _ := cmd.Flags().GetString("scope")
 	binaryPath, _ := cmd.Flags().GetString("binary")

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func TestRunDeployInstallWithSystemdWritesManifestAndUnit(t *testing.T) {
@@ -1722,6 +1723,242 @@ func TestParseDeployInstallFlagsEnableUpdaterDefaults(t *testing.T) {
 	}
 	if got, want := opts.updaterName, "workbuddy-updater"; got != want {
 		t.Fatalf("updaterName = %q, want %q", got, want)
+	}
+}
+
+// newDeployInstallTestCmd builds a fresh cobra.Command with an independent
+// flag set that mirrors the production `deploy install` flag schema, so tests
+// can drive runDeployInstallCmd without mutating the global deployInstallCmd
+// flag state across cases. (pflag's AddFlagSet shares Flag pointers, which
+// causes value bleed between tests.)
+func newDeployInstallTestCmd() *cobra.Command {
+	c := &cobra.Command{Use: "install", RunE: runDeployInstallCmd}
+	deployInstallCmd.Flags().VisitAll(func(f *pflag.Flag) {
+		switch f.Value.Type() {
+		case "bool":
+			c.Flags().Bool(f.Name, f.DefValue == "true", f.Usage)
+		case "string":
+			c.Flags().String(f.Name, f.DefValue, f.Usage)
+		case "stringArray":
+			c.Flags().StringArray(f.Name, nil, f.Usage)
+		case "stringSlice":
+			c.Flags().StringSlice(f.Name, nil, f.Usage)
+		default:
+			c.Flags().String(f.Name, f.DefValue, f.Usage)
+		}
+	})
+	return c
+}
+
+func newDeployUpgradeTestCmd() *cobra.Command {
+	c := &cobra.Command{Use: "upgrade", RunE: runDeployUpgradeCmd}
+	deployUpgradeCmd.Flags().VisitAll(func(f *pflag.Flag) {
+		switch f.Value.Type() {
+		case "bool":
+			c.Flags().Bool(f.Name, f.DefValue == "true", f.Usage)
+		case "string":
+			c.Flags().String(f.Name, f.DefValue, f.Usage)
+		case "stringArray":
+			c.Flags().StringArray(f.Name, nil, f.Usage)
+		case "stringSlice":
+			c.Flags().StringSlice(f.Name, nil, f.Usage)
+		default:
+			c.Flags().String(f.Name, f.DefValue, f.Usage)
+		}
+	})
+	return c
+}
+
+// TestRunDeployInstallCmdDefaultsToBundle verifies that `workbuddy deploy
+// install` with no flags installs the supervisor + coordinator + worker
+// bundle layout, satisfying issue #281's AC-1 (bundle is the default and
+// the headline path).
+func TestRunDeployInstallCmdDefaultsToBundle(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("systemd deployment is only supported on Linux")
+	}
+
+	tempDir := t.TempDir()
+	homeDir := filepath.Join(tempDir, "home")
+	configDir := filepath.Join(tempDir, "xdg")
+	repoDir := filepath.Join(tempDir, "repo")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	t.Setenv("HOME", homeDir)
+	t.Setenv("XDG_CONFIG_HOME", configDir)
+	t.Chdir(repoDir)
+
+	sourceBinary := filepath.Join(tempDir, "current-workbuddy")
+	if err := os.WriteFile(sourceBinary, []byte("binary-default"), 0o755); err != nil {
+		t.Fatalf("write source binary: %v", err)
+	}
+	restore := overrideDeployGlobals(t, sourceBinary)
+	defer restore()
+	deployRunSystemctl = func(_ context.Context, _ string, _ ...string) error { return nil }
+
+	c := newDeployInstallTestCmd()
+	if err := c.ParseFlags([]string{"--scope=user"}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	var stdout bytes.Buffer
+	c.SetOut(&stdout)
+	if err := runDeployInstallCmd(c, c.Flags().Args()); err != nil {
+		t.Fatalf("runDeployInstallCmd: %v", err)
+	}
+
+	for _, name := range []string{bundleSupervisorName, bundleCoordinatorName, bundleWorkerName} {
+		manifestPath := filepath.Join(configDir, "workbuddy", "deployments", name+".json")
+		if _, err := os.Stat(manifestPath); err != nil {
+			t.Errorf("expected bundle manifest %s, got: %v", manifestPath, err)
+		}
+		unitPath := filepath.Join(configDir, "systemd", "user", name+".service")
+		if _, err := os.Stat(unitPath); err != nil {
+			t.Errorf("expected bundle unit %s, got: %v", unitPath, err)
+		}
+	}
+	if !strings.Contains(stdout.String(), "bundle install complete") {
+		t.Errorf("stdout missing bundle summary: %q", stdout.String())
+	}
+	// And the legacy single-process unit must NOT have been written.
+	if _, err := os.Stat(filepath.Join(configDir, "workbuddy", "deployments", "workbuddy.json")); !os.IsNotExist(err) {
+		t.Errorf("legacy serve manifest should not exist by default: err=%v", err)
+	}
+}
+
+// TestRunDeployInstallCmdLegacyServeOptOut covers AC-1's opt-out path:
+// `--legacy-serve` keeps the old single-process install reachable and emits a
+// `serve` ExecStart, while honoring the explicit `--name`.
+func TestRunDeployInstallCmdLegacyServeOptOut(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("systemd deployment is only supported on Linux")
+	}
+
+	tempDir := t.TempDir()
+	homeDir := filepath.Join(tempDir, "home")
+	configDir := filepath.Join(tempDir, "xdg")
+	repoDir := filepath.Join(tempDir, "repo")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	t.Setenv("HOME", homeDir)
+	t.Setenv("XDG_CONFIG_HOME", configDir)
+	t.Chdir(repoDir)
+
+	sourceBinary := filepath.Join(tempDir, "current-workbuddy")
+	if err := os.WriteFile(sourceBinary, []byte("binary-legacy"), 0o755); err != nil {
+		t.Fatalf("write source binary: %v", err)
+	}
+	restore := overrideDeployGlobals(t, sourceBinary)
+	defer restore()
+	deployRunSystemctl = func(_ context.Context, _ string, _ ...string) error { return nil }
+
+	c := newDeployInstallTestCmd()
+	if err := c.ParseFlags([]string{"--legacy-serve", "--scope=user", "--systemd", "--name=workbuddy"}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	var stdout bytes.Buffer
+	c.SetOut(&stdout)
+	if err := runDeployInstallCmd(c, c.Flags().Args()); err != nil {
+		t.Fatalf("runDeployInstallCmd: %v", err)
+	}
+
+	manifestPath := filepath.Join(configDir, "workbuddy", "deployments", "workbuddy.json")
+	if _, err := os.Stat(manifestPath); err != nil {
+		t.Fatalf("expected legacy manifest %s, err=%v", manifestPath, err)
+	}
+	unitPath := filepath.Join(configDir, "systemd", "user", "workbuddy.service")
+	unitBytes, err := os.ReadFile(unitPath)
+	if err != nil {
+		t.Fatalf("read legacy unit: %v", err)
+	}
+	if !strings.Contains(string(unitBytes), `"serve"`) {
+		t.Errorf("legacy unit missing serve ExecStart fragment:\n%s", string(unitBytes))
+	}
+	// And the bundle units must NOT exist.
+	for _, name := range []string{bundleSupervisorName, bundleCoordinatorName, bundleWorkerName} {
+		manifestPath := filepath.Join(configDir, "workbuddy", "deployments", name+".json")
+		if _, err := os.Stat(manifestPath); !os.IsNotExist(err) {
+			t.Errorf("bundle manifest %s should not exist with --legacy-serve: err=%v", manifestPath, err)
+		}
+	}
+}
+
+// TestRunDeployInstallCmdRejectsTrailingArgsByDefault makes sure that the new
+// default install path refuses trailing -- args (which only made sense for
+// the legacy single-process install) instead of silently ignoring them.
+func TestRunDeployInstallCmdRejectsTrailingArgsByDefault(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("systemd deployment is only supported on Linux")
+	}
+	tempDir := t.TempDir()
+	t.Setenv("HOME", filepath.Join(tempDir, "home"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tempDir, "xdg"))
+	t.Chdir(tempDir)
+
+	sourceBinary := filepath.Join(tempDir, "current-workbuddy")
+	if err := os.WriteFile(sourceBinary, []byte("x"), 0o755); err != nil {
+		t.Fatalf("write source binary: %v", err)
+	}
+	restore := overrideDeployGlobals(t, sourceBinary)
+	defer restore()
+	deployRunSystemctl = func(_ context.Context, _ string, _ ...string) error { return nil }
+
+	c := newDeployInstallTestCmd()
+	if err := c.ParseFlags([]string{"--scope=user"}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	// runDeployInstallCmd takes trailing -- args as the second argument
+	// directly (cobra normally extracts them via Args). Pass them in
+	// explicitly to exercise the trailing-args guard.
+	err := runDeployInstallCmd(c, []string{"coordinator", "--listen", "127.0.0.1:8081"})
+	if err == nil || !strings.Contains(err.Error(), "trailing -- args are not supported") {
+		t.Fatalf("expected trailing-args error, got %v", err)
+	}
+}
+
+// TestRunDeployUpgradeCmdRefusesLegacyServeWithoutOptIn covers AC-4: deploy
+// upgrade against a legacy single-process serve install must error out unless
+// the caller passes --legacy-serve, so layout drift is always explicit.
+func TestRunDeployUpgradeCmdRefusesLegacyServeWithoutOptIn(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("systemd deployment is only supported on Linux")
+	}
+	tempDir := t.TempDir()
+	homeDir := filepath.Join(tempDir, "home")
+	configDir := filepath.Join(tempDir, "xdg")
+	repoDir := filepath.Join(tempDir, "repo")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	t.Setenv("HOME", homeDir)
+	t.Setenv("XDG_CONFIG_HOME", configDir)
+	t.Chdir(repoDir)
+
+	deployedBinary := filepath.Join(homeDir, ".local", "bin", "workbuddy")
+	if err := os.MkdirAll(filepath.Dir(deployedBinary), 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	if err := os.WriteFile(deployedBinary, []byte("legacy"), 0o755); err != nil {
+		t.Fatalf("write deployed binary: %v", err)
+	}
+	writeScopedManifest(t, "user", "workbuddy", &deploymentManifest{
+		BinaryPath:       deployedBinary,
+		WorkingDirectory: repoDir,
+		Command:          []string{"serve"},
+		Systemd: &deploymentSystemd{
+			ServiceName: "workbuddy",
+			Description: "legacy serve",
+		},
+	})
+
+	c := newDeployUpgradeTestCmd()
+	if err := c.ParseFlags([]string{"--name=workbuddy", "--scope=user", "--version=v0.5.0"}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	err := runDeployUpgradeCmd(c, nil)
+	if err == nil || !strings.Contains(err.Error(), "legacy single-process") {
+		t.Fatalf("expected legacy-serve refusal, got %v", err)
 	}
 }
 

--- a/docs/upgrade-v0.4-to-v0.5.md
+++ b/docs/upgrade-v0.4-to-v0.5.md
@@ -25,9 +25,11 @@ workbuddy deploy upgrade --name workbuddy-coordinator --version v0.5.0
 
 # 2) add the supervisor unit (idempotent — picks up the env-file from the
 #    coordinator/worker manifests, writes Type=notify, KillMode=process,
-#    Restart=always, ExecStart=workbuddy supervisor)
-workbuddy deploy upgrade --name workbuddy-worker --version v0.5.0 --bundle
-# (or, equivalently, run `deploy install --bundle` with --bundle-skip-coordinator
+#    Restart=always, ExecStart=workbuddy supervisor). Since v0.5.x this
+#    happens by default for any `deploy upgrade`; the --bundle alias is
+#    accepted for compatibility with existing automation.
+workbuddy deploy upgrade --name workbuddy-worker --version v0.5.0
+# (or, equivalently, run `deploy install` with --bundle-skip-coordinator
 #  and --bundle-skip-worker; both paths converge on the same supervisor unit.)
 
 # 3) start the supervisor first, then the worker
@@ -46,14 +48,28 @@ The coordinator can be left running through the upgrade — it has no stateful l
 ## Greenfield install (v0.5)
 
 ```bash
-workbuddy deploy install --bundle --scope user \
+workbuddy deploy install --scope user \
   --env-file /etc/workbuddy/bundle.env \
   --coordinator-args=--listen=127.0.0.1:8081 --coordinator-args=--auth \
   --worker-args=--coordinator=http://127.0.0.1:8081 --worker-args=--token=$WORKBUDDY_TOKEN \
   --worker-args=--repos=owner/repo=/srv/workbuddy
 ```
 
-The `--bundle` flag installs `workbuddy-supervisor.service` (`Type=notify`, `KillMode=process`, `Restart=always`), then `workbuddy-coordinator.service` and `workbuddy-worker.service` with `After=workbuddy-supervisor.service` ordering. Trailing `-- args` are not allowed with `--bundle`; use the per-unit `--{supervisor,coordinator,worker}-args` flags instead (each repeatable).
+`deploy install` defaults to the bundle layout: `workbuddy-supervisor.service`
+(`Type=notify`, `KillMode=process`, `Restart=always`), then
+`workbuddy-coordinator.service` and `workbuddy-worker.service` with
+`After=workbuddy-supervisor.service` ordering. Trailing `-- args` are not
+allowed in bundle mode; use the per-unit
+`--{supervisor,coordinator,worker}-args` flags instead (each repeatable).
+The `--bundle` flag is accepted as a no-op alias for backwards compatibility.
+
+To install the legacy single-process `serve` unit instead (preserved for one
+migration window only — does not preserve in-flight agent runs across
+restart), pass `--legacy-serve`:
+
+```bash
+workbuddy deploy install --legacy-serve --name workbuddy --scope user --systemd
+```
 
 To remove a bundled install:
 

--- a/plugins/workbuddy/skills/deploy/SKILL.md
+++ b/plugins/workbuddy/skills/deploy/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: deploy
+description: "Workbuddy deployment topology guide — explains the 3-unit bundle (supervisor + coordinator + worker), the rolling-restart property, and the cutover from the legacy single-process `serve` install. Use when the user says 'how should I deploy workbuddy', 'install workbuddy as a service', 'switch to bundle', 'rolling restart', '部署 workbuddy', '升级到 bundle'."
+---
+
+# Deploy
+
+See `docs/upgrade-v0.4-to-v0.5.md` and `workbuddy deploy install --help`.
+
+## Topology
+
+Workbuddy supports two systemd layouts:
+
+- **Bundle (default since v0.5)** — three user units. The supervisor
+  (`Type=notify`, `KillMode=process`, `Restart=always`) owns the agent
+  subprocesses behind a unix-socket IPC, so the worker can be SIGKILL'd /
+  restarted without killing in-flight Claude or Codex runs. The worker
+  re-attaches over the socket and continues `events-v1.jsonl` from the
+  right offset.
+  - `workbuddy-supervisor.service`
+  - `workbuddy-coordinator.service` (`After=workbuddy-supervisor.service`)
+  - `workbuddy-worker.service`     (`After=workbuddy-supervisor.service`)
+- **Legacy single-process `serve`** — one `workbuddy.service`. Preserved for
+  one migration window and for local-dev convenience only. Does **not**
+  preserve in-flight agent runs across restart.
+
+## Greenfield install (recommended)
+
+```bash
+workbuddy deploy install --scope user \
+  --working-directory "$PWD" \
+  --env-file /home/<you>/.config/workbuddy/worker.env \
+  --coordinator-args=--listen=127.0.0.1:8081 --coordinator-args=--auth \
+  --worker-args=--coordinator=http://127.0.0.1:8081 \
+  --worker-args=--token-file=/home/<you>/.config/workbuddy/auth-token \
+  --worker-args=--repos=OWNER/REPO=$PWD
+```
+
+The `--bundle` flag is no longer required — it is accepted as a no-op alias
+for backwards compatibility with existing scripts.
+
+## Cutover from `serve` to bundle
+
+```bash
+systemctl --user stop  workbuddy.service
+systemctl --user disable workbuddy.service
+workbuddy deploy delete --name workbuddy --scope user
+workbuddy deploy install --scope user --working-directory "$PWD" \
+  --env-file <env-file> --coordinator-args=... --worker-args=...
+```
+
+`workbuddy deploy upgrade` (no flags) refuses to silently upgrade a legacy
+`serve` install — it errors with a migration hint. Pass `--legacy-serve` if
+you genuinely want to upgrade the legacy unit in place.
+
+## Rolling-restart upgrade
+
+```bash
+workbuddy deploy upgrade --name workbuddy-worker --version vX.Y.Z
+```
+
+The supervisor stays up across the worker restart, agents keep running, and
+the new worker re-attaches via the supervisor socket. This is the
+operational property issue #281 standardized as the default.
+
+## Flag detail
+
+This skill is a signpost. For full flag detail use the CLI:
+
+```bash
+workbuddy deploy install --help
+workbuddy deploy upgrade --help
+workbuddy deploy uninstall --help
+```

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -3918,3 +3918,51 @@ requirements:
       - internal/auditapi/handler_test.go
     deps:
       - REQ-110
+
+  - id: REQ-112
+    title: "deploy install defaults to the supervisor+coordinator+worker bundle layout (#281)"
+    description: >
+      `workbuddy deploy install` (no flag) installs the v0.5 three-unit
+      bundle (workbuddy-supervisor + workbuddy-coordinator +
+      workbuddy-worker) by default. The legacy single-process `serve`
+      install path is reachable via an explicit `--legacy-serve` opt-out
+      flag, preserved for a one-version migration window. The `--bundle`
+      flag is kept as a no-op alias so existing automation continues to
+      work. `deploy upgrade` (no flag) runs the bundle upgrade path
+      (binary swap + supervisor backfill via
+      ensureSupervisorUnitForUpgrade) by default, and refuses to silently
+      upgrade a manifest whose Command is `serve` unless the caller passes
+      `--legacy-serve` — preventing silent layout drift between releases.
+      Documentation (`README.md`, `docs/upgrade-v0.4-to-v0.5.md`,
+      `deploy install --help`) leads with the bundle layout; single-process
+      `serve` is documented as legacy / for local-dev convenience only,
+      with a clear note that it does not preserve in-flight agent runs
+      across restart.
+    rationale: >
+      Issue #281: bundle was opt-in via `--bundle`, so operators following
+      the docs ended up with the worse single-process layout that loses
+      in-flight agent runs on every worker restart. The supervisor's
+      Type=notify + KillMode=process design (issue #245) is the
+      operational property we actually want as the headline path.
+    priority: P1
+    version: v0.5.0
+    status: tested
+    acceptance_criteria:
+      - "AC-281-1: `workbuddy deploy install` with no flags installs the bundle layout (supervisor + coordinator + worker user units). `--legacy-serve` opts back to the single-process serve install."
+      - "AC-281-2: `deploy install --help`, the example block, README and `docs/upgrade-v0.4-to-v0.5.md` lead with the bundle layout. Single-process `serve` is documented as legacy / for local-dev convenience only, with a note that it does not preserve in-flight agent runs across restart."
+      - "AC-281-3: A new Claude Code plugin skill (`deploy`) under `.claude/plugins/workbuddy/skills/deploy/` documents the recommended topology, the rolling-restart property, and the cutover from `serve` to bundle. The skill signposts to `workbuddy deploy install --help` for flag detail (per the skill-vs-CLI split rule)."
+      - "AC-281-4: `workbuddy deploy upgrade --bundle` continues to work; `workbuddy deploy upgrade` without `--bundle` runs the bundle upgrade path (ensureSupervisorUnitForUpgrade) against an existing bundle install, and emits an explicit error when the named manifest looks like a legacy single-process `serve` install."
+      - "AC-281-5: `go test ./cmd/...` covers the new default in `runDeployInstallCmd` (bundle path taken when `--bundle` is omitted) and the `--legacy-serve` opt-out renders a `serve` ExecStart. CI green."
+      - "AC-281-6: `serve` is not removed in this issue — it stays callable so the legacy install path keeps working through the migration window."
+      - "AC-281-7: project-index.yaml records this requirement with version v0.5.0 and status tested."
+    code:
+      - cmd/deploy.go
+      - cmd/deploy_bundle.go
+      - README.md
+      - docs/upgrade-v0.4-to-v0.5.md
+      - .claude/plugins/workbuddy/skills/deploy/SKILL.md
+    tests:
+      - cmd/deploy_test.go
+      - cmd/deploy_bundle_test.go
+    deps:
+      - REQ-105


### PR DESCRIPTION
Fixes #281.

## Summary
- `workbuddy deploy install` (no flag) now installs the v0.5 three-unit bundle (supervisor + coordinator + worker user units) by default. This is the layout that preserves in-flight agent runs across worker restart via the supervisor's `Type=notify` + `KillMode=process` design.
- New `--legacy-serve` opt-out flag keeps the single-process `serve` install reachable for one migration window. `--bundle` is preserved as a no-op alias so existing automation continues to work.
- `deploy upgrade` (no flag) runs the bundle upgrade path (`ensureSupervisorUnitForUpgrade`) by default, and refuses to silently upgrade a manifest whose Command is `serve` unless `--legacy-serve` is passed — no silent flips between layouts.
- Docs lead with the bundle layout: `README.md`, `docs/upgrade-v0.4-to-v0.5.md`, `deploy install --help` example block, and a new `deploy` skill under `.claude/plugins/workbuddy/skills/deploy/SKILL.md` that signposts to `workbuddy deploy install --help` for flag detail (per skill-vs-CLI split rule).
- `project-index.yaml`: adds REQ-111, version v0.5.0, status `tested`.

## AC traceability
- AC-1: `runDeployInstallCmd` takes the bundle path when `--bundle` is omitted; `--legacy-serve` opts back to single-process. Tests in `cmd/deploy_test.go` (`TestRunDeployInstallCmdDefaultsToBundle`, `TestRunDeployInstallCmdLegacyServeOptOut`, `TestRunDeployInstallCmdRejectsTrailingArgsByDefault`).
- AC-2: README, upgrade doc, and `deploy install --help` example all lead with the bundle layout; single-process `serve` clearly labelled legacy / non-rolling.
- AC-3: New `deploy` skill (`.claude/plugins/workbuddy/skills/deploy/SKILL.md`, mirrored to Codex copy under `plugins/workbuddy/skills/deploy/`).
- AC-4: `runDeployUpgradeCmd` always calls `ensureSupervisorUnitForUpgrade` unless `--legacy-serve` is set; refuses legacy `serve` install without explicit opt-in (`TestRunDeployUpgradeCmdRefusesLegacyServeWithoutOptIn`). `--bundle` alias still accepted.
- AC-5: New tests in `cmd/deploy_test.go` cover the bundle default and the `--legacy-serve` opt-out renders a `serve` ExecStart. `go test ./cmd/...` passes for the deploy suite (one pre-existing unrelated failure: `TestParseWorkerFlags_MgmtPublicURLRequiresSharedAuth` is failing on `main` too — not touched by this PR).
- AC-6: `serve` is not removed.
- AC-7: `project-index.yaml` REQ-111 added with `version: v0.5.0`, `status: tested`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./cmd/... -run Deploy -count=1`
- [x] `python3 ~/.autoharness/scripts/validate_index.py project-index.yaml`
- [x] `go run . validate-docs --strict` (regenerated `plugins/workbuddy/skills/deploy/`)