### PR TITLE
Fix escaped depends_on refs in dependency parser

### DIFF
--- a/internal/dependency/dependency.go
+++ b/internal/dependency/dependency.go
@@ -53,6 +53,7 @@ type ParsedDependency struct {
 	Status           string
 	Normalized       string
 	ParseErrorReason string
+	Line             int
 }
 
 type ParsedDeclaration struct {
@@ -78,23 +79,30 @@ func NewResolver(st *store.Store, reader IssueReader, eventlog EventRecorder, al
 }
 
 func ParseDeclaration(repo, body string) ParsedDeclaration {
-	matches := yamlFenceRe.FindAllStringSubmatch(body, -1)
+	matches := yamlFenceRe.FindAllStringSubmatchIndex(body, -1)
 	for _, match := range matches {
+		block := body[match[2]:match[3]]
 		var raw struct {
 			Workbuddy struct {
 				DependsOn []string `yaml:"depends_on"`
 			} `yaml:"workbuddy"`
 		}
-		if err := yaml.Unmarshal([]byte(match[1]), &raw); err != nil {
+		if err := yaml.Unmarshal([]byte(block), &raw); err != nil {
 			continue
 		}
 		if raw.Workbuddy.DependsOn == nil {
 			continue
 		}
+		blockStartLine := 1 + strings.Count(body[:match[2]], "\n")
+		linesByRaw := dependencyEntryLines(block, blockStartLine)
 		decl := ParsedDeclaration{HasBlock: true}
 		seen := make(map[string]struct{})
 		for _, dep := range raw.Workbuddy.DependsOn {
 			parsed := normalizeDependency(repo, dep)
+			if lines := linesByRaw[parsed.Raw]; len(lines) > 0 {
+				parsed.Line = lines[0]
+				linesByRaw[parsed.Raw] = lines[1:]
+			}
 			if parsed.Normalized != "" {
 				if _, ok := seen[parsed.Normalized]; ok {
 					continue
@@ -104,9 +112,15 @@ func ParseDeclaration(repo, body string) ParsedDeclaration {
 			decl.Dependencies = append(decl.Dependencies, parsed)
 		}
 		sort.Slice(decl.Dependencies, func(i, j int) bool {
-			return decl.Dependencies[i].Normalized < decl.Dependencies[j].Normalized
+			if decl.Dependencies[i].Normalized != decl.Dependencies[j].Normalized {
+				return decl.Dependencies[i].Normalized < decl.Dependencies[j].Normalized
+			}
+			if decl.Dependencies[i].Raw != decl.Dependencies[j].Raw {
+				return decl.Dependencies[i].Raw < decl.Dependencies[j].Raw
+			}
+			return decl.Dependencies[i].Line < decl.Dependencies[j].Line
 		})
-		decl.SourceHash = hashStrings(match[1], dependenciesSignature(decl.Dependencies))
+		decl.SourceHash = hashStrings(block, dependenciesSignature(decl.Dependencies))
 		return decl
 	}
 	return ParsedDeclaration{}
@@ -141,6 +155,9 @@ func (r *Resolver) EvaluateOpenIssues(ctx context.Context, repo string, graphVer
 	for num, issue := range openIssues {
 		decl := ParseDeclaration(repo, issue.Body)
 		parsedDecls[num] = decl
+		if err := r.syncMalformedDependencyHazard(repo, num, decl); err != nil {
+			return nil, err
+		}
 		deps := make([]store.IssueDependency, 0, len(decl.Dependencies))
 		for _, dep := range decl.Dependencies {
 			if dep.Repo == "" || dep.IssueNum <= 0 {
@@ -227,7 +244,7 @@ func (r *Resolver) publishAlert(eventKind string, severity alertbus.Severity, re
 		Kind:      eventKind,
 		Severity:  severity,
 		Repo:      repo,
-		IssueNum:   issueNum,
+		IssueNum:  issueNum,
 		AgentName: agentName,
 		Timestamp: time.Now().Unix(),
 		Payload:   payload,
@@ -333,10 +350,11 @@ func buildResolveResult(
 func normalizeDependency(repo, raw string) ParsedDependency {
 	raw = strings.TrimSpace(raw)
 	parsed := ParsedDependency{Raw: raw}
+	canonical := normalizeDependencyRef(raw)
 	switch {
-	case strings.HasPrefix(raw, "#"):
+	case strings.HasPrefix(canonical, "#"):
 		var num int
-		if _, err := fmt.Sscanf(raw, "#%d", &num); err != nil || num <= 0 {
+		if _, err := fmt.Sscanf(canonical, "#%d", &num); err != nil || num <= 0 {
 			parsed.Status = store.DependencyStatusInvalid
 			parsed.ParseErrorReason = "invalid_issue_number"
 			return parsed
@@ -344,8 +362,8 @@ func normalizeDependency(repo, raw string) ParsedDependency {
 		parsed.Repo = repo
 		parsed.IssueNum = num
 		parsed.Status = store.DependencyStatusActive
-	case fqIssueRefRe.MatchString(raw):
-		match := fqIssueRefRe.FindStringSubmatch(raw)
+	case fqIssueRefRe.MatchString(canonical):
+		match := fqIssueRefRe.FindStringSubmatch(canonical)
 		var num int
 		if _, err := fmt.Sscanf(match[3], "%d", &num); err != nil || num <= 0 {
 			parsed.Status = store.DependencyStatusInvalid
@@ -367,6 +385,150 @@ func normalizeDependency(repo, raw string) ParsedDependency {
 		parsed.Normalized = fmt.Sprintf("%s#%d", parsed.Repo, parsed.IssueNum)
 	}
 	return parsed
+}
+
+func normalizeDependencyRef(raw string) string {
+	raw = strings.TrimSpace(raw)
+	raw = strings.ReplaceAll(raw, `\"`, `"`)
+	raw = strings.ReplaceAll(raw, `\'`, `'`)
+	raw = stripMatchingQuotes(raw)
+	return strings.TrimSpace(raw)
+}
+
+func stripMatchingQuotes(raw string) string {
+	if len(raw) < 2 {
+		return raw
+	}
+	if raw[0] == '"' && raw[len(raw)-1] == '"' {
+		return raw[1 : len(raw)-1]
+	}
+	if raw[0] == '\'' && raw[len(raw)-1] == '\'' {
+		return raw[1 : len(raw)-1]
+	}
+	return raw
+}
+
+func dependencyEntryLines(block string, blockStartLine int) map[string][]int {
+	var root yaml.Node
+	if err := yaml.Unmarshal([]byte(block), &root); err != nil {
+		return nil
+	}
+	if len(root.Content) == 0 {
+		return nil
+	}
+	workbuddy := lookupMappingValue(root.Content[0], "workbuddy")
+	if workbuddy == nil {
+		return nil
+	}
+	dependsOn := lookupMappingValue(workbuddy, "depends_on")
+	if dependsOn == nil || dependsOn.Kind != yaml.SequenceNode {
+		return nil
+	}
+	lines := make(map[string][]int, len(dependsOn.Content))
+	for _, item := range dependsOn.Content {
+		if item.Kind != yaml.ScalarNode {
+			continue
+		}
+		lines[item.Value] = append(lines[item.Value], blockStartLine+item.Line-1)
+	}
+	return lines
+}
+
+func lookupMappingValue(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func invalidDependencies(deps []ParsedDependency) []ParsedDependency {
+	out := make([]ParsedDependency, 0)
+	for _, dep := range deps {
+		if dep.Status == store.DependencyStatusInvalid {
+			out = append(out, dep)
+		}
+	}
+	return out
+}
+
+func (r *Resolver) syncMalformedDependencyHazard(repo string, issueNum int, decl ParsedDeclaration) error {
+	invalid := invalidDependencies(decl.Dependencies)
+	if len(invalid) == 0 {
+		return r.clearPipelineHazardIfKind(repo, issueNum, store.HazardKindMalformedDependencyRef)
+	}
+	fingerprint := hashStrings("malformed_dependency_ref", decl.SourceHash, dependenciesSignature(invalid))
+	changed, err := r.store.UpsertIssuePipelineHazard(store.PipelineHazard{
+		Repo:        repo,
+		IssueNum:    issueNum,
+		Kind:        store.HazardKindMalformedDependencyRef,
+		Fingerprint: fingerprint,
+	})
+	if err != nil {
+		return fmt.Errorf("dependency: upsert malformed dependency hazard for %s#%d: %w", repo, issueNum, err)
+	}
+	if !changed || r.eventlog == nil {
+		return nil
+	}
+	r.eventlog.Log(eventlog.TypeIssueDependencyUnentered, repo, issueNum, map[string]any{
+		"reason":               "unparseable_ref",
+		"depends_on":           invalidDependencyRefs(invalid),
+		"invalid_dependencies": invalidDependencyPayload(invalid),
+		"hint":                 invalidDependencyHint(invalid),
+	})
+	return nil
+}
+
+func (r *Resolver) clearPipelineHazardIfKind(repo string, issueNum int, kind string) error {
+	prev, err := r.store.QueryIssuePipelineHazard(repo, issueNum)
+	if err != nil {
+		return fmt.Errorf("dependency: query pipeline hazard for %s#%d: %w", repo, issueNum, err)
+	}
+	if prev == nil || prev.Kind != kind {
+		return nil
+	}
+	if err := r.store.ClearIssuePipelineHazard(repo, issueNum); err != nil {
+		return fmt.Errorf("dependency: clear pipeline hazard for %s#%d: %w", repo, issueNum, err)
+	}
+	return nil
+}
+
+func invalidDependencyRefs(invalid []ParsedDependency) []string {
+	refs := make([]string, 0, len(invalid))
+	for _, dep := range invalid {
+		refs = append(refs, dep.Raw)
+	}
+	return refs
+}
+
+func invalidDependencyPayload(invalid []ParsedDependency) []map[string]any {
+	payload := make([]map[string]any, 0, len(invalid))
+	for _, dep := range invalid {
+		entry := map[string]any{
+			"raw":                dep.Raw,
+			"parse_error_reason": dep.ParseErrorReason,
+		}
+		if dep.Line > 0 {
+			entry["line"] = dep.Line
+		}
+		payload = append(payload, entry)
+	}
+	return payload
+}
+
+func invalidDependencyHint(invalid []ParsedDependency) string {
+	if len(invalid) == 0 {
+		return "edit the malformed depends_on entry so it uses `#<int>` or `owner/repo#<int>`"
+	}
+	dep := invalid[0]
+	if dep.Line > 0 {
+		return fmt.Sprintf("edit issue body line %d under `workbuddy.depends_on`: replace %q with `#<int>` or `owner/repo#<int>`", dep.Line, dep.Raw)
+	}
+	return fmt.Sprintf("edit the malformed `workbuddy.depends_on` entry %q so it uses `#<int>` or `owner/repo#<int>`", dep.Raw)
 }
 
 func detectCycles(graph map[int][]int) map[int][]string {

--- a/internal/dependency/dependency.go
+++ b/internal/dependency/dependency.go
@@ -35,6 +35,7 @@ const (
 )
 
 var yamlFenceRe = regexp.MustCompile("(?s)```yaml\\s*\n(.*?)```")
+var localIssueRefRe = regexp.MustCompile(`^#([1-9][0-9]*)$`)
 var fqIssueRefRe = regexp.MustCompile(`^([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)#([1-9][0-9]*)$`)
 
 type IssueReader interface {
@@ -352,7 +353,7 @@ func normalizeDependency(repo, raw string) ParsedDependency {
 	parsed := ParsedDependency{Raw: raw}
 	canonical := normalizeDependencyRef(raw)
 	switch {
-	case strings.HasPrefix(canonical, "#"):
+	case localIssueRefRe.MatchString(canonical):
 		var num int
 		if _, err := fmt.Sscanf(canonical, "#%d", &num); err != nil || num <= 0 {
 			parsed.Status = store.DependencyStatusInvalid

--- a/internal/dependency/dependency_test.go
+++ b/internal/dependency/dependency_test.go
@@ -1,0 +1,178 @@
+package dependency
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Lincyaw/workbuddy/internal/eventlog"
+	"github.com/Lincyaw/workbuddy/internal/poller"
+	"github.com/Lincyaw/workbuddy/internal/store"
+)
+
+type testEventRecord struct {
+	EventType string
+	Repo      string
+	IssueNum  int
+	Payload   any
+}
+
+type testEventRecorder struct {
+	records []testEventRecord
+}
+
+func (r *testEventRecorder) Log(eventType, repo string, issueNum int, payload interface{}) {
+	r.records = append(r.records, testEventRecord{
+		EventType: eventType,
+		Repo:      repo,
+		IssueNum:  issueNum,
+		Payload:   payload,
+	})
+}
+
+func (r *testEventRecorder) find(eventType string) []testEventRecord {
+	var out []testEventRecord
+	for _, record := range r.records {
+		if record.EventType == eventType {
+			out = append(out, record)
+		}
+	}
+	return out
+}
+
+type noopIssueReader struct{}
+
+func (noopIssueReader) ListIssues(string) ([]poller.Issue, error) { return nil, nil }
+
+func (noopIssueReader) ReadIssue(string, int) (poller.IssueDetails, error) {
+	return poller.IssueDetails{}, nil
+}
+
+func TestNormalizeDependencyHandlesEscapedQuotes(t *testing.T) {
+	repo := "Lincyaw/workbuddy"
+	tests := []struct {
+		name      string
+		raw       string
+		wantRepo  string
+		wantIssue int
+		wantState string
+		wantErr   string
+	}{
+		{
+			name:      "backslash quoted local ref",
+			raw:       `\"#292\"`,
+			wantRepo:  repo,
+			wantIssue: 292,
+			wantState: store.DependencyStatusActive,
+		},
+		{
+			name:      "quoted local ref",
+			raw:       `"#292"`,
+			wantRepo:  repo,
+			wantIssue: 292,
+			wantState: store.DependencyStatusActive,
+		},
+		{
+			name:      "bare local ref",
+			raw:       `#292`,
+			wantRepo:  repo,
+			wantIssue: 292,
+			wantState: store.DependencyStatusActive,
+		},
+		{
+			name:      "fully qualified same repo ref",
+			raw:       `Lincyaw/workbuddy#292`,
+			wantRepo:  repo,
+			wantIssue: 292,
+			wantState: store.DependencyStatusActive,
+		},
+		{
+			name:      "garbage is invalid",
+			raw:       `garbage`,
+			wantState: store.DependencyStatusInvalid,
+			wantErr:   "invalid_format",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizeDependency(repo, tc.raw)
+			if got.Repo != tc.wantRepo || got.IssueNum != tc.wantIssue {
+				t.Fatalf("normalizeDependency(%q) = repo=%q issue=%d, want repo=%q issue=%d", tc.raw, got.Repo, got.IssueNum, tc.wantRepo, tc.wantIssue)
+			}
+			if got.Status != tc.wantState {
+				t.Fatalf("normalizeDependency(%q) status = %q, want %q", tc.raw, got.Status, tc.wantState)
+			}
+			if got.ParseErrorReason != tc.wantErr {
+				t.Fatalf("normalizeDependency(%q) parse error = %q, want %q", tc.raw, got.ParseErrorReason, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestEvaluateOpenIssues_LogsMalformedDependencyHazard(t *testing.T) {
+	st, err := store.NewStore(t.TempDir() + "/dependency.db")
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	const (
+		repo     = "Lincyaw/workbuddy"
+		issueNum = 293
+	)
+
+	body := "Prelude\n\n```yaml\nworkbuddy:\n  depends_on:\n    - \\\"#292\\\"\n    - garbage\n```\n"
+	if err := st.UpsertIssueCache(store.IssueCache{
+		Repo:     repo,
+		IssueNum: issueNum,
+		Labels:   `["workbuddy","status:developing"]`,
+		Body:     body,
+		State:    "open",
+	}); err != nil {
+		t.Fatalf("UpsertIssueCache: %v", err)
+	}
+
+	rec := &testEventRecorder{}
+	resolver := NewResolver(st, noopIssueReader{}, rec, nil)
+	if _, err := resolver.EvaluateOpenIssues(context.Background(), repo, 1); err != nil {
+		t.Fatalf("EvaluateOpenIssues: %v", err)
+	}
+
+	hazard, err := st.QueryIssuePipelineHazard(repo, issueNum)
+	if err != nil {
+		t.Fatalf("QueryIssuePipelineHazard: %v", err)
+	}
+	if hazard == nil || hazard.Kind != store.HazardKindMalformedDependencyRef {
+		t.Fatalf("hazard = %+v, want malformed dependency ref hazard", hazard)
+	}
+
+	got := rec.find(eventlog.TypeIssueDependencyUnentered)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 issue_dependency_unentered event, got %d", len(got))
+	}
+	payload, _ := got[0].Payload.(map[string]any)
+	if payload["reason"] != "unparseable_ref" {
+		t.Fatalf("reason = %v, want unparseable_ref", payload["reason"])
+	}
+	invalid, _ := payload["invalid_dependencies"].([]map[string]any)
+	if len(invalid) != 1 {
+		t.Fatalf("invalid_dependencies = %#v, want 1 entry", payload["invalid_dependencies"])
+	}
+	if invalid[0]["raw"] != "garbage" {
+		t.Fatalf("invalid dependency raw = %v, want garbage", invalid[0]["raw"])
+	}
+	if invalid[0]["parse_error_reason"] != "invalid_format" {
+		t.Fatalf("invalid dependency parse_error_reason = %v, want invalid_format", invalid[0]["parse_error_reason"])
+	}
+	if invalid[0]["line"] != 7 {
+		t.Fatalf("invalid dependency line = %v, want 7", invalid[0]["line"])
+	}
+
+	deps, err := st.ListIssueDependencies(repo, issueNum)
+	if err != nil {
+		t.Fatalf("ListIssueDependencies: %v", err)
+	}
+	if len(deps) != 1 || deps[0].DependsOnIssueNum != 292 {
+		t.Fatalf("persisted dependencies = %+v, want normalized #292 only", deps)
+	}
+}

--- a/internal/dependency/dependency_test.go
+++ b/internal/dependency/dependency_test.go
@@ -79,6 +79,12 @@ func TestNormalizeDependencyHandlesEscapedQuotes(t *testing.T) {
 			wantState: store.DependencyStatusActive,
 		},
 		{
+			name:      "local ref must match entire shape",
+			raw:       `#292garbage`,
+			wantState: store.DependencyStatusInvalid,
+			wantErr:   "invalid_format",
+		},
+		{
 			name:      "fully qualified same repo ref",
 			raw:       `Lincyaw/workbuddy#292`,
 			wantRepo:  repo,

--- a/internal/diagnose/diagnose.go
+++ b/internal/diagnose/diagnose.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Lincyaw/workbuddy/internal/config"
+	"github.com/Lincyaw/workbuddy/internal/dependency"
 	recoverpkg "github.com/Lincyaw/workbuddy/internal/recover"
 	"github.com/Lincyaw/workbuddy/internal/store"
 )
@@ -278,8 +279,8 @@ func analyzeWithConfig(st *store.Store, repo string, now time.Time, cfg diagnose
 			Repo:         h.Repo,
 			IssueNum:     h.IssueNum,
 			Severity:     SeverityWarn,
-			Diagnosis:    pipelineHazardDiagnosis(h.Kind),
-			SuggestedFix: pipelineHazardSuggestedFix(h.Kind),
+			Diagnosis:    pipelineHazardDiagnosis(st, h),
+			SuggestedFix: pipelineHazardSuggestedFix(st, h),
 		})
 	}
 
@@ -594,26 +595,59 @@ func parseFailureKey(raw string) (string, int, string) {
 	return parts[0], issueNum, parts[2]
 }
 
-func pipelineHazardDiagnosis(kind string) string {
-	switch kind {
+func pipelineHazardDiagnosis(st *store.Store, hazard store.PipelineHazard) string {
+	switch hazard.Kind {
 	case store.HazardKindNoWorkflowMatch:
 		return "issue carries a status:* label but no workflow trigger label matched, so the state machine cannot enter it"
 	case store.HazardKindAwaitingStatusLabel:
 		return "issue declares depends_on but has no status:* label, so the state machine cannot enter it and the dependency gate cannot release downstream work"
+	case store.HazardKindMalformedDependencyRef:
+		if dep, ok := firstInvalidDependency(st, hazard); ok {
+			if dep.Line > 0 {
+				return fmt.Sprintf("issue declares an unparseable depends_on ref at line %d (%q), so the resolver dropped it and dependency gating may stay stuck", dep.Line, dep.Raw)
+			}
+			return fmt.Sprintf("issue declares an unparseable depends_on ref (%q), so the resolver dropped it and dependency gating may stay stuck", dep.Raw)
+		}
+		return "issue declares an unparseable depends_on ref, so the resolver dropped it and dependency gating may stay stuck"
 	default:
-		return fmt.Sprintf("pipeline hazard: %s", kind)
+		return fmt.Sprintf("pipeline hazard: %s", hazard.Kind)
 	}
 }
 
-func pipelineHazardSuggestedFix(kind string) string {
-	switch kind {
+func pipelineHazardSuggestedFix(st *store.Store, hazard store.PipelineHazard) string {
+	switch hazard.Kind {
 	case store.HazardKindNoWorkflowMatch:
 		return "add the workflow trigger label, e.g. `workbuddy`"
 	case store.HazardKindAwaitingStatusLabel:
 		return "add `status:blocked` so the gate can evaluate, or `status:developing` if the deps are already satisfied"
+	case store.HazardKindMalformedDependencyRef:
+		if dep, ok := firstInvalidDependency(st, hazard); ok {
+			if dep.Line > 0 {
+				return fmt.Sprintf("edit issue body line %d under `workbuddy.depends_on`: replace `%s` with `#<int>` or `owner/repo#<int>`, then run `workbuddy cache invalidate --repo %s --issue %d`", dep.Line, dep.Raw, hazard.Repo, hazard.IssueNum)
+			}
+			return fmt.Sprintf("edit the malformed `workbuddy.depends_on` entry `%s` so it uses `#<int>` or `owner/repo#<int>`, then run `workbuddy cache invalidate --repo %s --issue %d`", dep.Raw, hazard.Repo, hazard.IssueNum)
+		}
+		return fmt.Sprintf("fix the malformed `workbuddy.depends_on` entry so it uses `#<int>` or `owner/repo#<int>`, then run `workbuddy cache invalidate --repo %s --issue %d`", hazard.Repo, hazard.IssueNum)
 	default:
 		return "inspect issue labels and body; clear the hazard once the configuration is complete"
 	}
+}
+
+func firstInvalidDependency(st *store.Store, hazard store.PipelineHazard) (dependency.ParsedDependency, bool) {
+	if st == nil {
+		return dependency.ParsedDependency{}, false
+	}
+	cache, err := st.QueryIssueCache(hazard.Repo, hazard.IssueNum)
+	if err != nil || cache == nil {
+		return dependency.ParsedDependency{}, false
+	}
+	decl := dependency.ParseDeclaration(hazard.Repo, cache.Body)
+	for _, dep := range decl.Dependencies {
+		if dep.Status == store.DependencyStatusInvalid {
+			return dep, true
+		}
+	}
+	return dependency.ParsedDependency{}, false
 }
 
 func issueKey(repo string, issueNum int) string {

--- a/internal/diagnose/diagnose_test.go
+++ b/internal/diagnose/diagnose_test.go
@@ -111,6 +111,56 @@ func TestAnalyzeHeartbeatOnlyZombieSignals(t *testing.T) {
 	})
 }
 
+func TestAnalyzePipelineHazard_MalformedDependencyRefIncludesLineHint(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	restore := stubTaskProcesses(func() ([]taskProcess, error) { return nil, nil })
+	defer restore()
+
+	st, _ := newDiagnoseStore(t)
+	defer func() { _ = st.Close() }()
+
+	const (
+		repo     = "Lincyaw/workbuddy"
+		issueNum = 293
+	)
+
+	body := "Prelude\n\n```yaml\nworkbuddy:\n  depends_on:\n    - \\\"#292\\\"\n    - garbage\n```\n"
+	if err := st.UpsertIssueCache(store.IssueCache{
+		Repo:     repo,
+		IssueNum: issueNum,
+		Labels:   `["workbuddy","status:developing"]`,
+		Body:     body,
+		State:    "open",
+	}); err != nil {
+		t.Fatalf("UpsertIssueCache: %v", err)
+	}
+	if _, err := st.UpsertIssuePipelineHazard(store.PipelineHazard{
+		Repo:        repo,
+		IssueNum:    issueNum,
+		Kind:        store.HazardKindMalformedDependencyRef,
+		Fingerprint: "fp",
+	}); err != nil {
+		t.Fatalf("UpsertIssuePipelineHazard: %v", err)
+	}
+
+	findings, err := analyzeWithConfig(st, repo, now, diagnoseConfig{})
+	if err != nil {
+		t.Fatalf("analyzeWithConfig: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("findings=%d, want 1: %+v", len(findings), findings)
+	}
+	if findings[0].Kind != KindPipelineHazard {
+		t.Fatalf("kind=%q, want %q", findings[0].Kind, KindPipelineHazard)
+	}
+	if !strings.Contains(findings[0].Diagnosis, `line 7`) || !strings.Contains(findings[0].Diagnosis, `"garbage"`) {
+		t.Fatalf("diagnosis=%q, want line-specific malformed ref context", findings[0].Diagnosis)
+	}
+	if !strings.Contains(findings[0].SuggestedFix, "line 7") || !strings.Contains(findings[0].SuggestedFix, "`garbage`") {
+		t.Fatalf("suggested_fix=%q, want line-specific edit hint", findings[0].SuggestedFix)
+	}
+}
+
 type runningTaskFixture struct {
 	repo         string
 	issueNum     int

--- a/internal/eventlog/eventlog.go
+++ b/internal/eventlog/eventlog.go
@@ -61,11 +61,11 @@ const (
 	// i.e. the issue cannot enter the state machine. Idempotent per
 	// (labels) fingerprint via the issue_pipeline_hazards table. See REQ #255.
 	TypeIssueNoWorkflowMatch = "issue_no_workflow_match"
-	// TypeIssueDependencyUnentered fires when an issue carries a workflow
-	// trigger label and a workbuddy.depends_on declaration but no status:*
-	// label, so the state machine cannot enter the issue and the dependency
-	// gate cannot release downstream work. Idempotent per (labels+depends_on)
-	// fingerprint. See REQ #255.
+	// TypeIssueDependencyUnentered fires when dependency declarations are
+	// present but cannot fully enter the normal dependency flow: either the
+	// issue lacks a status:* label, or at least one depends_on ref is
+	// malformed and dropped. Idempotent per hazard fingerprint. See REQ #255
+	// and #303.
 	TypeIssueDependencyUnentered = "issue_dependency_unentered"
 	// TypeCoordinatorStarted is emitted at the tail of coordinator/serve startup
 	// (after the HTTP listener is reserved). Payload carries listen address,

--- a/internal/statemachine/statemachine.go
+++ b/internal/statemachine/statemachine.go
@@ -2031,6 +2031,7 @@ func (sm *StateMachine) detectDependencyUnenteredHazard(wf *config.WorkflowConfi
 	}
 	sm.eventlog.Log(eventlog.TypeIssueDependencyUnentered, event.Repo, event.IssueNum, map[string]any{
 		"workflow":   wf.Name,
+		"reason":     "missing_status_label",
 		"labels":     append([]string(nil), event.Labels...),
 		"depends_on": deps,
 		"hint":       "add status:blocked so the dependency gate can evaluate, or status:developing if the deps are already satisfied",

--- a/internal/store/pipeline_hazards.go
+++ b/internal/store/pipeline_hazards.go
@@ -18,6 +18,11 @@ const (
 	// machine never enters the issue and the dependency gate cannot release
 	// downstream work.
 	HazardKindAwaitingStatusLabel = "awaiting-status-label"
+	// HazardKindMalformedDependencyRef — issue declares workbuddy.depends_on
+	// but at least one dependency ref could not be normalized into #<int> or
+	// owner/repo#<int>, so the resolver dropped it and the issue may remain
+	// blocked until the body is fixed.
+	HazardKindMalformedDependencyRef = "malformed-dependency-ref"
 )
 
 // PipelineHazard records a per-issue configuration-incompleteness condition.
@@ -75,8 +80,8 @@ func (s *Store) QueryIssuePipelineHazard(repo string, issueNum int) (*PipelineHa
 		repo, issueNum,
 	)
 	var (
-		out    PipelineHazard
-		rawTS  string
+		out   PipelineHazard
+		rawTS string
 	)
 	err := row.Scan(&out.Repo, &out.IssueNum, &out.Kind, &out.Fingerprint, &rawTS)
 	if err == sql.ErrNoRows {

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -4257,3 +4257,35 @@ requirements:
       - internal/validate/template_schema_test.go
     deps:
       - REQ-115
+
+  - id: REQ-118
+    title: "Normalize escaped depends_on refs and surface malformed entries (#303)"
+    description: >
+      Issue #303 hardens the dependency declaration parser against shell- or
+      JSON-escaped issue refs that leak into issue-body YAML literally (for
+      example `\\\"#292\\\"`). The parser now normalizes surrounding quotes
+      and backslash-quoted quotes at the parsing boundary, validates the
+      resulting ref shape, records malformed entries with structured
+      `issue_dependency_unentered` warning payloads, persists a
+      `malformed-dependency-ref` pipeline hazard for diagnose/status
+      surfaces, and points operators at the offending issue-body line.
+    priority: P1
+    version: v0.5.0
+    status: tested
+    acceptance_criteria:
+      - "AC-118-1: dependency.ParseDeclaration / normalizeDependency trims whitespace, unescapes `\\\"` and `\\'`, strips one matching surrounding quote pair, and resolves `\\\"#292\\\"`, `\"#292\"`, and `#292` to the same local dependency target."
+      - "AC-118-2: dependency refs are accepted only when they match `#<int>` or `<owner>/<repo>#<int>` after normalization (anchored regex `^#[1-9][0-9]*$`); malformed refs like `#292garbage` are reported via `issue_dependency_unentered` with `reason=unparseable_ref` plus per-entry parse metadata."
+      - "AC-118-3: unit tests cover escaped/local/fq refs and invalid garbage input including suffix garbage, plus malformed-entry warning payloads and persisted dependency rows."
+      - "AC-118-4: malformed refs create a `pipeline_hazard` / `malformed-dependency-ref` diagnose finding with `severity=warn` and a suggested fix that points to the offending issue-body line."
+      - "AC-118-5: `go build ./...`, `go vet ./...`, and `go test ./... -count=1` pass after the change."
+    code:
+      - internal/dependency/dependency.go
+      - internal/eventlog/eventlog.go
+      - internal/store/pipeline_hazards.go
+      - internal/statemachine/statemachine.go
+      - internal/diagnose/diagnose.go
+      - project-index.yaml
+    tests:
+      - internal/dependency/dependency_test.go
+      - internal/diagnose/diagnose_test.go
+    deps: []


### PR DESCRIPTION
Fixes #303

## What changed
- normalize literal backslash-quoted dependency refs at the parser boundary
- record malformed depends_on entries as structured dependency warning events + pipeline hazards
- surface line-specific diagnose guidance for malformed refs
- add parser/diagnose tests and update project-index coverage

## Verification
- go build ./...
- go vet ./...
- go test ./... -count=1
- go run . validate-docs --strict
- python3 ~/.autoharness/scripts/validate_index.py project-index.yaml