### PR TITLE
Fix runtime-aware worker routing

### DIFF
--- a/cmd/coordinator_infra_failure_test.go
+++ b/cmd/coordinator_infra_failure_test.go
@@ -52,7 +52,7 @@ func TestCoordinator_InfraFailureEmitsInfraEvent(t *testing.T) {
 		Pollers: &pollerManager{},
 	}
 
-	if err := reg.Register("worker-1", "owner/repo", []string{"dev"}, "host1"); err != nil {
+	if err := reg.Register("worker-1", "owner/repo", []string{"dev"}, "", "host1"); err != nil {
 		t.Fatalf("register worker: %v", err)
 	}
 
@@ -139,7 +139,7 @@ func TestCoordinator_GenuineFailureDoesNotEmitInfraEvent(t *testing.T) {
 		TaskHub:  tasknotify.NewHub(),
 		Pollers:  &pollerManager{},
 	}
-	if err := reg.Register("worker-1", "owner/repo", []string{"dev"}, "host1"); err != nil {
+	if err := reg.Register("worker-1", "owner/repo", []string{"dev"}, "", "host1"); err != nil {
 		t.Fatalf("register worker: %v", err)
 	}
 	if err := st.InsertTask(store.TaskRecord{

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 
+	"github.com/Lincyaw/workbuddy/internal/store"
 	intvalidate "github.com/Lincyaw/workbuddy/internal/validate"
 	"github.com/spf13/cobra"
 )
@@ -92,9 +96,16 @@ func parseValidateFlags(cmd *cobra.Command) (*validateOpts, error) {
 }
 
 func runValidateWithOpts(_ context.Context, opts *validateOpts, stdout, stderr io.Writer) error {
-	diags, err := intvalidate.ValidateDirWithOptions(opts.configDir, intvalidate.Options{
+	validateOptions := intvalidate.Options{
 		SkipRuntimeBinaryCheck: opts.noRuntimeCheck,
-	})
+	}
+	if runtimes, ok, err := loadAdvertisedWorkerRuntimes(opts.configDir); err != nil {
+		return err
+	} else if ok {
+		validateOptions.WorkerRuntimes = runtimes
+		validateOptions.CheckWorkerRuntimes = true
+	}
+	diags, err := intvalidate.ValidateDirWithOptions(opts.configDir, validateOptions)
 	if err != nil {
 		return err
 	}
@@ -145,4 +156,58 @@ func classifyDiagnostics(diags []intvalidate.Diagnostic) (hasError, hasWarning b
 		}
 	}
 	return
+}
+
+func loadAdvertisedWorkerRuntimes(configDir string) ([]string, bool, error) {
+	dbPath, ok, err := localWorkerDBPath(configDir)
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+	st, err := store.NewStore(dbPath)
+	if err != nil {
+		return nil, false, fmt.Errorf("validate: open worker registry %q: %w", dbPath, err)
+	}
+	defer func() { _ = st.Close() }()
+
+	workers, err := st.QueryWorkers("")
+	if err != nil {
+		return nil, false, fmt.Errorf("validate: query workers from %q: %w", dbPath, err)
+	}
+	seen := make(map[string]struct{}, len(workers))
+	for _, worker := range workers {
+		runtime := strings.TrimSpace(worker.Runtime)
+		if runtime == "" {
+			continue
+		}
+		seen[runtime] = struct{}{}
+	}
+	runtimes := make([]string, 0, len(seen))
+	for runtime := range seen {
+		runtimes = append(runtimes, runtime)
+	}
+	sort.Strings(runtimes)
+	return runtimes, true, nil
+}
+
+func localWorkerDBPath(configDir string) (string, bool, error) {
+	configDir = strings.TrimSpace(configDir)
+	if configDir == "" {
+		return "", false, nil
+	}
+	absConfigDir, err := filepath.Abs(configDir)
+	if err != nil {
+		return "", false, fmt.Errorf("validate: abs config dir: %w", err)
+	}
+	repoRoot := filepath.Dir(absConfigDir)
+	if filepath.Base(absConfigDir) == "workbuddy" && filepath.Base(repoRoot) == ".github" {
+		repoRoot = filepath.Dir(repoRoot)
+	}
+	dbPath := filepath.Join(repoRoot, ".workbuddy", "workbuddy.db")
+	if _, err := os.Stat(dbPath); err != nil {
+		if os.IsNotExist(err) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("validate: stat worker registry %q: %w", dbPath, err)
+	}
+	return dbPath, true, nil
 }

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/Lincyaw/workbuddy/internal/store"
 )
 
 func TestRunValidateWithOpts_ValidConfig(t *testing.T) {
@@ -141,6 +143,55 @@ func TestRunValidateWithOpts_StrictPromotesWarnings(t *testing.T) {
 	var exitErr *cliExitError
 	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
 		t.Fatalf("expected exit 1 from --strict, got %v", err)
+	}
+}
+
+func TestRunValidateWithOpts_WarnsWhenNoWorkerAdvertisesAgentRuntime(t *testing.T) {
+	configDir := writeValidateFixture(t, validateFixtureFiles{
+		"config.yaml": "repo: octo/workbuddy\n",
+		"agents/dev-agent.md": `---
+name: dev-agent
+description: test agent
+triggers:
+  - state: developing
+role: dev
+runtime: codex
+command: echo run
+context:
+  - Repo
+---
+Repo: {{.Repo}}
+`,
+		"agents/review-agent.md": validateAgentFixture("review-agent", "status:reviewing"),
+		"workflows/default.md":   validateWorkflowFixture(),
+	})
+	dbPath := filepath.Join(filepath.Dir(filepath.Dir(configDir)), ".workbuddy", "workbuddy.db")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatalf("mkdir db dir: %v", err)
+	}
+	st, err := store.NewStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if err := st.InsertWorker(store.WorkerRecord{
+		ID:       "worker-1",
+		Repo:     "octo/workbuddy",
+		Roles:    `["dev"]`,
+		Runtime:  "claude-code",
+		Hostname: "host1",
+		Status:   "online",
+	}); err != nil {
+		t.Fatalf("InsertWorker: %v", err)
+	}
+	_ = st.Close()
+
+	var stderr bytes.Buffer
+	err = runValidateWithOpts(t.Context(), &validateOpts{configDir: configDir, noRuntimeCheck: true}, io.Discard, &stderr)
+	if err != nil {
+		t.Fatalf("warning-only run should exit 0, got %v", err)
+	}
+	if !strings.Contains(stderr.String(), "WB-S005") || !strings.Contains(stderr.String(), "runtime \"codex\"") {
+		t.Fatalf("stderr missing WB-S005 runtime warning: %q", stderr.String())
 	}
 }
 

--- a/cmd/worker_test.go
+++ b/cmd/worker_test.go
@@ -340,6 +340,7 @@ func TestParseWorkerFlags_DefaultReportBaseURLAndMgmtAuthToken(t *testing.T) {
 }
 
 func TestParseWorkerFlags_MgmtPublicURLRequiresSharedAuth(t *testing.T) {
+	t.Setenv("WORKBUDDY_AUTH_TOKEN", "")
 	cmd := newWorkerFlagCommand()
 	if err := cmd.Flags().Set("coordinator", "http://coord:8081"); err != nil {
 		t.Fatalf("set coordinator: %v", err)

--- a/internal/app/coordinator.go
+++ b/internal/app/coordinator.go
@@ -361,6 +361,9 @@ func (s *FullCoordinatorServer) HandleRegisterWorker(w http.ResponseWriter, r *h
 	if req.Repo == "" && len(req.Repos) > 0 {
 		req.Repo = strings.TrimSpace(req.Repos[0])
 	}
+	if strings.TrimSpace(req.Runtime) == "" {
+		req.Runtime = config.RuntimeClaudeCode
+	}
 	if req.WorkerID == "" || req.Repo == "" || len(req.Roles) == 0 {
 		CoordWriteJSON(w, http.StatusBadRequest, map[string]string{"error": "worker_id, repo, and roles are required"})
 		return
@@ -376,7 +379,7 @@ func (s *FullCoordinatorServer) HandleRegisterWorker(w http.ResponseWriter, r *h
 			return
 		}
 	}
-	if err := s.Registry.RegisterWithRepos(req.WorkerID, req.Repo, req.Repos, req.Roles, req.Hostname, req.MgmtBaseURL); err != nil {
+	if err := s.Registry.RegisterWithRepos(req.WorkerID, req.Repo, req.Repos, req.Roles, req.Runtime, req.Hostname, req.MgmtBaseURL); err != nil {
 		CoordWriteJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
@@ -613,16 +616,7 @@ func (s *FullCoordinatorServer) HandleTaskRelease(w http.ResponseWriter, r *http
 }
 
 func (s *FullCoordinatorServer) lookupWorker(workerID string) (*store.WorkerRecord, error) {
-	workers, err := s.Store.QueryWorkers("")
-	if err != nil {
-		return nil, err
-	}
-	for _, worker := range workers {
-		if worker.ID == workerID {
-			return &worker, nil
-		}
-	}
-	return nil, nil
+	return s.Store.GetWorker(workerID)
 }
 
 func (s *FullCoordinatorServer) claimNextTask(worker *store.WorkerRecord) (*TaskPollResponse, error) {
@@ -634,7 +628,7 @@ func (s *FullCoordinatorServer) claimNextTask(worker *store.WorkerRecord) (*Task
 	if err := json.Unmarshal([]byte(worker.ReposJSON), &repos); err != nil || len(repos) == 0 {
 		repos = []string{worker.Repo}
 	}
-	task, err := s.Store.ClaimNextTask(worker.ID, roles, repos, "", DefaultLongPollTimeout)
+	task, err := s.Store.ClaimNextTask(worker.ID, roles, repos, worker.Runtime, "", DefaultLongPollTimeout)
 	if err != nil || task == nil {
 		return nil, err
 	}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -44,12 +44,12 @@ func (r *Registry) SetPollInterval(pollInterval time.Duration) {
 
 // Register adds a worker to the registry.
 // roles is stored as a JSON array string in the DB.
-func (r *Registry) Register(id, repo string, roles []string, hostname string) error {
-	return r.RegisterWithRepos(id, repo, []string{repo}, roles, hostname, "")
+func (r *Registry) Register(id, repo string, roles []string, runtime string, hostname string) error {
+	return r.RegisterWithRepos(id, repo, []string{repo}, roles, runtime, hostname, "")
 }
 
 // RegisterWithRepos adds a worker to the registry with explicit repo bindings.
-func (r *Registry) RegisterWithRepos(id, repo string, repos []string, roles []string, hostname, mgmtBaseURL string) error {
+func (r *Registry) RegisterWithRepos(id, repo string, repos []string, roles []string, runtime, hostname, mgmtBaseURL string) error {
 	rolesJSON, err := json.Marshal(roles)
 	if err != nil {
 		return fmt.Errorf("registry: marshal roles: %w", err)
@@ -63,6 +63,7 @@ func (r *Registry) RegisterWithRepos(id, repo string, repos []string, roles []st
 		Repo:        repo,
 		ReposJSON:   string(reposJSON),
 		Roles:       string(rolesJSON),
+		Runtime:     runtime,
 		Hostname:    hostname,
 		MgmtBaseURL: mgmtBaseURL,
 		Status:      "online",
@@ -174,7 +175,7 @@ func (r *Registry) RegisterEmbedded(repo string, roles []string) (string, error)
 		hostname = "unknown"
 	}
 	id := "embedded-" + hostname
-	if err := r.Register(id, repo, roles, hostname); err != nil {
+	if err := r.Register(id, repo, roles, "", hostname); err != nil {
 		return "", fmt.Errorf("registry: register embedded: %w", err)
 	}
 	return id, nil

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -170,6 +170,7 @@ func (s *Store) createTables() error {
 			repo TEXT NOT NULL,
 			repos_json TEXT NOT NULL DEFAULT '[]',
 			roles TEXT NOT NULL,
+			runtime TEXT NOT NULL DEFAULT '',
 			hostname TEXT,
 			mgmt_base_url TEXT NOT NULL DEFAULT '',
 			status TEXT NOT NULL DEFAULT 'online',
@@ -321,6 +322,9 @@ func (s *Store) createTables() error {
 	}
 	if _, err := s.db.Exec(`ALTER TABLE workers ADD COLUMN repos_json TEXT NOT NULL DEFAULT '[]'`); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
 		return fmt.Errorf("store: alter workers add repos_json: %w", err)
+	}
+	if _, err := s.db.Exec(`ALTER TABLE workers ADD COLUMN runtime TEXT NOT NULL DEFAULT ''`); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+		return fmt.Errorf("store: alter workers add runtime: %w", err)
 	}
 	if _, err := s.db.Exec(`ALTER TABLE workers ADD COLUMN token_hash TEXT`); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
 		return fmt.Errorf("store: alter workers add token_hash: %w", err)
@@ -785,21 +789,21 @@ func (s *Store) ReleaseTask(taskID, workerID string) (bool, error) {
 // ClaimNextTask assigns the next dispatchable task to workerID. If the same
 // worker repeats the request with the same non-empty claimToken before the
 // lease expires, the previously claimed task is returned.
-func (s *Store) ClaimNextTask(workerID string, roles []string, repos []string, claimToken string, lease time.Duration) (*TaskRecord, error) {
+func (s *Store) ClaimNextTask(workerID string, roles []string, repos []string, runtime string, claimToken string, lease time.Duration) (*TaskRecord, error) {
 	if lease <= 0 {
 		lease = 30 * time.Second
 	}
 	for attempt := 0; attempt < 5; attempt++ {
-		task, err := s.claimNextTaskOnce(workerID, roles, repos, claimToken, lease)
+		task, err := s.claimNextTaskOnce(workerID, roles, repos, runtime, claimToken, lease)
 		if err == nil || !isSQLiteBusyError(err) {
 			return task, err
 		}
 		time.Sleep(time.Duration(attempt+1) * 10 * time.Millisecond)
 	}
-	return s.claimNextTaskOnce(workerID, roles, repos, claimToken, lease)
+	return s.claimNextTaskOnce(workerID, roles, repos, runtime, claimToken, lease)
 }
 
-func (s *Store) claimNextTaskOnce(workerID string, roles []string, repos []string, claimToken string, lease time.Duration) (*TaskRecord, error) {
+func (s *Store) claimNextTaskOnce(workerID string, roles []string, repos []string, runtime string, claimToken string, lease time.Duration) (*TaskRecord, error) {
 	tx, err := s.db.Begin()
 	if err != nil {
 		return nil, fmt.Errorf("store: begin claim tx: %w", err)
@@ -866,6 +870,13 @@ func (s *Store) claimNextTaskOnce(workerID string, roles []string, repos []strin
 	if len(repoConds) > 0 {
 		query += ` AND (` + strings.Join(repoConds, " OR ") + `)`
 		args = append(args, repoArgs...)
+	}
+	runtime = strings.TrimSpace(runtime)
+	if runtime == "" {
+		query += ` AND COALESCE(NULLIF(TRIM(runtime), ''), '') = ''`
+	} else {
+		query += ` AND (COALESCE(NULLIF(TRIM(runtime), ''), '') = '' OR runtime = ?)`
+		args = append(args, runtime)
 	}
 	query += ` ORDER BY created_at, id LIMIT 1`
 
@@ -1086,17 +1097,18 @@ func (s *Store) InsertWorker(w WorkerRecord) error {
 		w.ReposJSON = "[]"
 	}
 	_, err := s.db.Exec(
-		`INSERT INTO workers (id, repo, repos_json, roles, hostname, mgmt_base_url, status)
-		 VALUES (?, ?, ?, ?, ?, ?, ?)
+		`INSERT INTO workers (id, repo, repos_json, roles, runtime, hostname, mgmt_base_url, status)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(id) DO UPDATE SET
 		 repo = excluded.repo,
 		 repos_json = excluded.repos_json,
 		 roles = excluded.roles,
+		 runtime = excluded.runtime,
 		 hostname = excluded.hostname,
 		 mgmt_base_url = excluded.mgmt_base_url,
 		 status = excluded.status,
 		 last_heartbeat = CURRENT_TIMESTAMP`,
-		w.ID, w.Repo, w.ReposJSON, w.Roles, w.Hostname, w.MgmtBaseURL, w.Status,
+		w.ID, w.Repo, w.ReposJSON, w.Roles, w.Runtime, w.Hostname, w.MgmtBaseURL, w.Status,
 	)
 	if err != nil {
 		return fmt.Errorf("store: insert worker: %w", err)
@@ -1106,7 +1118,7 @@ func (s *Store) InsertWorker(w WorkerRecord) error {
 
 // QueryWorkers returns workers filtered by repo (empty = all).
 func (s *Store) QueryWorkers(repo string) ([]WorkerRecord, error) {
-	rows, err := s.db.Query(`SELECT id, repo, repos_json, roles, hostname, mgmt_base_url, status, last_heartbeat, registered_at FROM workers ORDER BY id`)
+	rows, err := s.db.Query(`SELECT id, repo, repos_json, roles, runtime, hostname, mgmt_base_url, status, last_heartbeat, registered_at FROM workers ORDER BY id`)
 	if err != nil {
 		return nil, fmt.Errorf("store: query workers: %w", err)
 	}
@@ -1116,7 +1128,7 @@ func (s *Store) QueryWorkers(repo string) ([]WorkerRecord, error) {
 	for rows.Next() {
 		var w WorkerRecord
 		var hb, ra string
-		if err := rows.Scan(&w.ID, &w.Repo, &w.ReposJSON, &w.Roles, &w.Hostname, &w.MgmtBaseURL, &w.Status, &hb, &ra); err != nil {
+		if err := rows.Scan(&w.ID, &w.Repo, &w.ReposJSON, &w.Roles, &w.Runtime, &w.Hostname, &w.MgmtBaseURL, &w.Status, &hb, &ra); err != nil {
 			return nil, fmt.Errorf("store: scan worker: %w", err)
 		}
 		w.LastHeartbeat, _ = ParseTimestamp(hb, "worker.last_heartbeat")
@@ -1131,10 +1143,10 @@ func (s *Store) QueryWorkers(repo string) ([]WorkerRecord, error) {
 
 // GetWorker returns a single registered worker by ID, or nil when absent.
 func (s *Store) GetWorker(workerID string) (*WorkerRecord, error) {
-	row := s.db.QueryRow(`SELECT id, repo, repos_json, roles, hostname, mgmt_base_url, status, last_heartbeat, registered_at FROM workers WHERE id = ?`, workerID)
+	row := s.db.QueryRow(`SELECT id, repo, repos_json, roles, runtime, hostname, mgmt_base_url, status, last_heartbeat, registered_at FROM workers WHERE id = ?`, workerID)
 	var w WorkerRecord
 	var hb, ra string
-	if err := row.Scan(&w.ID, &w.Repo, &w.ReposJSON, &w.Roles, &w.Hostname, &w.MgmtBaseURL, &w.Status, &hb, &ra); err != nil {
+	if err := row.Scan(&w.ID, &w.Repo, &w.ReposJSON, &w.Roles, &w.Runtime, &w.Hostname, &w.MgmtBaseURL, &w.Status, &hb, &ra); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
 		}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -119,7 +119,7 @@ func TestCreateAndReadWrite(t *testing.T) {
 	}
 
 	// --- Workers ---
-	err = s.InsertWorker(WorkerRecord{ID: "w-1", Repo: "org/repo", Roles: `["dev"]`, Hostname: "host1", Status: "online"})
+	err = s.InsertWorker(WorkerRecord{ID: "w-1", Repo: "org/repo", Roles: `["dev"]`, Runtime: "codex", Hostname: "host1", Status: "online"})
 	if err != nil {
 		t.Fatalf("InsertWorker: %v", err)
 	}
@@ -129,6 +129,9 @@ func TestCreateAndReadWrite(t *testing.T) {
 	}
 	if len(workers) != 1 || workers[0].Hostname != "host1" {
 		t.Fatalf("unexpected workers: %+v", workers)
+	}
+	if workers[0].Runtime != "codex" {
+		t.Fatalf("expected runtime codex, got %+v", workers[0])
 	}
 	if err := s.UpdateWorkerHeartbeat("w-1"); err != nil {
 		t.Fatalf("UpdateWorkerHeartbeat: %v", err)
@@ -369,7 +372,7 @@ func TestTaskClaimLifecycle(t *testing.T) {
 		t.Fatalf("InsertTask: %v", err)
 	}
 
-	task, err := s.ClaimNextTask("worker-a", []string{"dev"}, []string{"org/repo"}, "claim-1", 30*time.Second)
+	task, err := s.ClaimNextTask("worker-a", []string{"dev"}, []string{"org/repo"}, "codex", "claim-1", 30*time.Second)
 	if err != nil {
 		t.Fatalf("ClaimNextTask: %v", err)
 	}
@@ -377,7 +380,7 @@ func TestTaskClaimLifecycle(t *testing.T) {
 		t.Fatalf("unexpected claimed task: %+v", task)
 	}
 
-	sameTask, err := s.ClaimNextTask("worker-a", []string{"dev"}, []string{"org/repo"}, "claim-1", 30*time.Second)
+	sameTask, err := s.ClaimNextTask("worker-a", []string{"dev"}, []string{"org/repo"}, "codex", "claim-1", 30*time.Second)
 	if err != nil {
 		t.Fatalf("ClaimNextTask idempotent: %v", err)
 	}
@@ -385,7 +388,7 @@ func TestTaskClaimLifecycle(t *testing.T) {
 		t.Fatalf("idempotent claim returned %+v, want %q", sameTask, task.ID)
 	}
 
-	none, err := s.ClaimNextTask("worker-b", []string{"dev"}, []string{"other/repo"}, "", 30*time.Second)
+	none, err := s.ClaimNextTask("worker-b", []string{"dev"}, []string{"other/repo"}, "codex", "", 30*time.Second)
 	if err != nil {
 		t.Fatalf("ClaimNextTask other worker: %v", err)
 	}
@@ -426,7 +429,7 @@ func TestTaskOwnershipConflicts(t *testing.T) {
 		t.Fatalf("InsertTask: %v", err)
 	}
 
-	task, err := s.ClaimNextTask("worker-a", []string{"review"}, []string{"org/repo"}, "claim-review", 30*time.Second)
+	task, err := s.ClaimNextTask("worker-a", []string{"review"}, []string{"org/repo"}, "codex", "claim-review", 30*time.Second)
 	if err != nil {
 		t.Fatalf("ClaimNextTask: %v", err)
 	}
@@ -453,7 +456,7 @@ func TestClaimNextTaskDoesNotSelfReclaimExpiredRunningTask(t *testing.T) {
 		t.Fatalf("InsertTask: %v", err)
 	}
 
-	task, err := s.ClaimNextTask("worker-a", []string{"dev"}, []string{"org/repo"}, "", 30*time.Second)
+	task, err := s.ClaimNextTask("worker-a", []string{"dev"}, []string{"org/repo"}, "codex", "", 30*time.Second)
 	if err != nil {
 		t.Fatalf("ClaimNextTask: %v", err)
 	}
@@ -465,7 +468,7 @@ func TestClaimNextTaskDoesNotSelfReclaimExpiredRunningTask(t *testing.T) {
 		t.Fatalf("expire lease: %v", err)
 	}
 
-	again, err := s.ClaimNextTask("worker-a", []string{"dev"}, []string{"org/repo"}, "", 30*time.Second)
+	again, err := s.ClaimNextTask("worker-a", []string{"dev"}, []string{"org/repo"}, "codex", "", 30*time.Second)
 	if err != nil {
 		t.Fatalf("ClaimNextTask self reclaim: %v", err)
 	}
@@ -473,13 +476,78 @@ func TestClaimNextTaskDoesNotSelfReclaimExpiredRunningTask(t *testing.T) {
 		t.Fatalf("expected expired running task to be hidden from original worker, got %+v", again)
 	}
 
-	other, err := s.ClaimNextTask("worker-b", []string{"dev"}, []string{"org/repo"}, "", 30*time.Second)
+	other, err := s.ClaimNextTask("worker-b", []string{"dev"}, []string{"org/repo"}, "codex", "", 30*time.Second)
 	if err != nil {
 		t.Fatalf("ClaimNextTask other worker: %v", err)
 	}
 	if other == nil || other.ID != task.ID {
 		t.Fatalf("expected another worker to reclaim expired task, got %+v", other)
 	}
+}
+
+func TestClaimNextTaskFiltersByRuntime(t *testing.T) {
+	insertTask := func(t *testing.T, s *Store, id, runtime string) {
+		t.Helper()
+		if err := s.InsertTask(TaskRecord{
+			ID:        id,
+			Repo:      "org/repo",
+			IssueNum:  10,
+			AgentName: "dev-agent",
+			Role:      "dev",
+			Runtime:   runtime,
+			Status:    TaskStatusPending,
+		}); err != nil {
+			t.Fatalf("InsertTask(%s): %v", id, err)
+		}
+	}
+
+	t.Run("codex worker claims codex task", func(t *testing.T) {
+		s := newTestStore(t)
+		insertTask(t, s, "task-codex", "codex")
+		task, err := s.ClaimNextTask("worker-codex", []string{"dev"}, []string{"org/repo"}, "codex", "", 30*time.Second)
+		if err != nil {
+			t.Fatalf("ClaimNextTask: %v", err)
+		}
+		if task == nil || task.ID != "task-codex" {
+			t.Fatalf("expected codex task, got %+v", task)
+		}
+	})
+
+	t.Run("codex worker does not claim claude task", func(t *testing.T) {
+		s := newTestStore(t)
+		insertTask(t, s, "task-claude", "claude-code")
+		task, err := s.ClaimNextTask("worker-codex-2", []string{"dev"}, []string{"org/repo"}, "codex", "", 30*time.Second)
+		if err != nil {
+			t.Fatalf("ClaimNextTask: %v", err)
+		}
+		if task != nil {
+			t.Fatalf("expected no task, got %+v", task)
+		}
+	})
+
+	t.Run("claude worker does not claim codex task", func(t *testing.T) {
+		s := newTestStore(t)
+		insertTask(t, s, "task-codex-2", "codex")
+		task, err := s.ClaimNextTask("worker-claude", []string{"dev"}, []string{"org/repo"}, "claude-code", "", 30*time.Second)
+		if err != nil {
+			t.Fatalf("ClaimNextTask: %v", err)
+		}
+		if task != nil {
+			t.Fatalf("expected no task, got %+v", task)
+		}
+	})
+
+	t.Run("empty-runtime worker only claims any-runtime task", func(t *testing.T) {
+		s := newTestStore(t)
+		insertTask(t, s, "task-any", "")
+		task, err := s.ClaimNextTask("worker-any", []string{"dev"}, []string{"org/repo"}, "", "", 30*time.Second)
+		if err != nil {
+			t.Fatalf("ClaimNextTask: %v", err)
+		}
+		if task == nil || task.ID != "task-any" {
+			t.Fatalf("expected any-runtime task, got %+v", task)
+		}
+	})
 }
 
 // TestParseTimestamp verifies the multi-format timestamp parser.

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -46,6 +46,7 @@ type WorkerRecord struct {
 	Repo          string
 	ReposJSON     string
 	Roles         string // JSON array
+	Runtime       string
 	Hostname      string
 	MgmtBaseURL   string
 	Status        string // online, offline

--- a/internal/validate/semantics.go
+++ b/internal/validate/semantics.go
@@ -32,6 +32,10 @@ const (
 	// that has no outgoing transitions. Terminal states should not
 	// invoke an agent because there is no path forward.
 	CodeAgentInTerminalState = "WB-S004"
+
+	// CodeRuntimeNoWorkerSupport — an agent declares a runtime that no local
+	// registered worker currently advertises, so dispatch would dead-end.
+	CodeRuntimeNoWorkerSupport = "WB-S005"
 )
 
 // suspiciousTimeoutCutoff is the upper bound past which WB-S002 fires.
@@ -50,6 +54,8 @@ var runtimeBinaries = map[string]string{
 
 type semanticsOptions struct {
 	SkipRuntimeBinaryCheck bool
+	WorkerRuntimes         map[string]struct{}
+	CheckWorkerRuntimes    bool
 }
 
 // validateSemantics implements WB-S001..WB-S004.
@@ -161,6 +167,33 @@ func validateAgentSemantics(agent *agentDoc, idleThreshold time.Duration, opts s
 						),
 					})
 				}
+			}
+		}
+	}
+
+	// WB-S005 — local workers do not advertise the agent's explicit runtime.
+	if opts.CheckWorkerRuntimes {
+		if rt := strings.TrimSpace(agent.Runtime); rt != "" {
+			if _, ok := opts.WorkerRuntimes[rt]; !ok {
+				advertised := make([]string, 0, len(opts.WorkerRuntimes))
+				for runtime := range opts.WorkerRuntimes {
+					advertised = append(advertised, runtime)
+				}
+				sort.Strings(advertised)
+				msg := "no registered workers advertise any runtime"
+				if len(advertised) > 0 {
+					msg = fmt.Sprintf("registered worker runtimes: %s", strings.Join(advertised, ", "))
+				}
+				diags = append(diags, Diagnostic{
+					Path:     agent.Path,
+					Line:     orFallback(agent.RuntimeLine, agent.NameLine),
+					Severity: SeverityWarning,
+					Code:     CodeRuntimeNoWorkerSupport,
+					Message: fmt.Sprintf(
+						"agent %q declares runtime %q but no registered worker advertises it (%s)",
+						agent.Name, rt, msg,
+					),
+				})
 			}
 		}
 	}

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -162,6 +162,13 @@ type Options struct {
 	// Useful for CI/sandbox environments where neither codex nor claude
 	// is installed.
 	SkipRuntimeBinaryCheck bool
+	// WorkerRuntimes enables WB-S005 when populated from the local workers
+	// registry. The validator treats an explicit empty list as "checked and no
+	// worker runtimes are currently advertised".
+	WorkerRuntimes []string
+	// CheckWorkerRuntimes toggles WB-S005. Callers should set this only when
+	// they successfully loaded a local workers table.
+	CheckWorkerRuntimes bool
 }
 
 // ValidateDir validates a .github/workbuddy configuration directory using
@@ -266,7 +273,7 @@ func ValidateDirWithOptions(configDir string, opts Options) ([]Diagnostic, error
 	}
 
 	// Layer 4 — semantic / cross-knob consistency (WB-S001..S004).
-	diags = append(diags, validateSemantics(configDir, agents, workflows, semanticsOptions(opts))...)
+	diags = append(diags, validateSemantics(configDir, agents, workflows, newSemanticsOptions(opts))...)
 
 	// Layer L — content/control-flow drift lint (WB-L001..L003). All
 	// warnings; default exit 0, gated by --strict.
@@ -448,6 +455,25 @@ func parseAgentFile(path string) (*agentDoc, []Diagnostic) {
 		diags = append(diags, Diagnostic{Path: path, Line: fmStartLine, Message: "missing agent name"})
 	}
 	return agent, diags
+}
+
+func newSemanticsOptions(opts Options) semanticsOptions {
+	out := semanticsOptions{
+		SkipRuntimeBinaryCheck: opts.SkipRuntimeBinaryCheck,
+		CheckWorkerRuntimes:    opts.CheckWorkerRuntimes,
+	}
+	if len(opts.WorkerRuntimes) == 0 {
+		return out
+	}
+	out.WorkerRuntimes = make(map[string]struct{}, len(opts.WorkerRuntimes))
+	for _, runtime := range opts.WorkerRuntimes {
+		runtime = strings.TrimSpace(runtime)
+		if runtime == "" {
+			continue
+		}
+		out.WorkerRuntimes[runtime] = struct{}{}
+	}
+	return out
 }
 
 // firstNonBlankLine returns the absolute file line of the first non-blank

--- a/internal/validate/validate_codes_test.go
+++ b/internal/validate/validate_codes_test.go
@@ -225,6 +225,23 @@ func TestValidateDir_CodeFixtures(t *testing.T) {
 			wantHas: CodeAgentInTerminalState,
 		},
 		{
+			name: "WB-S005 no worker advertises agent runtime",
+			files: map[string]string{
+				"config.yaml":         "repo: octo/x\n",
+				"agents/dev-agent.md": fixtureAgent("dev-agent", "developing", "dev", "codex", "Repo: {{.Repo}}"),
+				"workflows/default.md": fixtureWorkflow(map[string]workflowState{
+					"developing": {EnterLabel: "status:developing", Agent: "dev-agent", Transitions: []string{"reviewing"}},
+					"reviewing":  {EnterLabel: "status:reviewing"},
+				}),
+			},
+			opts: Options{
+				SkipRuntimeBinaryCheck: true,
+				CheckWorkerRuntimes:    true,
+				WorkerRuntimes:         []string{"claude-code"},
+			},
+			wantHas: CodeRuntimeNoWorkerSupport,
+		},
+		{
 			name: "WB-L001 prompt body inlines gh issue edit",
 			files: map[string]string{
 				"config.yaml": "repo: octo/x\n",

--- a/internal/worker/distributed.go
+++ b/internal/worker/distributed.go
@@ -106,7 +106,7 @@ func (w *DistributedWorker) ExecuteTask(ctx context.Context, task *workerclient.
 	}
 
 	agentCopy := *agentCfg
-	if w.deps.RuntimeAlias != "" {
+	if strings.TrimSpace(agentCopy.Runtime) == "" && w.deps.RuntimeAlias != "" {
 		agentCopy.Runtime = w.deps.RuntimeAlias
 	}
 

--- a/internal/worker/distributed_test.go
+++ b/internal/worker/distributed_test.go
@@ -9,6 +9,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Lincyaw/workbuddy/internal/config"
+	launcherevents "github.com/Lincyaw/workbuddy/internal/launcher/events"
+	"github.com/Lincyaw/workbuddy/internal/poller"
+	"github.com/Lincyaw/workbuddy/internal/reporter"
+	runtimepkg "github.com/Lincyaw/workbuddy/internal/runtime"
 	"github.com/Lincyaw/workbuddy/internal/workerclient"
 )
 
@@ -16,9 +21,9 @@ import (
 type fakeRemoteClient struct {
 	mu sync.Mutex
 
-	submitErrs   []error // consumed in order; once exhausted returns nil
-	submitCalls  int
-	submitReqs   []workerclient.ResultRequest
+	submitErrs  []error // consumed in order; once exhausted returns nil
+	submitCalls int
+	submitReqs  []workerclient.ResultRequest
 
 	releaseErr   error
 	releaseCalls int
@@ -48,6 +53,20 @@ func (c *fakeRemoteClient) SubmitResult(ctx context.Context, taskID string, req 
 	err := c.submitErrs[0]
 	c.submitErrs = c.submitErrs[1:]
 	return err
+}
+
+type fakeCommentWriter struct{}
+
+func (fakeCommentWriter) WriteComment(string, int, string) error { return nil }
+
+type fakeDistributedIssueReader struct{}
+
+func (fakeDistributedIssueReader) ReadIssue(string, int) (poller.IssueDetails, error) {
+	return poller.IssueDetails{}, nil
+}
+
+func (fakeDistributedIssueReader) ReadIssueLabels(string, int) ([]string, error) {
+	return nil, nil
 }
 
 func init() {
@@ -169,5 +188,54 @@ func TestDistributedWorker_ReleasesWithReasonOnPermanentSubmitFailure(t *testing
 	}
 	if got := client.releaseReqs[0].Reason; !strings.Contains(got, "submit result failed") || !strings.Contains(got, "coordinator 500") {
 		t.Fatalf("release reason should reference submit error, got %q", got)
+	}
+}
+
+func TestDistributedWorker_PreservesExplicitAgentRuntime(t *testing.T) {
+	t.Parallel()
+
+	launcher := runtimepkg.NewRegistry()
+	var startedRuntime string
+	launcher.SetSessionStarter(func(_ context.Context, agent *config.AgentConfig, _ *runtimepkg.TaskContext) (runtimepkg.Session, error, bool) {
+		startedRuntime = agent.Runtime
+		return &fakeSession{
+			run: func(_ context.Context, _ chan<- launcherevents.Event) (*runtimepkg.Result, error) {
+				return &runtimepkg.Result{ExitCode: 0, Meta: map[string]string{}}, nil
+			},
+		}, nil, true
+	})
+	executor := NewExecutor(launcher, fakeDistributedIssueReader{})
+	client := &fakeRemoteClient{}
+	worker := NewDistributedWorker(DistributedDeps{
+		Config: &config.FullConfig{
+			Agents: map[string]*config.AgentConfig{
+				"dev-agent": {Name: "dev-agent", Runtime: config.RuntimeCodex},
+			},
+		},
+		Executor:          executor,
+		Reporter:          reporter.NewReporter(fakeCommentWriter{}),
+		Reader:            fakeDistributedIssueReader{},
+		Client:            client,
+		WorkDir:           t.TempDir(),
+		WorkerID:          "worker-1",
+		RuntimeAlias:      config.RuntimeClaudeCode,
+		HeartbeatInterval: time.Hour,
+		ShutdownTimeout:   time.Second,
+	})
+
+	err := worker.ExecuteTask(context.Background(), &workerclient.Task{
+		TaskID:    "task-1",
+		Repo:      "owner/repo",
+		IssueNum:  42,
+		AgentName: "dev-agent",
+	})
+	if err != nil {
+		t.Fatalf("ExecuteTask: %v", err)
+	}
+	if startedRuntime != config.RuntimeCodex {
+		t.Fatalf("runtime passed to launcher = %q, want %q", startedRuntime, config.RuntimeCodex)
+	}
+	if client.submitCalls != 1 {
+		t.Fatalf("submitCalls = %d, want 1", client.submitCalls)
 	}
 }

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -3966,3 +3966,46 @@ requirements:
       - cmd/deploy_bundle_test.go
     deps:
       - REQ-105
+
+  - id: REQ-113
+    title: "Runtime-aware task routing honors worker capability and agent config (#285)"
+    description: >
+      Issue #285: distributed workers were claiming tasks solely by repo+role,
+      ignoring the queued task runtime, and then overwriting the agent's
+      requested runtime with the worker's startup `--runtime` alias. That made
+      `.github/workbuddy/agents/*.md` `runtime:` effectively dead metadata and
+      silently dispatched codex tasks onto claude-only workers. The dispatch
+      path must treat `task_queue.runtime=''` as backward-compatible any
+      runtime for old rows, persist each worker's advertised runtime in the
+      workers table, route polls through that capability, preserve an explicit
+      agent runtime during execution, and warn during `workbuddy validate` when
+      the local config declares a runtime that no registered worker advertises.
+    rationale: >
+      Multi-runtime deployments only work when worker capability, queue
+      routing, and launcher selection agree on the same runtime contract.
+      Without that, operators get silent misroutes and misleading session
+      metadata instead of an actionable validation signal.
+    priority: P1
+    version: v0.5.0
+    status: tested
+    acceptance_criteria:
+      - "AC-113-1: `Store.ClaimNextTask` accepts a worker runtime and only claims tasks whose `task_queue.runtime` matches that runtime, while still treating empty task runtime as backward-compatible any-runtime."
+      - "AC-113-2: coordinator task polling reads the worker's advertised runtime from the workers table and passes it through to the claim path without changing the `/api/v1/tasks/poll` wire contract."
+      - "AC-113-3: worker registration persists runtime capability on the workers row so later lookups and routing decisions can read it back."
+      - "AC-113-4: distributed worker execution preserves an explicit agent-config runtime and only falls back to the worker runtime alias when the agent config has no runtime."
+      - "AC-113-5: `workbuddy validate` emits a warning when a local agent declares a runtime that no registered worker advertises."
+      - "AC-113-6: Unit tests cover runtime claim filtering, worker-runtime persistence, explicit-runtime preservation, and the validate warning path."
+    code:
+      - internal/store/store.go
+      - internal/store/types.go
+      - internal/app/coordinator.go
+      - internal/registry/registry.go
+      - internal/worker/distributed.go
+      - internal/validate/validate.go
+      - internal/validate/semantics.go
+      - cmd/validate.go
+    tests:
+      - internal/store/store_test.go
+      - internal/worker/distributed_test.go
+      - internal/validate/validate_codes_test.go
+      - cmd/validate_test.go


### PR DESCRIPTION
Fixes #285

- route task claims by worker runtime capability
- persist worker runtime on registration and pass it through polling
- preserve explicit agent runtime instead of always overriding with the worker alias
- warn from validate when no registered worker advertises a declared runtime
- add store/worker/validate coverage and update project-index