### PR TITLE
tunnel: wire session events handler on worker; raise WS read limit

### DIFF
--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -938,5 +938,8 @@ func workerTunnelHTTPClient(opts *workerOpts) *http.Client {
 		log.Printf("[worker] tunnel CA cert is invalid: %s", opts.caCert)
 		return http.DefaultClient
 	}
-	return &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool}}}
+	return &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{RootCAs: pool, NextProtos: []string{"http/1.1"}},
+		TLSNextProto:    map[string]func(string, *tls.Conn) http.RoundTripper{},
+	}}
 }

--- a/cmd/worker_repos.go
+++ b/cmd/worker_repos.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/Lincyaw/workbuddy/internal/auditapi"
 	"github.com/Lincyaw/workbuddy/internal/store"
+	"github.com/Lincyaw/workbuddy/internal/webui"
 	"github.com/Lincyaw/workbuddy/internal/workerclient"
 	"github.com/spf13/cobra"
 )
@@ -229,6 +230,10 @@ func startWorkerMgmtServer(mgmtAddr, addrFile, authToken string, bindings *worke
 	if st != nil {
 		sessionAPI := auditapi.NewHandler(st)
 		sessionAPI.SetSessionsDir(sessionsDir)
+		sessionUI := webui.NewHandler(st)
+		sessionUI.SetSessionsDir(sessionsDir)
+		sessionAPI.SetSessionEventsHandler(sessionUI.HandleAPISessionEvents)
+		sessionAPI.SetSessionStreamHandler(sessionUI.HandleAPISessionStream)
 		sessionAPIMux := http.NewServeMux()
 		sessionAPI.RegisterSessionsOnly(sessionAPIMux)
 		sessionAPI.RegisterAPISessions(sessionAPIMux)

--- a/internal/wstunnel/tunnel.go
+++ b/internal/wstunnel/tunnel.go
@@ -51,7 +51,16 @@ type Endpoint struct {
 	next     atomic.Uint64
 }
 
+// MaxFrameBytes caps a single tunnel WebSocket message at 64 MiB. The
+// default nhooyr/websocket limit is 32 KiB, far too small for session
+// listings or events responses that are buffered into one frame today
+// (REQ-132 will introduce body streaming).
+const MaxFrameBytes = 64 << 20
+
 func NewEndpoint(conn *websocket.Conn) *Endpoint {
+	if conn != nil {
+		conn.SetReadLimit(MaxFrameBytes)
+	}
 	return &Endpoint{
 		conn:     conn,
 		streams:  make(map[string]chan Frame),


### PR DESCRIPTION
## Summary

Two follow-ups to REQ-131 surfaced once the SPA started loading tunneled session detail at `/sessions/<id>`:

1. **Worker mgmt missing events/stream wiring.** Worker's `auditapi.Handler` had `RegisterAPISessions` but never `SetSessionEventsHandler`/`SetSessionStreamHandler`. Coordinator-only wiring meant `/api/v1/sessions/{id}/events` through the tunnel returned 404 `session events not configured` from the worker's own handler. Mirror the coordinator setup with `webui.NewHandler(st)`.
2. **WS default read limit too small.** `coder/websocket` defaults `SetReadLimit` to 32 KiB. Today's events listings are buffered into one frame (REQ-132 will introduce streaming) and routinely exceed 32 KiB, so the tunnel was tearing down with `message too big: read limited at 32769 bytes`. Bump to 64 MiB until REQ-132 lands.

Verified locally end-to-end: `/api/v1/sessions/<id>/events` over TLS+tunnel returns full JSON (~700 KB) without tearing the tunnel.

## Test plan
- [x] `go build ./... && go vet ./... && go test ./... -count=1`
- [x] Local hot-swap both ends, request session events through tunnel — full response delivered, no tunnel disconnect
- [ ] CI passes