### PR TITLE
worker: force HTTP/1.1 for tunnel dial to avoid HTTP/2 ALPN fallback

### DIFF
--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -938,5 +938,8 @@ func workerTunnelHTTPClient(opts *workerOpts) *http.Client {
 		log.Printf("[worker] tunnel CA cert is invalid: %s", opts.caCert)
 		return http.DefaultClient
 	}
-	return &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool}}}
+	return &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{RootCAs: pool, NextProtos: []string{"http/1.1"}},
+		TLSNextProto:    map[string]func(string, *tls.Conn) http.RoundTripper{},
+	}}
 }


### PR DESCRIPTION
## Summary

- Worker tunnel dial was breaking against TLS coordinators because Go's default `http.Transport` auto-negotiates HTTP/2 via ALPN; classic WebSocket (RFC 6455) requires HTTP/1.1 and `nhooyr.io/websocket` does not implement RFC 8441 over HTTP/2.
- Coordinator saw a non-GET request on `/api/v1/workers/tunnel` and returned 405; tunnel never connected and live session viewing was broken.
- Pin `TLSClientConfig.NextProtos` to `http/1.1` and zero out `TLSNextProto` so ALPN negotiates HTTP/1.1 only.

Reproduces against today's `v0.6.3` whenever coordinator is behind native TLS (`--tls-cert/--tls-key`). Verified locally: with the fix, `[worker] coordinator tunnel connected` shows up immediately.

## Test plan

- [x] `go build ./... && go vet ./... && go test ./... -count=1`
- [x] Local hot-swap worker against TLS coordinator at https://101.96.215.245:8090 — tunnel connects, `/api/v1/workers/tunnel` returns 101
- [ ] CI passes