### PR TITLE
Fix coordinator boot crash on persisted legacy join scalar

### DIFF
--- a/internal/config/state_join.go
+++ b/internal/config/state_join.go
@@ -1,10 +1,43 @@
 package config
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 
 	"gopkg.in/yaml.v3"
 )
+
+// UnmarshalJSON accepts both legacy scalar joins persisted as bare strings
+// (`"join": "all_passed"`) and the rollout-aware mapping form
+// (`"join": {"strategy": "rollouts", "min_successes": 2}`). This mirrors
+// State.UnmarshalYAML so configs that round-trip through SQLite registration
+// JSON keep decoding after the rollouts phase-1 schema change. Without this
+// method, persisted registrations written before the JoinConfig struct
+// existed (where `Join` was a string scalar) will fail with
+// `cannot unmarshal string into Go struct field`.
+func (j *JoinConfig) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		*j = JoinConfig{}
+		return nil
+	}
+	if trimmed[0] == '"' {
+		var s string
+		if err := json.Unmarshal(trimmed, &s); err != nil {
+			return fmt.Errorf("config: decode legacy join scalar: %w", err)
+		}
+		*j = JoinConfig{Strategy: s}
+		return nil
+	}
+	type joinAlias JoinConfig
+	var aux joinAlias
+	if err := json.Unmarshal(trimmed, &aux); err != nil {
+		return fmt.Errorf("config: decode join object: %w", err)
+	}
+	*j = JoinConfig(aux)
+	return nil
+}
 
 // UnmarshalYAML accepts both legacy scalar joins (`join: all_passed`) and the
 // rollout-aware mapping form (`join: {strategy: rollouts, min_successes: 2}`).

--- a/internal/config/state_join_test.go
+++ b/internal/config/state_join_test.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestJoinConfigJSONLegacyScalar pins down the round-trip path used by
+// persisted SQLite coordinator registrations. Old registrations written
+// before rollouts phase 1 stored `join` as a bare string scalar; the new
+// JoinConfig struct must keep decoding them or the coordinator crashes on
+// boot with `cannot unmarshal string into Go struct field`.
+func TestJoinConfigJSONLegacyScalar(t *testing.T) {
+	var j JoinConfig
+	if err := json.Unmarshal([]byte(`"all_passed"`), &j); err != nil {
+		t.Fatalf("legacy scalar must decode: %v", err)
+	}
+	if j.Strategy != "all_passed" {
+		t.Fatalf("strategy: got %q want %q", j.Strategy, "all_passed")
+	}
+	if j.MinSuccesses != 0 {
+		t.Fatalf("min_successes: got %d want 0", j.MinSuccesses)
+	}
+}
+
+func TestJoinConfigJSONObject(t *testing.T) {
+	// Persisted registrations use Go default (CamelCase) field naming because
+	// JoinConfig has no explicit json tags. Round-trip must keep that form
+	// decodable.
+	var j JoinConfig
+	if err := json.Unmarshal([]byte(`{"Strategy":"rollouts","MinSuccesses":2}`), &j); err != nil {
+		t.Fatalf("object form must decode: %v", err)
+	}
+	if j.Strategy != "rollouts" || j.MinSuccesses != 2 {
+		t.Fatalf("decoded join = %+v", j)
+	}
+}
+
+func TestJoinConfigJSONNullAndEmpty(t *testing.T) {
+	var j JoinConfig
+	if err := json.Unmarshal([]byte(`null`), &j); err != nil {
+		t.Fatalf("null must decode: %v", err)
+	}
+	if j != (JoinConfig{}) {
+		t.Fatalf("null should produce zero value, got %+v", j)
+	}
+}
+
+// TestStateJSONLegacyScalarJoin exercises the inner field path: registrations
+// embed JoinConfig inside State, so the failing prod path is decoding a State
+// JSON blob whose `join` is a bare string.
+func TestStateJSONLegacyScalarJoin(t *testing.T) {
+	raw := []byte(`{"EnterLabel":"developing","Join":"all_passed","Transitions":{"status:reviewing":"reviewing"}}`)
+	var s State
+	if err := json.Unmarshal(raw, &s); err != nil {
+		t.Fatalf("State with legacy scalar join must decode: %v", err)
+	}
+	if s.Join.Strategy != "all_passed" {
+		t.Fatalf("join.strategy = %q", s.Join.Strategy)
+	}
+}

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -4144,4 +4144,5 @@ requirements:
       - internal/worker/distributed_test.go
       - internal/workspace/workspace_test.go
       - internal/recover/recover_test.go
+      - internal/config/state_join_test.go
       - web/src/utils/sessionGroups.test.ts


### PR DESCRIPTION
## Summary

After #292 merged, \`JoinConfig\` changed from a bare string scalar to a struct (\`Strategy\` + \`MinSuccesses\`). Coordinator startup decodes \`repo_registrations.config_json\` from SQLite, but existing rows still carry \`\"Join\": \"all_passed\"\` written by the pre-rollouts coordinator. Those rows now fail JSON decoding with \`cannot unmarshal string into Go struct field State.workflows.States.Join of type config.JoinConfig\` and the coordinator dies in a restart loop (observed live on my local box right after the v0.6.0 deploy).

## Fix

Add \`JoinConfig.UnmarshalJSON\` that mirrors the existing \`State.UnmarshalYAML\` shape:

- bare string scalar → \`Strategy = s\`
- object form → full struct
- \`null\` / empty → zero value

Tests cover legacy scalar, object form, null, and the embedded \`State.Join\` field path so a future schema change won't silently regress.

## Test plan

- [x] \`go test ./internal/config/... -count=1\` — pass
- [x] \`go build ./... && go vet ./...\` — clean
- [x] \`python3 ~/.autoharness/scripts/validate_index.py project-index.yaml\` — pass
- [x] \`go run . validate-docs --strict\` — clean
- [ ] After merge: deploy and watch \`workbuddy-coordinator\` come up clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)