### PR TITLE
Fix stale inflight recovery for issue restart

### DIFF
--- a/cmd/admin_restart_issue.go
+++ b/cmd/admin_restart_issue.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"path/filepath"
 	"strings"
 
@@ -17,6 +18,8 @@ type restartIssueOpts struct {
 	repo        string
 	issue       int
 	dbPath      string
+	coordinator string
+	token       string
 	source      string
 	jsonOut     bool
 	force       bool
@@ -32,6 +35,7 @@ type restartIssueResult struct {
 	DependencyStateCleared bool   `json:"dependency_state_cleared"`
 	ClaimCleared           bool   `json:"claim_cleared"`
 	CycleStateCleared      bool   `json:"cycle_state_cleared"`
+	InflightCleared        bool   `json:"inflight_cleared"`
 	ClaimOwner             string `json:"claim_owner,omitempty"`
 	EventLogged            bool   `json:"event_logged"`
 }
@@ -42,9 +46,12 @@ var issueRestartCmd = &cobra.Command{
 	Long: `Clear the local recovery state for one issue so the next poll cycle
 treats it as fresh. This removes the issue's poller cache row, resets any
 cached dependency verdict, and clears a lingering issue-claim lease when one
-exists. Use this when an issue is stuck in status:developing/status:reviewing
-and simple label toggles are ignored because the poller cache already matches
-GitHub.`,
+exists. When --coordinator is set, the command also asks the running
+coordinator to drop the matching in-memory inflight tracker entry so the
+"clear in-memory state" promise is immediate instead of waiting for the next
+self-heal dispatch attempt. Use this when an issue is stuck in
+status:developing/status:reviewing and simple label toggles are ignored
+because the poller cache already matches GitHub.`,
 	Example: `  workbuddy issue restart --repo owner/name --issue 173
   workbuddy issue restart --repo owner/name --issue 173 --format json`,
 	RunE: runRestartIssueCmd,
@@ -87,6 +94,8 @@ func bindRestartIssueFlags(cmd *cobra.Command) {
 	cmd.Flags().String("repo", "", "GitHub repository in OWNER/NAME form")
 	cmd.Flags().Int("issue", 0, "Issue number to restart")
 	cmd.Flags().String("db-path", ".workbuddy/workbuddy.db", "SQLite database path")
+	cmd.Flags().String("coordinator", "", "Coordinator base URL for clearing the live inflight tracker")
+	addCoordinatorAuthFlags(cmd.Flags(), "t", "Bearer token for coordinator auth")
 	addOutputFormatFlag(cmd)
 	addDeprecatedJSONAliasFlag(cmd)
 	cmd.Flags().Bool("force", false, "Skip confirmation prompts for destructive actions")
@@ -97,7 +106,12 @@ func parseRestartIssueFlags(cmd *cobra.Command) (*restartIssueOpts, error) {
 	repo, _ := cmd.Flags().GetString("repo")
 	issue, _ := cmd.Flags().GetInt("issue")
 	dbPath, _ := cmd.Flags().GetString("db-path")
+	coordinatorURL, _ := cmd.Flags().GetString("coordinator")
 	format, err := resolveOutputFormat(cmd, "restart-issue")
+	if err != nil {
+		return nil, err
+	}
+	token, err := resolveCoordinatorAuthToken(cmd, "restart-issue")
 	if err != nil {
 		return nil, err
 	}
@@ -119,6 +133,8 @@ func parseRestartIssueFlags(cmd *cobra.Command) (*restartIssueOpts, error) {
 		repo:        repo,
 		issue:       issue,
 		dbPath:      dbPath,
+		coordinator: strings.TrimRight(strings.TrimSpace(coordinatorURL), "/"),
+		token:       token,
 		source:      "cli:admin:restart-issue",
 		jsonOut:     isJSONOutput(format),
 		force:       force,
@@ -128,7 +144,12 @@ func parseRestartIssueFlags(cmd *cobra.Command) (*restartIssueOpts, error) {
 	}, nil
 }
 
-func runRestartIssueWithOpts(_ context.Context, opts *restartIssueOpts, stdout io.Writer) error {
+// runRestartIssueWithOpts uses a push-based reconciliation path: after the
+// local SQLite recovery rows are cleared, the CLI POSTs to the coordinator's
+// admin clear-inflight endpoint when --coordinator is configured. If that
+// endpoint is unavailable, Dispatch's task_queue-backed self-heal path is the
+// pull-based fallback that clears stale inflight state on the next dispatch.
+func runRestartIssueWithOpts(ctx context.Context, opts *restartIssueOpts, stdout io.Writer) error {
 	dbPath, err := filepath.Abs(opts.dbPath)
 	if err != nil {
 		return fmt.Errorf("restart-issue: resolve db path: %w", err)
@@ -173,6 +194,13 @@ func runRestartIssueWithOpts(_ context.Context, opts *restartIssueOpts, stdout i
 	if err != nil {
 		return err
 	}
+	if opts.coordinator != "" {
+		cleared, clearErr := clearCoordinatorInflight(ctx, opts.coordinator, opts.token, opts.repo, opts.issue)
+		if clearErr != nil {
+			return clearErr
+		}
+		result.InflightCleared = cleared
+	}
 	return writeRestartIssueResult(stdout, result, false, opts.jsonOut)
 }
 
@@ -195,7 +223,7 @@ func writeRestartIssueResult(stdout io.Writer, result restartIssueResult, dryRun
 	if dryRun {
 		prefix = "dry-run: "
 	}
-	_, _ = fmt.Fprintf(stdout, "%s%s#%d: cache=%t dependency_state=%t claim=%t cycle_state=%t", prefix, result.Repo, result.IssueNum, result.CacheCleared, result.DependencyStateCleared, result.ClaimCleared, result.CycleStateCleared)
+	_, _ = fmt.Fprintf(stdout, "%s%s#%d: cache=%t dependency_state=%t claim=%t cycle_state=%t inflight=%t", prefix, result.Repo, result.IssueNum, result.CacheCleared, result.DependencyStateCleared, result.ClaimCleared, result.CycleStateCleared, result.InflightCleared)
 	if result.ClaimOwner != "" {
 		_, _ = fmt.Fprintf(stdout, " held_by=%s", result.ClaimOwner)
 	}
@@ -204,6 +232,32 @@ func writeRestartIssueResult(stdout io.Writer, result restartIssueResult, dryRun
 	}
 	_, _ = fmt.Fprintln(stdout)
 	return nil
+}
+
+func clearCoordinatorInflight(ctx context.Context, coordinatorURL, token, repo string, issueNum int) (bool, error) {
+	path := fmt.Sprintf("%s/api/v1/admin/issues/%s/%d/clear-inflight", strings.TrimRight(strings.TrimSpace(coordinatorURL), "/"), escapeRepoPath(repo), issueNum)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, path, nil)
+	if err != nil {
+		return false, fmt.Errorf("restart-issue: build coordinator clear-inflight request: %w", err)
+	}
+	if trimmedToken := strings.TrimSpace(token); trimmedToken != "" {
+		req.Header.Set("Authorization", "Bearer "+trimmedToken)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("restart-issue: clear coordinator inflight: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return true, nil
+	case http.StatusNotFound:
+		return false, nil
+	case http.StatusUnauthorized:
+		return false, fmt.Errorf("restart-issue: coordinator clear-inflight unauthorized")
+	default:
+		return false, fmt.Errorf("restart-issue: coordinator clear-inflight returned %s", resp.Status)
+	}
 }
 
 func inspectRestartIssueStore(st *store.Store, repo string, issueNum int) (restartIssueResult, error) {

--- a/cmd/admin_restart_issue_test.go
+++ b/cmd/admin_restart_issue_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -131,6 +133,65 @@ func TestRunRestartIssueStoreClearsCacheClaimAndLogsEvent(t *testing.T) {
 	}
 	if latest == nil || latest.Type != eventlog.TypeIssueRestarted {
 		t.Fatalf("latest event = %+v, want %q", latest, eventlog.TypeIssueRestarted)
+	}
+}
+
+func TestRunRestartIssueWithOptsClearsCoordinatorInflight(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "restart-coordinator.db")
+	st, err := store.NewStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	const (
+		repo     = "owner/repo"
+		issueNum = 218
+	)
+	if err := st.UpsertIssueCache(store.IssueCache{
+		Repo:     repo,
+		IssueNum: issueNum,
+		Labels:   `["workbuddy","status:developing"]`,
+		State:    "open",
+	}); err != nil {
+		t.Fatalf("UpsertIssueCache: %v", err)
+	}
+	_ = st.Close()
+
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if got, want := r.URL.Path, "/api/v1/admin/issues/owner/repo/218/clear-inflight"; got != want {
+			t.Fatalf("path = %q, want %q", got, want)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer shared-secret" {
+			t.Fatalf("authorization = %q, want Bearer shared-secret", got)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"repo":"owner/repo","issue_num":218}`))
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	err = runRestartIssueWithOpts(context.Background(), &restartIssueOpts{
+		repo:        repo,
+		issue:       issueNum,
+		dbPath:      dbPath,
+		coordinator: srv.URL,
+		token:       "shared-secret",
+		source:      "test",
+		force:       true,
+		interactive: false,
+	}, &out)
+	if err != nil {
+		t.Fatalf("runRestartIssueWithOpts: %v", err)
+	}
+	if !called {
+		t.Fatal("expected coordinator clear-inflight request")
+	}
+	if !strings.Contains(out.String(), "inflight=true") {
+		t.Fatalf("output missing inflight=true: %q", out.String())
 	}
 }
 

--- a/cmd/coordinator.go
+++ b/cmd/coordinator.go
@@ -652,6 +652,7 @@ func buildCoordinatorMux(api *app.FullCoordinatorServer, st *store.Store, evlog 
 	mux.Handle("/api/v1/workers/", api.WrapAuth(http.HandlerFunc(api.HandleWorkerByPath)))
 	mux.Handle("/workers/", api.WrapAuth(newCoordinatorSessionProxy(st, api.AuthToken)))
 	mux.Handle("/api/v1/config/reload", api.WrapAuth(http.HandlerFunc(api.HandleConfigReload)))
+	mux.Handle("/api/v1/admin/issues/", api.WrapAuth(http.HandlerFunc(api.HandleClearIssueInflight)))
 	mux.Handle("/api/v1/tasks/poll", api.WrapAuth(http.HandlerFunc(api.HandlePollTask)))
 	mux.Handle("/api/v1/tasks/", api.WrapAuth(http.HandlerFunc(api.HandleTaskAction)))
 

--- a/docs/implemented/distributed-topology-and-cli.md
+++ b/docs/implemented/distributed-topology-and-cli.md
@@ -57,7 +57,7 @@ workbuddy worker \
 | `workbuddy validate` | 校验配置文件完整性和交叉引用 | REQ-021 | v0.2.0 |
 | `workbuddy logs` | 查看 session 归档日志和 artifact | REQ-022 | v0.2.0 |
 | `workbuddy cache invalidate` | 清除 issue 缓存强制重新评估（`cache-invalidate` 为 deprecated alias） | REQ-034, 061 | v0.2.0 |
-| `workbuddy issue restart` | 清除 issue cache / dependency state / issue claim，强制下一 poll 重新派发（`admin restart-issue` 为 deprecated alias） | REQ-060, 061 | v0.2.0 |
+| `workbuddy issue restart` | 清除 issue cache / dependency state / issue claim / cycle state；若 coordinator 可达则同时清掉进程内 inflight tracker（`admin restart-issue` 为 deprecated alias） | REQ-060, 061, 116 | v0.2.0 |
 | `workbuddy diagnose` | 自动诊断 pipeline 问题（stuck/orphaned/repeated failure） | REQ-037 | v0.2.0 |
 | `workbuddy recover` | 重启恢复（清理僵尸进程、重置运行时状态） | REQ-032 | v0.2.0 |
 | `workbuddy deploy` | 安装当前 binary、写入 systemd unit，并支持后续 redeploy/upgrade/start/stop/delete | main | main |

--- a/docs/implemented/pipeline-observability-and-diagnosis.md
+++ b/docs/implemented/pipeline-observability-and-diagnosis.md
@@ -61,7 +61,7 @@ workbuddy cache invalidate --repo OWNER/NAME --issue 47,48,49
 - 直连 SQLite，不依赖 serve 进程
 - `workbuddy cache-invalidate ...` 仍可用，但会在 stderr 打印 deprecation warning
 
-### issue restart（REQ-060, REQ-061）
+### issue restart（REQ-060, REQ-061, REQ-116）
 
 显式重启单个 issue 的调度状态，解决“标签没变但就是不再派发”的恢复场景：
 
@@ -72,10 +72,15 @@ workbuddy issue restart --repo OWNER/NAME --issue 173
 - 删除该 issue 的 `issue_cache` 行，让下一次 poll 把它当成新 issue
 - 清除 `issue_dependency_state`，避免沿用旧 verdict
 - 如果存在残留 `issue_claim`，一并删除
+- 清除 dev↔review cycle state，避免 cycle-cap 旧记录继续卡住后续派发
+- 如果能连到运行中的 coordinator（显式 `--coordinator`），会额外调用 `POST /api/v1/admin/issues/{owner}/{repo}/{issue}/clear-inflight` 清掉进程内 inflight map
+- 如果 coordinator 当时不可达，下一次 dispatch 也会基于 `task_queue` 自愈：当 backing task 行已删除、已变成 `failed`/`timeout`，或 lease 过期超过 `5×lease_duration` 时，会自动丢弃泄漏的 inflight 记录并继续派发
 - 记录 `issue_restarted` 事件，方便事后审计
 - `workbuddy admin restart-issue ...` 仍可用，但会在 stderr 打印 deprecation warning
 
 相比直接操作 SQLite，这个命令把手工恢复流程固化成了可审计的 CLI。
+
+`dispatch_skipped_inflight` 事件现在带 `task_status` 字段，operator 直接看事件流就能区分“确实还在跑”（例如 `pending` / `running`）还是“内存 inflight 泄漏”（`gone` / `failed` / `timeout`）。
 
 ### diagnose（REQ-037）
 

--- a/internal/app/coordinator.go
+++ b/internal/app/coordinator.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -111,6 +112,51 @@ type TaskHeartbeatRequest struct {
 type TaskReleaseRequest struct {
 	WorkerID string `json:"worker_id"`
 	Reason   string `json:"reason,omitempty"`
+}
+
+// HandleClearIssueInflight serves
+// POST /api/v1/admin/issues/{owner}/{repo}/{issue_num}/clear-inflight.
+func (s *FullCoordinatorServer) HandleClearIssueInflight(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		CoordWriteJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	repo, issueNum, ok := parseClearIssueInflightPath(r.URL.Path)
+	if !ok {
+		CoordWriteJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid issue path; expect /api/v1/admin/issues/<owner>/<repo>/<num>/clear-inflight"})
+		return
+	}
+	if s.Pollers == nil {
+		CoordWriteJSON(w, http.StatusNotFound, map[string]string{"error": "poller manager unavailable"})
+		return
+	}
+	snapshot, cleared := s.Pollers.ClearInflight(repo, issueNum)
+	if !cleared || snapshot == nil {
+		CoordWriteJSON(w, http.StatusNotFound, map[string]string{"error": "no inflight entry for issue"})
+		return
+	}
+	CoordWriteJSON(w, http.StatusOK, map[string]any{
+		"repo":      repo,
+		"issue_num": issueNum,
+		"group":     snapshot,
+	})
+}
+
+func parseClearIssueInflightPath(path string) (string, int, bool) {
+	trimmed := strings.TrimPrefix(path, "/api/v1/admin/issues/")
+	parts := strings.Split(strings.Trim(trimmed, "/"), "/")
+	if len(parts) < 4 || parts[len(parts)-1] != "clear-inflight" {
+		return "", 0, false
+	}
+	issueNum, err := strconv.Atoi(parts[len(parts)-2])
+	if err != nil || issueNum <= 0 {
+		return "", 0, false
+	}
+	repo := strings.Join(parts[:len(parts)-2], "/")
+	if strings.TrimSpace(repo) == "" {
+		return "", 0, false
+	}
+	return repo, issueNum, true
 }
 
 // HandleConfigReload serves POST /api/v1/config/reload.

--- a/internal/app/coordinator_test.go
+++ b/internal/app/coordinator_test.go
@@ -6,8 +6,15 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/Lincyaw/workbuddy/internal/config"
+	"github.com/Lincyaw/workbuddy/internal/poller"
+	"github.com/Lincyaw/workbuddy/internal/statemachine"
 	"github.com/Lincyaw/workbuddy/internal/store"
 )
+
+type noopEventRecorder struct{}
+
+func (noopEventRecorder) Log(string, string, int, interface{}) {}
 
 func newCoordinatorTestStore(t *testing.T) *store.Store {
 	t.Helper()
@@ -111,5 +118,73 @@ func TestWrapAuthRejectsRevokedAndUnregisteredWorkerTokens(t *testing.T) {
 				t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
 			}
 		})
+	}
+}
+
+func TestHandleClearIssueInflight(t *testing.T) {
+	st := newCoordinatorTestStore(t)
+	dispatchCh := make(chan statemachine.DispatchRequest, 1)
+	sm := statemachine.NewStateMachine(
+		map[string]*config.WorkflowConfig{"dev-flow": testWorkflowConfig()},
+		st,
+		dispatchCh,
+		noopEventRecorder{},
+		nil,
+	)
+	if err := sm.HandleEvent(t.Context(), statemachine.ChangeEvent{
+		Type:     poller.EventIssueCreated,
+		Repo:     "owner/repo",
+		IssueNum: 41,
+		Labels:   []string{"workbuddy", "status:developing"},
+	}); err != nil {
+		t.Fatalf("HandleEvent: %v", err)
+	}
+	select {
+	case <-dispatchCh:
+	case <-t.Context().Done():
+		t.Fatal("expected dispatch to create inflight state")
+	}
+
+	pm := &PollerManager{
+		rootCtx:  t.Context(),
+		store:    st,
+		runtimes: map[string]*RepoRuntime{"owner/repo": {StateMachine: sm}},
+	}
+	server := &FullCoordinatorServer{
+		Store:       st,
+		Pollers:     pm,
+		AuthEnabled: true,
+		AuthToken:   "shared-secret",
+	}
+	protected := server.WrapAuth(http.HandlerFunc(server.HandleClearIssueInflight))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/issues/owner/repo/41/clear-inflight", nil)
+	req.Header.Set("Authorization", "Bearer shared-secret")
+	rec := httptest.NewRecorder()
+	protected.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if sm.IsInflight("owner/repo", 41) {
+		t.Fatal("inflight entry should be cleared")
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/admin/issues/owner/repo/41/clear-inflight", nil)
+	req.Header.Set("Authorization", "Bearer shared-secret")
+	rec = httptest.NewRecorder()
+	protected.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("second clear status = %d, want %d body=%s", rec.Code, http.StatusNotFound, rec.Body.String())
+	}
+}
+
+func testWorkflowConfig() *config.WorkflowConfig {
+	return &config.WorkflowConfig{
+		Name:    "dev-flow",
+		Trigger: config.WorkflowTrigger{IssueLabel: "workbuddy"},
+		States: map[string]*config.State{
+			"developing": {EnterLabel: "status:developing", Agent: "dev-agent"},
+		},
 	}
 }

--- a/internal/app/repo_runtime.go
+++ b/internal/app/repo_runtime.go
@@ -491,6 +491,17 @@ func (pm *PollerManager) MarkAgentCompleted(repo string, issueNum int, taskID, a
 	runtime.StateMachine.MarkAgentCompleted(repo, issueNum, taskID, agentName, exitCode, currentLabels)
 }
 
+// ClearInflight removes one repo runtime's in-memory inflight entry.
+func (pm *PollerManager) ClearInflight(repo string, issueNum int) (*statemachine.InflightGroupSnapshot, bool) {
+	pm.mu.RLock()
+	runtime := pm.runtimes[repo]
+	pm.mu.RUnlock()
+	if runtime == nil {
+		return nil, false
+	}
+	return runtime.StateMachine.ClearInflight(repo, issueNum)
+}
+
 func (pm *PollerManager) handleEvent(ev poller.ChangeEvent) {
 	pm.mu.RLock()
 	runtime := pm.runtimes[ev.Repo]

--- a/internal/statemachine/statemachine.go
+++ b/internal/statemachine/statemachine.go
@@ -89,6 +89,12 @@ const (
 	stateNameBlocked    = "blocked"
 )
 
+const (
+	inflightTaskStatusGone        = "gone"
+	inflightLeaseExpiryMultiplier = 5
+	defaultTaskLease              = 30 * time.Second
+)
+
 // CycleCapReporter is the optional callback used by the StateMachine to post
 // a needs-human comment with the rejection-trail digest when an issue trips
 // the dev↔review cycle cap. The interface is satisfied by *reporter.Reporter
@@ -136,6 +142,41 @@ func newDispatchGroup(wf, state string, join config.JoinConfig, slots map[string
 		g.slots[key] = agentName
 	}
 	return g
+}
+
+// InflightGroupSnapshot is the operator-facing identity of one tracked
+// in-memory dispatch group.
+type InflightGroupSnapshot struct {
+	Workflow string            `json:"workflow"`
+	State    string            `json:"state"`
+	Join     string            `json:"join"`
+	Agents   []string          `json:"agents"`
+	Slots    map[string]string `json:"slots"`
+}
+
+func snapshotDispatchGroup(group *dispatchGroup) *InflightGroupSnapshot {
+	if group == nil {
+		return nil
+	}
+	agents := make([]string, 0, len(group.slots))
+	seen := make(map[string]struct{}, len(group.slots))
+	slots := make(map[string]string, len(group.slots))
+	for slotKey, agentName := range group.slots {
+		slots[slotKey] = agentName
+		if _, ok := seen[agentName]; ok {
+			continue
+		}
+		seen[agentName] = struct{}{}
+		agents = append(agents, agentName)
+	}
+	sort.Strings(agents)
+	return &InflightGroupSnapshot{
+		Workflow: group.workflow,
+		State:    group.state,
+		Join:     group.join.Strategy,
+		Agents:   agents,
+		Slots:    slots,
+	}
 }
 
 // StateMachine evaluates Poller events against workflow definitions,
@@ -669,6 +710,7 @@ func (sm *StateMachine) DispatchAgent(ctx context.Context, repo string, issueNum
 	} else if blocked {
 		return nil
 	}
+	sm.reconcileStaleInflight(repo, issueNum)
 	if blocked, err := sm.isBlockedByIssueClaim(repo, issueNum, agentName, workflow, state); err != nil {
 		return err
 	} else if blocked {
@@ -911,15 +953,17 @@ func (sm *StateMachine) dispatchSingleAgent(ctx context.Context, req DispatchReq
 	if existing, ok := sm.inflight[issueKey]; ok {
 		if existing.workflow != workflow || existing.state != state {
 			sm.inflightMu.Unlock()
+			taskStatus, _ := sm.inspectInflightTaskStatus(repo, issueNum, existing)
 			sm.eventlog.Log(eventlog.TypeDispatchSkippedInflight, repo, issueNum,
-				map[string]string{"agent": agentName, "reason": "different state/workflow already running", "state": state, "workflow": workflow})
+				map[string]string{"agent": agentName, "reason": "different state/workflow already running", "state": state, "task_status": taskStatus, "workflow": workflow})
 			return nil
 		}
 		// Same workflow+state: block if this slot was already dispatched.
 		if _, dispatched := existing.dispatchedSlots[slotKey]; dispatched {
 			sm.inflightMu.Unlock()
+			taskStatus, _ := sm.inspectInflightTaskStatus(repo, issueNum, existing)
 			sm.eventlog.Log(eventlog.TypeDispatchSkippedInflight, repo, issueNum,
-				map[string]string{"agent": agentName, "reason": "agent already dispatched", "state": state, "workflow": workflow})
+				map[string]string{"agent": agentName, "reason": "agent already dispatched", "state": state, "task_status": taskStatus, "workflow": workflow})
 			return nil
 		}
 		existing.dispatchedSlots[slotKey] = struct{}{}
@@ -987,6 +1031,7 @@ func (sm *StateMachine) dispatchStateAgents(ctx context.Context, repo string, is
 	} else if blocked {
 		return nil
 	}
+	sm.reconcileStaleInflight(repo, issueNum)
 
 	// Acquire the per-issue claim once for the whole group so concurrent
 	// coordinators sharing the same SQLite database cannot both dispatch a
@@ -1055,8 +1100,9 @@ func (sm *StateMachine) dispatchStateAgents(ctx context.Context, repo string, is
 			reason = "different state/workflow already running"
 		}
 		sm.inflightMu.Unlock()
+		taskStatus, _ := sm.inspectInflightTaskStatus(repo, issueNum, existing)
 		sm.eventlog.Log(eventlog.TypeDispatchSkippedInflight, repo, issueNum,
-			map[string]string{"state": state, "reason": reason, "workflow": wfName})
+			map[string]string{"state": state, "reason": reason, "task_status": taskStatus, "workflow": wfName})
 		return nil
 	}
 	sm.inflight[issueKey] = group
@@ -1468,6 +1514,194 @@ func (sm *StateMachine) IsInflight(repo string, issueNum int) bool {
 	defer sm.inflightMu.Unlock()
 	_, ok := sm.inflight[issueKey]
 	return ok
+}
+
+// ClearInflight removes the in-memory inflight entry for one issue and returns
+// the prior group identity. This is the manual escape hatch behind the
+// coordinator admin API; ordinary recovery should come from Dispatch's
+// task_queue-backed self-heal path.
+func (sm *StateMachine) ClearInflight(repo string, issueNum int) (*InflightGroupSnapshot, bool) {
+	issueKey := sm.issueKey(repo, issueNum)
+	sm.inflightMu.Lock()
+	group := sm.inflight[issueKey]
+	if group == nil {
+		sm.inflightMu.Unlock()
+		return nil, false
+	}
+	snapshot := snapshotDispatchGroup(group)
+	delete(sm.inflight, issueKey)
+	sm.inflightMu.Unlock()
+	sm.releaseIssueClaim(repo, issueNum)
+	return snapshot, true
+}
+
+func (sm *StateMachine) reconcileStaleInflight(repo string, issueNum int) {
+	issueKey := sm.issueKey(repo, issueNum)
+	sm.inflightMu.Lock()
+	group := sm.inflight[issueKey]
+	sm.inflightMu.Unlock()
+	if group == nil {
+		return
+	}
+	taskStatus, stale := sm.inspectInflightTaskStatus(repo, issueNum, group)
+	if !stale {
+		return
+	}
+	if !sm.clearInflightIfMatch(issueKey, group) {
+		return
+	}
+	sm.releaseIssueClaim(repo, issueNum)
+	log.Printf("[statemachine] reclaimed stale inflight group for %s task_status=%s", issueKey, taskStatus)
+}
+
+func (sm *StateMachine) clearInflightIfMatch(issueKey string, target *dispatchGroup) bool {
+	sm.inflightMu.Lock()
+	defer sm.inflightMu.Unlock()
+	current := sm.inflight[issueKey]
+	if current == nil || current != target {
+		return false
+	}
+	delete(sm.inflight, issueKey)
+	return true
+}
+
+func (sm *StateMachine) inspectInflightTaskStatus(repo string, issueNum int, group *dispatchGroup) (string, bool) {
+	if sm.store == nil || group == nil {
+		return "", false
+	}
+	tasks, err := sm.store.ListIssueTasks(repo, issueNum)
+	if err != nil {
+		log.Printf("[statemachine] inspect inflight task status for %s#%d: %v", repo, issueNum, err)
+		return "", false
+	}
+	slotKeys := make([]string, 0, len(group.slots))
+	for slotKey := range group.slots {
+		slotKeys = append(slotKeys, slotKey)
+	}
+	sort.Strings(slotKeys)
+
+	statusBySlot := make(map[string]string, len(slotKeys))
+	allReclaimable := len(slotKeys) > 0
+	for _, slotKey := range slotKeys {
+		task, ok := findInflightSlotTask(tasks, group, slotKey)
+		if !ok {
+			statusBySlot[slotKey] = inflightTaskStatusGone
+			continue
+		}
+		statusBySlot[slotKey] = task.Status
+		if inflightTaskKeepsGroupLive(task) {
+			allReclaimable = false
+		}
+	}
+	return formatInflightTaskStatus(slotKeys, statusBySlot), allReclaimable
+}
+
+func findInflightSlotTask(tasks []store.TaskRecord, group *dispatchGroup, slotKey string) (*store.TaskRecord, bool) {
+	wantAgent := group.slots[slotKey]
+	wantRollout := 0
+	if strings.HasPrefix(slotKey, "rollout:") {
+		idx, err := strconv.Atoi(strings.TrimPrefix(slotKey, "rollout:"))
+		if err != nil {
+			return nil, false
+		}
+		wantRollout = idx
+	}
+
+	var best *store.TaskRecord
+	for i := range tasks {
+		task := &tasks[i]
+		if task.Workflow != group.workflow || task.State != group.state {
+			continue
+		}
+		if wantRollout > 0 {
+			if task.RolloutIndex != wantRollout {
+				continue
+			}
+		} else {
+			if task.RolloutIndex != 0 || task.AgentName != wantAgent {
+				continue
+			}
+		}
+		if best == nil || taskRecency(task).After(taskRecency(best)) {
+			best = task
+		}
+	}
+	if best == nil {
+		return nil, false
+	}
+	return best, true
+}
+
+func taskRecency(task *store.TaskRecord) time.Time {
+	if task == nil {
+		return time.Time{}
+	}
+	if !task.UpdatedAt.IsZero() {
+		return task.UpdatedAt
+	}
+	return task.CreatedAt
+}
+
+func inflightTaskKeepsGroupLive(task *store.TaskRecord) bool {
+	if task == nil {
+		return false
+	}
+	switch task.Status {
+	case store.TaskStatusPending:
+		return true
+	case store.TaskStatusRunning:
+		if task.LeaseExpiresAt.IsZero() {
+			return true
+		}
+		lease := inferredTaskLease(task)
+		return time.Now().UTC().Before(task.LeaseExpiresAt.Add(inflightLeaseExpiryMultiplier * lease))
+	case store.TaskStatusCompleted:
+		return true
+	default:
+		return false
+	}
+}
+
+func inferredTaskLease(task *store.TaskRecord) time.Duration {
+	if task == nil || task.LeaseExpiresAt.IsZero() {
+		return defaultTaskLease
+	}
+	var leaseStart time.Time
+	switch {
+	case !task.HeartbeatAt.IsZero():
+		leaseStart = task.HeartbeatAt
+	case !task.AckedAt.IsZero():
+		leaseStart = task.AckedAt
+	}
+	if leaseStart.IsZero() {
+		return defaultTaskLease
+	}
+	lease := task.LeaseExpiresAt.Sub(leaseStart)
+	if lease <= 0 {
+		return defaultTaskLease
+	}
+	return lease
+}
+
+func formatInflightTaskStatus(slotKeys []string, statusBySlot map[string]string) string {
+	if len(slotKeys) == 0 {
+		return inflightTaskStatusGone
+	}
+	if len(slotKeys) == 1 {
+		if status := strings.TrimSpace(statusBySlot[slotKeys[0]]); status != "" {
+			return status
+		}
+		return inflightTaskStatusGone
+	}
+	parts := make([]string, 0, len(slotKeys))
+	for _, slotKey := range slotKeys {
+		status := strings.TrimSpace(statusBySlot[slotKey])
+		if status == "" {
+			status = inflightTaskStatusGone
+		}
+		parts = append(parts, fmt.Sprintf("%s=%s", slotKey, status))
+	}
+	return strings.Join(parts, ",")
 }
 
 func (sm *StateMachine) stateAgents(state *config.State) []string {

--- a/internal/statemachine/statemachine_test.go
+++ b/internal/statemachine/statemachine_test.go
@@ -461,6 +461,17 @@ func TestExecutionMutex(t *testing.T) {
 		t.Fatalf("HandleEvent 1: %v", err)
 	}
 	<-dispatch // drain; agent is now inflight
+	if err := sm.store.InsertTask(store.TaskRecord{
+		ID:        "task-review-live",
+		Repo:      "r",
+		IssueNum:  7,
+		AgentName: "review-agent",
+		Workflow:  "dev-flow",
+		State:     "reviewing",
+		Status:    store.TaskStatusRunning,
+	}); err != nil {
+		t.Fatalf("InsertTask: %v", err)
+	}
 
 	// Don't mark complete — agent still running.
 	sm.ResetDedup() // simulate new poll cycle
@@ -482,8 +493,168 @@ func TestExecutionMutex(t *testing.T) {
 	}
 
 	// Should have logged the skip.
-	if len(rec.find(eventlog.TypeDispatchSkippedInflight)) == 0 {
+	skips := rec.find(eventlog.TypeDispatchSkippedInflight)
+	if len(skips) == 0 {
 		t.Error("expected dispatch_skipped_inflight event")
+	}
+	payload, ok := skips[len(skips)-1].Payload.(map[string]string)
+	if !ok {
+		t.Fatalf("skip payload type = %T", skips[len(skips)-1].Payload)
+	}
+	if got := payload["task_status"]; got != store.TaskStatusRunning {
+		t.Fatalf("task_status = %q, want %q", got, store.TaskStatusRunning)
+	}
+}
+
+func TestDispatchSelfHealsDeletedInflightTask(t *testing.T) {
+	sm, _, dispatch := newTestSM(t)
+
+	if err := sm.HandleEvent(context.Background(), ChangeEvent{
+		Type:     poller.EventLabelAdded,
+		Repo:     "test/repo",
+		IssueNum: 207,
+		Labels:   []string{"workbuddy", "status:developing"},
+		Detail:   "status:reviewing",
+	}); err != nil {
+		t.Fatalf("HandleEvent 1: %v", err)
+	}
+	<-dispatch
+	if err := sm.store.InsertTask(store.TaskRecord{
+		ID:        "task-review-deleted",
+		Repo:      "test/repo",
+		IssueNum:  207,
+		AgentName: "review-agent",
+		Workflow:  "dev-flow",
+		State:     "reviewing",
+		Status:    store.TaskStatusRunning,
+	}); err != nil {
+		t.Fatalf("InsertTask: %v", err)
+	}
+	if _, err := sm.store.DB().Exec(`DELETE FROM task_queue WHERE id = ?`, "task-review-deleted"); err != nil {
+		t.Fatalf("delete task: %v", err)
+	}
+
+	sm.ResetDedup()
+	if err := sm.HandleEvent(context.Background(), ChangeEvent{
+		Type:     poller.EventLabelAdded,
+		Repo:     "test/repo",
+		IssueNum: 207,
+		Labels:   []string{"workbuddy", "status:reviewing"},
+		Detail:   "status:developing",
+	}); err != nil {
+		t.Fatalf("HandleEvent 2: %v", err)
+	}
+
+	select {
+	case req := <-dispatch:
+		if req.AgentName != "dev-agent" || req.State != "developing" {
+			t.Fatalf("unexpected redispatch: %+v", req)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected redispatch after stale inflight task row was deleted")
+	}
+}
+
+func TestDispatchSelfHealsFailedInflightTask(t *testing.T) {
+	sm, _, dispatch := newTestSM(t)
+
+	if err := sm.HandleEvent(context.Background(), ChangeEvent{
+		Type:     poller.EventLabelAdded,
+		Repo:     "test/repo",
+		IssueNum: 208,
+		Labels:   []string{"workbuddy", "status:developing"},
+		Detail:   "status:reviewing",
+	}); err != nil {
+		t.Fatalf("HandleEvent 1: %v", err)
+	}
+	<-dispatch
+	if err := sm.store.InsertTask(store.TaskRecord{
+		ID:        "task-review-failed",
+		Repo:      "test/repo",
+		IssueNum:  208,
+		AgentName: "review-agent",
+		Workflow:  "dev-flow",
+		State:     "reviewing",
+		Status:    store.TaskStatusFailed,
+	}); err != nil {
+		t.Fatalf("InsertTask: %v", err)
+	}
+
+	sm.ResetDedup()
+	if err := sm.HandleEvent(context.Background(), ChangeEvent{
+		Type:     poller.EventLabelAdded,
+		Repo:     "test/repo",
+		IssueNum: 208,
+		Labels:   []string{"workbuddy", "status:reviewing"},
+		Detail:   "status:developing",
+	}); err != nil {
+		t.Fatalf("HandleEvent 2: %v", err)
+	}
+
+	select {
+	case req := <-dispatch:
+		if req.AgentName != "dev-agent" || req.State != "developing" {
+			t.Fatalf("unexpected redispatch: %+v", req)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected redispatch after inflight task failed")
+	}
+}
+
+func TestDispatchSelfHealsExpiredInflightLease(t *testing.T) {
+	sm, _, dispatch := newTestSM(t)
+
+	if err := sm.HandleEvent(context.Background(), ChangeEvent{
+		Type:     poller.EventLabelAdded,
+		Repo:     "test/repo",
+		IssueNum: 209,
+		Labels:   []string{"workbuddy", "status:developing"},
+		Detail:   "status:reviewing",
+	}); err != nil {
+		t.Fatalf("HandleEvent 1: %v", err)
+	}
+	<-dispatch
+	if err := sm.store.InsertTask(store.TaskRecord{
+		ID:        "task-review-expired",
+		Repo:      "test/repo",
+		IssueNum:  209,
+		AgentName: "review-agent",
+		Workflow:  "dev-flow",
+		State:     "reviewing",
+		Status:    store.TaskStatusRunning,
+	}); err != nil {
+		t.Fatalf("InsertTask: %v", err)
+	}
+	now := time.Now().UTC()
+	leaseStart := now.Add(-7 * defaultTaskLease)
+	leaseExpiry := leaseStart.Add(defaultTaskLease)
+	if _, err := sm.store.DB().Exec(
+		`UPDATE task_queue SET heartbeat_at = ?, lease_expires_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
+		leaseStart.Format("2006-01-02 15:04:05"),
+		leaseExpiry.Format("2006-01-02 15:04:05"),
+		"task-review-expired",
+	); err != nil {
+		t.Fatalf("expire lease: %v", err)
+	}
+
+	sm.ResetDedup()
+	if err := sm.HandleEvent(context.Background(), ChangeEvent{
+		Type:     poller.EventLabelAdded,
+		Repo:     "test/repo",
+		IssueNum: 209,
+		Labels:   []string{"workbuddy", "status:reviewing"},
+		Detail:   "status:developing",
+	}); err != nil {
+		t.Fatalf("HandleEvent 2: %v", err)
+	}
+
+	select {
+	case req := <-dispatch:
+		if req.AgentName != "dev-agent" || req.State != "developing" {
+			t.Fatalf("unexpected redispatch: %+v", req)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected redispatch after inflight lease expired beyond grace window")
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -650,6 +650,37 @@ func (s *Store) GetTask(taskID string) (*TaskRecord, error) {
 	return &t, nil
 }
 
+// ListIssueTasks returns every task row for one issue, including terminal
+// tasks, ordered from oldest to newest.
+func (s *Store) ListIssueTasks(repo string, issueNum int) ([]TaskRecord, error) {
+	rows, err := s.db.Query(`SELECT
+		tq.id, tq.repo, tq.issue_num, tq.agent_name, ic.labels, tq.role, tq.runtime, tq.workflow, tq.state,
+		tq.worker_id, tq.claim_token, tq.status, tq.lease_expires_at, tq.acked_at, tq.heartbeat_at,
+		tq.completed_at, tq.exit_code, tq.session_refs, tq.rollout_index, tq.rollouts_total, tq.rollout_group_id, tq.supervisor_agent_id, tq.created_at, tq.updated_at
+		FROM task_queue tq
+		LEFT JOIN issue_cache ic
+		  ON ic.repo = tq.repo AND ic.issue_num = tq.issue_num
+		WHERE tq.repo = ? AND tq.issue_num = ?
+		ORDER BY tq.created_at, tq.id`, repo, issueNum)
+	if err != nil {
+		return nil, fmt.Errorf("store: list issue tasks: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []TaskRecord
+	for rows.Next() {
+		t, scanErr := scanTaskRecord(rows.Scan)
+		if scanErr != nil {
+			return nil, fmt.Errorf("store: scan issue task: %w", scanErr)
+		}
+		out = append(out, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("store: iterate issue tasks: %w", err)
+	}
+	return out, nil
+}
+
 // UpdateTaskSupervisorAgentID writes the supervisor-managed agent id onto a
 // task row. Used by the worker immediately after POSTing to the supervisor
 // IPC API so a coordinator-side resume path can find the agent on restart

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -4146,3 +4146,45 @@ requirements:
       - internal/recover/recover_test.go
       - internal/config/state_join_test.go
       - web/src/utils/sessionGroups.test.ts
+
+  - id: REQ-116
+    title: "Stale inflight dispatch groups self-heal and expose a clear-inflight escape hatch (#300)"
+    description: >
+      Issue #300 redoes the leaked inflight-dispatch fix on the post-#296
+      slot-based architecture. When an agent dies before the coordinator calls
+      `MarkAgentCompleted`, the in-memory inflight group can outlive its
+      backing `task_queue` rows and silently suppress all future redispatches
+      for that issue. Dispatch must now reconcile inflight groups against live
+      task rows, and operators need a write-authenticated admin endpoint plus a
+      CLI bridge to clear the in-memory tracker immediately when required.
+    rationale: >
+      Durable SQLite recovery and in-memory coordinator locking must converge
+      after crashes, redeploys, and zombie workers. Without reconciliation,
+      operators see endless `dispatch_skipped_inflight` events and the only
+      recovery path is a full coordinator restart.
+    priority: P1
+    version: v0.5.0
+    status: tested
+    acceptance_criteria:
+      - "AC-116-1: `internal/statemachine/statemachine.go` self-heals a tracked inflight group when all backing task rows are gone, terminal (`failed`/`timeout`/equivalent), or have leases expired beyond `5×lease_duration`; the stale inflight entry is dropped, the issue claim is released, and dispatch proceeds."
+      - "AC-116-2: `POST /api/v1/admin/issues/{owner}/{repo}/{issue_num}/clear-inflight` is auth-gated like other coordinator write routes, returns 200 with the cleared workflow/state/agents/slots snapshot when an inflight group existed, and 404 when nothing was tracked."
+      - "AC-116-3: `dispatch_skipped_inflight` event payloads include `task_status`, reporting the live backing task status (or `gone` when no backing row exists) so operators can distinguish real work from leaked tracker state."
+      - "AC-116-4: `workbuddy issue restart` calls the admin clear-inflight endpoint when `--coordinator` is configured, and its CLI help/docs explain the immediate push path plus the dispatch self-heal fallback."
+      - "AC-116-5: Tests cover stale inflight self-heal for deleted rows, failed rows, and lease-expired rows, plus the admin clear-inflight endpoint and the CLI restart bridge."
+    code:
+      - internal/statemachine/statemachine.go
+      - internal/store/store.go
+      - internal/app/coordinator.go
+      - internal/app/repo_runtime.go
+      - cmd/coordinator.go
+      - cmd/admin_restart_issue.go
+      - docs/implemented/pipeline-observability-and-diagnosis.md
+      - docs/implemented/distributed-topology-and-cli.md
+    tests:
+      - internal/statemachine/statemachine_test.go
+      - internal/app/coordinator_test.go
+      - cmd/admin_restart_issue_test.go
+    deps:
+      - REQ-060
+      - REQ-061
+      - REQ-086


### PR DESCRIPTION
Fixes #300

## What changed
- self-heal stale slot-based inflight groups from task_queue state
- add the admin clear-inflight endpoint and wire `workbuddy issue restart` to it
- expose inflight task status in skip events and sync docs/project index

## Validation
- go build ./...
- go vet ./...
- go test ./... -count=1
- go run . validate-docs --strict
- python3 ~/.autoharness/scripts/validate_index.py project-index.yaml