### PR TITLE
auditapi: tolerate ErrTaskNotFound in worker-side session listing

### DIFF
--- a/internal/auditapi/handler.go
+++ b/internal/auditapi/handler.go
@@ -1805,6 +1805,14 @@ func (h *Handler) sessionTaskStats(record store.SessionRecord) (int, string, *ti
 	}
 	task, err := h.store.GetTask(record.TaskID)
 	if err != nil {
+		// Worker DBs don't keep terminal task_queue rows around (the row
+		// is acked + deleted on completion), so a missing task is the
+		// normal case for finished sessions on the worker-side audit
+		// listener. Treat ErrTaskNotFound like the task==nil branch
+		// rather than bubbling it up as a 500.
+		if errors.Is(err, store.ErrTaskNotFound) {
+			return exitCode, status, finishedAt, nil
+		}
 		return 0, "", nil, fmt.Errorf("get task %s: %w", record.TaskID, err)
 	}
 	if task == nil {


### PR DESCRIPTION
## Summary

v0.5.0 hotfix. Found while deploying the session-data-ownership refactor: every `/api/v1/sessions` call against the worker-side audit listener returned 500 "failed to query sessions".

Cause: workers ack and delete terminal task_queue rows on completion, so finished sessions on the worker-side audit listener almost always have a `TaskID` that no longer resolves. `sessionTaskStats` wrapped `GetTask`'s `ErrTaskNotFound` in `fmt.Errorf` and bubbled it up as a 500.

Treat `ErrTaskNotFound` the same as `task == nil` — fall through with the record's own status / closed_at. Coordinator-side behavior unchanged (coord keeps task_queue rows around).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/auditapi/ -count=1` green
- [x] Manually verified live: worker-side `curl http://100.90.170.69:8091/api/v1/sessions` returns the expected rows; coordinator proxy now returns sessions as `completed` instead of empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)