### PR TITLE
v0.5: agentm runtime + invocation contract (#315)

### DIFF
--- a/docs/decisions/2026-05-13-k8s-agentm-otel.md
+++ b/docs/decisions/2026-05-13-k8s-agentm-otel.md
@@ -1,0 +1,156 @@
+# K8s-ification + AgentM Runtime + OTel End-to-End Tracing
+
+- Date: 2026-05-13
+- Status: accepted
+- Target versions: v0.5 (in-process changes), v0.6 (K8s path)
+
+## Context
+
+Workbuddy today runs as `coordinator + worker` processes on hosts (systemd / `serve` mode), dispatches agents as host subprocesses (`claude-code`, `codex`), and persists state in SQLite. OTel tracing landed in 8b72e81 covering Go-internal spans across coordinator/worker/pipeline.
+
+Three pressures motivate the next step:
+
+1. **Service-ification.** Helm-chart deployment so workbuddy can be scheduled into the same cluster as other internal services.
+2. **Per-repo execution environments.** Each repo should be developed in its own dev container image; today the agent inherits whatever the worker host has installed.
+3. **Trace continuity.** A given issue's lifecycle (label → dispatch → agent → PR → review → merge) should be observable as one trace, not scattered across disjoint operations.
+
+Two adjacent codebases inform the design:
+
+- **AgentM** (`../AgentM`): Python pluggable agent SDK, OTel-aware.
+- **agent-env** (`../agent-env`, a.k.a. ARL-Infra): K8s operator with Gateway API, SandboxSession abstraction, per-image isolation. Already has its own Helm chart.
+
+Also:
+
+- **AegisLab** (`../aegis/AegisLab`): provides shared MySQL and OTel collector in-cluster — workbuddy will reuse these rather than ship its own.
+
+## Design principles
+
+- The systemd path and the K8s path coexist as parallel deployment modes. K8s is additive; systemd users see no regression.
+- K8s mode pays the cost of breaking changes (DB engine, agent isolation model) in exchange for clean isolation and observability.
+- agent-env is used **thin**: only as a sandbox provider. Warm pool stays off; workbuddy's per-issue runs are minutes-long and don't benefit from sub-second pod-start latency.
+- Agent boundaries are decided by **execution location**, not by runtime name (with one exception, noted in Block 2).
+
+## Block 1 — AgentM as a third runtime
+
+**Changes**
+
+- Add `agentm` to the `runtime` enum alongside `claude-code` / `codex`.
+- Define AgentM invocation contract:
+  - Inputs: issue context, acceptance criteria, repo workspace path, `TRACEPARENT` env var.
+  - Outputs: structured JSON containing `success | fail`, suggested `next_label`, artifact path, session log path.
+- AgentM's CLI mode must accept the above inputs and emit a session artifact in the format workbuddy's session-data layer expects (conversation events + tool-call history).
+- Trace propagation: AgentM's OTel SDK reads `TRACEPARENT` and continues the parent span.
+
+**Cross-repo work**: small adapter PR to AgentM if its CLI contract doesn't already match.
+
+## Block 2 — agent-env as execution environment
+
+### Two execution modes
+
+| Mode                  | Who handles git / `gh issue edit` | Who holds credentials       |
+|-----------------------|-----------------------------------|------------------------------|
+| Self-managed          | Agent (Agent-as-Router preserved) | Agent process               |
+| Coordinator-managed   | Coordinator                       | Coordinator only            |
+
+Coordinator-managed mode breaks the original "agent calls `gh issue edit` to drive the state machine" contract. Agent instead returns a structured result; coordinator executes the corresponding git push, PR creation, and label change.
+
+### Mode selection (deployment matrix)
+
+| runtime     | systemd (host)  | K8s (sandbox)        |
+|-------------|------------------|----------------------|
+| claude-code | self-managed     | **not supported**    |
+| codex       | self-managed     | **not supported**    |
+| agentm      | not supported    | coordinator-managed  |
+
+Rationale for refusing claude-code/codex inside sandbox: anyone reaching for K8s mode is buying isolation; allowing tokens-in-sandbox would defeat the value proposition. If real demand emerges later, revisit.
+
+### Architectural consequences
+
+- **Single-process model in K8s.** Coordinator absorbs the original worker's scheduling logic (claim, cycle counter, stale-claim sweep). The independent `workbuddy worker` binary is for systemd only.
+- **Workspace lifecycle.** Each session ephemerally `git clone`s into the sandbox, destroyed on session end. No PVC caching at v0.6; revisit only if clone latency becomes a real complaint.
+- **No credentials in sandbox.** No PAT injection. The `gh`/`git` write surface is concentrated in the coordinator process.
+- agent-env Gateway is called from coordinator with `create session(image, env) → exec → fetch artifacts → destroy`. The image is chosen per repo (config-declared or inferred from `.devcontainer/`).
+
+## Block 3 — Workbuddy Helm chart
+
+### Storage
+
+- **SQLite → MySQL.** The DB layer is abstracted behind an interface; SQLite stays as the systemd default, MySQL is the K8s default.
+- MySQL is **reused from AegisLab**; workbuddy's chart exposes `mysql.host` / `user` / `pass` / `db` values, no embedded MySQL.
+- Coordinator runs **single-replica** with `strategy: Recreate`. Brief restart-window outages are accepted. Horizontal scale-out is deferred (would require leader election or pervasive optimistic locking — not justified at current scale).
+
+### Chart layout
+
+- `workbuddy` and `agent-env` are **independent Helm releases** with values that reference each other (Gateway endpoint, OTel endpoint, MySQL DSN). Not bundled as subchart — agent-env has its own release cadence.
+- Agent configs (`.github/workbuddy/agents/*.md`) injected via ConfigMap. Updates require `helm upgrade` + pod restart. git-sync sidecar deferred.
+- Gitea token in K8s Secret. One org-level token; no per-repo PAT scoping (internal trust boundary).
+- Service: ClusterIP + Ingress (webui + webhook entrypoint).
+
+### Migration tool
+
+- `workbuddy db migrate --from sqlite --to mysql` for one-shot migration of existing installations.
+
+## Block 4 — OTel end-to-end
+
+### Collector
+
+- Reuse AegisLab's collector. Chart exposes `otel.endpoint`. No collector bundled with workbuddy.
+
+### Span coverage
+
+- **Entrypoint spans** (root): webhook intake and each poll cycle in coordinator.
+- **In-process**: coordinator / worker / pipeline (already present, 8b72e81).
+- **Cross-process to sandbox**: coordinator passes `Env: {TRACEPARENT: <ctx>}` when calling agent-env Gateway's session-create. agent-env already supports env injection (`pkg/gateway/types.go:79`); no upstream PR required.
+- **Inside sandbox**: AgentM continues the parent span via its OTel SDK. claude-code / codex remain opaque (not in scope; they don't run in sandbox anyway).
+
+### Long-lifecycle trace correlation
+
+Issues and PRs live for hours-to-days and span many discrete workbuddy operations. OTel spans can't stay open that long, so correlation is done by **trace_id reuse**, not by long-running spans.
+
+- DB schema adds `issues.root_trace_id` and `prs.root_trace_id`.
+- On first sighting of an issue, coordinator creates a brief root span (closed immediately), stores its `trace_id` in the issues row.
+- Every subsequent operation on that issue (poll-hit, dispatch, git push, PR creation, label change, review) loads `root_trace_id` from DB, constructs a parent `SpanContext` with `(trace_id=stored, span_id=new, parent=root)`, and emits its span under the shared trace.
+- PRs inherit `root_trace_id` from their parent issue.
+- Required span attributes on every span: `issue.id`, `issue.number`, `repo`, `pr.number` (when applicable), `agent.role`, `agent.runtime`.
+
+This produces sparse multi-hour trees in Jaeger/Tempo — supported by the format. If span volume per trace becomes unwieldy, fall back to span-links between shorter traces.
+
+## Block 5 — Migration & rollout
+
+### Backward compatibility
+
+- All existing `.github/workbuddy/agents/*.md` configs (runtime=claude-code/codex) continue to work unchanged in systemd mode (self-managed).
+- AgentM agents are new files; they only deploy in K8s mode.
+- No forced migration. Users opt into K8s when ready.
+
+### Documentation
+
+- `workbuddy` skill adds K8s deployment section; clearly separates the two paths.
+- `workbuddy deploy` CLI remains systemd-only. K8s users use standard `helm install`.
+
+### Version split
+
+- **v0.5** (no K8s dependency, ships independently):
+  - DB-layer abstraction + MySQL backend
+  - SQLite→MySQL migration tool
+  - `agentm` runtime (still host-exec, no sandbox yet)
+  - OTel `root_trace_id` persistence + cross-span correlation
+- **v0.6** (depends on v0.5):
+  - agent-env integration
+  - Helm chart
+  - Coordinator-managed dispatch path
+  - Sandbox execution for AgentM
+
+## Cross-repo dependencies
+
+- **AgentM**: confirm CLI input/output contract matches; adapter PR if needed.
+- **agent-env**: env injection already supported; no changes required. Helm chart consumed as-is.
+- **AegisLab**: MySQL service + OTel collector referenced via values only; no upstream changes.
+
+## Open items (deferred, not blocking)
+
+- PVC-based workspace caching for slow-cloning repos.
+- Coordinator multi-replica (requires leader election or optimistic-lock audit of dispatch path).
+- git-sync sidecar for hot-reloading agent configs.
+- claude-code / codex inside sandbox (only if real demand emerges).
+- Span-links fallback if per-issue trace size grows unwieldy.

--- a/docs/planned/agentm-runtime.md
+++ b/docs/planned/agentm-runtime.md
@@ -1,0 +1,192 @@
+# AgentM Runtime — invocation & output contract (v0.5)
+
+- Status: contract only — config validation lands in v0.5 via issue [#315];
+  actual dispatch wiring is tracked in issue **#319**.
+- Design anchor: [docs/decisions/2026-05-13-k8s-agentm-otel.md](../decisions/2026-05-13-k8s-agentm-otel.md) (Block 1).
+- Upstream: [AgentM](https://github.com/AgentM-dev/AgentM) (sibling repo `../AgentM`).
+
+## What this document is
+
+The `agentm` value of `runtime:` in an agent-config frontmatter selects the
+AgentM pluggable agent SDK as the execution backend. This document is the
+single source of truth for how workbuddy invokes `agentm` and what shape the
+output must take, so that:
+
+1. Config files that declare `runtime: agentm` validate cleanly (`workbuddy
+   validate`, `workbuddy validate-docs --strict`).
+2. The follow-up dispatch implementation (issue #319) has a written contract
+   to code against.
+3. AgentM contributors know exactly what workbuddy expects when the upstream
+   CLI is adapted.
+
+**Out of scope for v0.5.**
+Sandboxed / coordinator-managed dispatch is v0.6 (see decision doc Block 2 and
+issue [#319]). v0.5 only delivers the runtime enum entry, the JSON Schemas,
+and validation.
+
+## How `agentm` differs from `claude-code` / `codex`
+
+| Aspect | `claude-code` / `codex` | `agentm` (v0.5 host-exec) | `agentm` (v0.6 sandbox) |
+|---|---|---|---|
+| Execution host | worker host subprocess | worker host subprocess | agent-env sandbox pod |
+| Holds GitHub credentials | yes (PAT in env) | yes (PAT in env) | **no** — coordinator only |
+| Drives state machine | self-managed: agent calls `gh issue edit` | self-managed: agent calls `gh issue edit` | coordinator-managed: workbuddy flips labels using `next_label` from the structured output |
+| Structured output expected on stdout | no — labels move via `gh issue edit` | **yes** — RESULT line matching `schemas/agentm-output.schema.json` | yes — same schema; `gh issue edit` is forbidden |
+| Workspace lifecycle | inherits worker working tree | inherits worker working tree | ephemeral clone in sandbox |
+| Trace propagation | none today | `TRACEPARENT` env, AgentM OTel SDK continues parent span | same, via agent-env Gateway env injection |
+
+In v0.5 the **self-managed** column applies. The structured output is still
+required because it is the v0.6-forward contract: producing it now keeps the
+two paths convergent and lets workbuddy's worker double-check the label flip
+against `next_label` even in host-exec.
+
+## Invocation contract (host-exec, v0.5)
+
+Workbuddy's worker invokes AgentM as a subprocess. The contract below is what
+issue #319 must implement and what the upstream `agentm` CLI must accept.
+
+### Binary
+
+- Expected on `$PATH`: `agentm` (matches `runtimeBinaries["agentm"]` in
+  `internal/validate/semantics.go`).
+- Recovery-floor fallback (`agentm --no-extensions`) is acceptable when an
+  operator forces it, but workbuddy itself always invokes full mode.
+
+### Arguments
+
+```
+agentm run \
+  --workspace <abs path to repo workspace> \
+  --task-file <abs path to a JSON file workbuddy writes pre-launch> \
+  --session-log <abs path AgentM should write its session log to> \
+  --result-file <abs path AgentM should write its RESULT JSON to>
+```
+
+- `--workspace` is the per-task workspace the worker prepared (clone +
+  branch checkout). AgentM must `cd` here before doing any tool calls.
+- `--task-file` is a JSON document workbuddy writes describing the issue
+  (number, title, body, AC text, labels, prior review comments) — see the
+  Inputs section below for fields.
+- `--session-log` is where AgentM's `observability` atom MUST emit the
+  OTel-flavored JSONL session log (so workbuddy's session-data layer can
+  ingest it).
+- `--result-file` is where AgentM MUST write its structured result on exit.
+  Workbuddy reads this file on subprocess exit (status 0 OR non-zero) and
+  validates it against `schemas/agentm-output.schema.json`.
+
+### Environment
+
+Variables workbuddy injects (additive to whatever the worker process
+inherits):
+
+| Var | Required | Notes |
+|---|---|---|
+| `TRACEPARENT` | yes when OTel is enabled | W3C TraceContext (`00-<trace_id>-<span_id>-<flags>`) for the current dispatch span. AgentM's OTel SDK reads it and continues the parent span (see decision doc Block 4). |
+| `WORKBUDDY_RUN_ID` | yes | Workbuddy's internal dispatch id; AgentM echoes it on every emitted span as `workbuddy.run_id`. |
+| `WORKBUDDY_ISSUE_NUMBER` | yes | For span attributes and audit logs. |
+| `WORKBUDDY_REPO` | yes | `owner/repo` form. |
+| `GH_TOKEN` | host-exec only | Same PAT codex/claude-code receive today. **In v0.6 sandbox mode this MUST NOT be injected.** |
+| `ANTHROPIC_API_KEY` / provider keys | provider-dependent | AgentM expects its provider extension to find these in env. |
+
+### stdin
+
+Workbuddy does not write to AgentM's stdin. The task description is delivered
+via `--task-file` instead so that arbitrarily large issue bodies and AC text
+don't have to be argv-safe.
+
+### Task file (JSON document workbuddy writes pre-launch)
+
+```jsonc
+{
+  "schema_version": 1,
+  "issue": {
+    "number": 315,
+    "title": "v0.5: Add agentm runtime + invocation contract",
+    "body": "…full issue body…",
+    "labels": ["status:triage", "type:feature"],
+    "comments": [/* prior review-agent comments, ordered */]
+  },
+  "acceptance_criteria": "AC-1-1: …\nAC-1-2: …",
+  "repo": "Lincyaw/workbuddy",
+  "branch": "v0.5/agentm-runtime-contract",
+  "workspace": "/var/lib/workbuddy/work/<run-id>",
+  "agent_role": "dev",
+  "scenario": "general_purpose"
+}
+```
+
+The exact field set will be finalized when #319 lands; this document MUST be
+updated in the same PR if the field set changes.
+
+### Expected workspace state on entry
+
+- Clean working tree on the target branch (the worker has already done
+  `git checkout` / `git pull`).
+- Git identity configured (`user.name`, `user.email`).
+- The worker's standard config-only files (`.workbuddy/`, etc.) are *not*
+  guaranteed to be inside the workspace — AgentM must not rely on them.
+
+## Output contract
+
+AgentM MUST emit a JSON object at the path passed via `--result-file`,
+matching [`schemas/agentm-output.schema.json`](../../schemas/agentm-output.schema.json).
+Fields:
+
+| Field | Required | Notes |
+|---|---|---|
+| `success` | always | `true` if the run satisfied the task. |
+| `next_label` | always | `status:<lowercase>` literal — the label workbuddy should add. In self-managed v0.5 this should match what AgentM itself flipped via `gh issue edit`; in v0.6 sandbox mode AgentM does *not* flip labels and `next_label` is the sole signal. |
+| `artifact_path` | optional | Absolute path to the produced patch/diff/output. Recommended on success. |
+| `session_log_path` | required when `success=true` | Path to AgentM's session JSONL. |
+| `failure_reason` | required when `success=false` | Short single-line reason; long rationale belongs in the session log. |
+
+### Validation behavior (post-#319)
+
+When dispatch lands, workbuddy will:
+
+1. Refuse to consider an `agentm` run finished if `--result-file` is missing or
+   the JSON fails `schemas/agentm-output.schema.json` validation. The run is
+   classified as `infra-failure`, not `task-failure`.
+2. Compare `next_label` against the label the issue actually ended up with
+   (in self-managed mode) and emit a warning if they disagree.
+3. Forward `session_log_path` to the session-data ingester.
+
+## Forward-compatibility (v0.6 preview)
+
+The same schema is reused for coordinator-managed dispatch. The only operational
+delta:
+
+- `GH_TOKEN` is **not** in env.
+- AgentM MUST NOT shell out to `gh` or `git push`. The coordinator performs
+  the post-run `git push` + `gh pr create` + label flip using `next_label`.
+- The workspace is an ephemeral sandbox clone; nothing persists between runs.
+
+Because the output contract is identical, no schema bump is expected when
+v0.6 ships. If a bump *is* needed (e.g. AgentM wants to return multiple
+artifacts), the schema MUST add an optional field rather than break v0.5
+consumers.
+
+## Where this is wired in v0.5
+
+| Surface | File | Behavior |
+|---|---|---|
+| Runtime enum | `internal/config/loader.go` — `RuntimeAgentM` | added to `validRuntimes` and `publicRuntimes`. |
+| Policy matrix | `internal/config/loader.go` — `normalizeAgentConfig` | accepts `runtime: agentm` with the same sandbox/approval set as `codex`. |
+| Cross-ref validator | `internal/validate/cross_refs.go` — `ValidRuntimes` | recognizes `"agentm"`. |
+| Binary check | `internal/validate/semantics.go` — `runtimeBinaries` | maps `agentm → agentm`. |
+| Agent frontmatter schema | `schemas/agent.schema.json` | enum includes `"agentm"`. |
+| Output schema | `schemas/agentm-output.schema.json` | this file. |
+| Dispatch | *not in v0.5* | tracked in issue #319. |
+
+## Out-of-scope reminders
+
+- **No dispatch.** A worker invoked with `runtime: agentm` today will fail at
+  dispatch time — that wiring is #319. v0.5 only guarantees the config
+  validates and the contract is documented.
+- **No sandbox.** agent-env integration is v0.6.
+- **No new agents.** This work does not add agent configs under
+  `.github/workbuddy/agents/` for AgentM. Catalog policy (dev + review only)
+  is unchanged.
+
+[#315]: https://github.com/Lincyaw/workbuddy/issues/315
+[#319]: https://github.com/Lincyaw/workbuddy/issues/319

--- a/docs/planned/index.md
+++ b/docs/planned/index.md
@@ -10,7 +10,9 @@
 
 ## 文档列表
 
-_当前无待落地的设计文档。_ Worker execution boundary (`#146`~`#151`) 已整体落地 (v0.4.0)，原设计锚点已迁移到 `docs/implemented/worker-execution-boundary.md`。
+- [agentm-runtime.md](agentm-runtime.md) — AgentM 作为第三个 runtime 的 invocation + output contract（v0.5 仅契约 + config 校验，dispatch 在 #319，sandbox 在 v0.6）。
+
+Worker execution boundary (`#146`~`#151`) 已整体落地 (v0.4.0)，原设计锚点已迁移到 `docs/implemented/worker-execution-boundary.md`。
 
 ## 维护规则
 

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -31,6 +31,12 @@ const (
 	RuntimeCodex       = "codex"
 	RuntimeCodexExec   = "codex-exec"
 	RuntimeCodexServer = "codex-appserver"
+	// RuntimeAgentM names the AgentM pluggable agent SDK (../AgentM).
+	// v0.5 introduces it as a config + contract-validated runtime only;
+	// actual dispatch wiring lands in a follow-up (issue #319). See
+	// docs/decisions/2026-05-13-k8s-agentm-otel.md (Block 1) and
+	// docs/planned/agentm-runtime.md for the invocation contract.
+	RuntimeAgentM = "agentm"
 )
 
 const (
@@ -45,9 +51,10 @@ var validRuntimes = map[string]bool{
 	RuntimeCodex:       true,
 	RuntimeCodexExec:   true,
 	RuntimeCodexServer: true,
+	RuntimeAgentM:      true,
 }
 
-var publicRuntimes = []string{RuntimeClaudeCode, RuntimeCodex, RuntimeCodexServer}
+var publicRuntimes = []string{RuntimeClaudeCode, RuntimeCodex, RuntimeCodexServer, RuntimeAgentM}
 var validRunners = map[string]bool{
 	RunnerLocal:         true,
 	RunnerGitHubActions: true,
@@ -335,6 +342,21 @@ func normalizeAgentConfig(agent *AgentConfig) ([]Warning, error) {
 		default:
 			return warnings, fmt.Errorf("unsupported policy.approval %q for runtime %q", agent.Policy.Approval, agent.Runtime)
 		}
+	case RuntimeAgentM:
+		// v0.5: host-exec only. Sandbox/coordinator-managed mode is v0.6
+		// (see docs/decisions/2026-05-13-k8s-agentm-otel.md Block 2).
+		// AgentM is self-managed in host-exec, so the same sandbox/approval
+		// set as codex is allowed.
+		switch agent.Policy.Sandbox {
+		case "read-only", "workspace-write", "danger-full-access":
+		default:
+			return warnings, fmt.Errorf("unsupported policy.sandbox %q for runtime %q", agent.Policy.Sandbox, agent.Runtime)
+		}
+		switch agent.Policy.Approval {
+		case "never", "on-failure", "on-request", "via-approver":
+		default:
+			return warnings, fmt.Errorf("unsupported policy.approval %q for runtime %q", agent.Policy.Approval, agent.Runtime)
+		}
 	default:
 		return warnings, fmt.Errorf("unsupported runtime %q", agent.Runtime)
 	}
@@ -364,6 +386,8 @@ func defaultSandboxForRuntime(runtime string) string {
 		return "read-only"
 	case RuntimeCodex:
 		return "read-only"
+	case RuntimeAgentM:
+		return "read-only"
 	default:
 		return ""
 	}
@@ -371,7 +395,7 @@ func defaultSandboxForRuntime(runtime string) string {
 
 func defaultApprovalForRuntime(runtime string) string {
 	switch runtime {
-	case RuntimeClaudeCode, RuntimeClaudeShot, RuntimeCodex:
+	case RuntimeClaudeCode, RuntimeClaudeShot, RuntimeCodex, RuntimeAgentM:
 		return "never"
 	default:
 		return ""

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -180,3 +180,130 @@ func TestLoadConfig_RejectsUnknownRolloutJoinKey(t *testing.T) {
 		t.Fatal("expected unknown rollout join key to fail")
 	}
 }
+
+// TestNormalizeAgentConfig_AcceptsAgentMRuntime covers AC-1-1 of issue #315:
+// `runtime: agentm` must pass config normalization with the same sandbox /
+// approval set as `codex`. v0.5 is host-exec only — see
+// docs/planned/agentm-runtime.md and docs/decisions/2026-05-13-k8s-agentm-otel.md.
+func TestNormalizeAgentConfig_AcceptsAgentMRuntime(t *testing.T) {
+	t.Helper()
+
+	cases := []struct {
+		name    string
+		policy  PolicyConfig
+		wantSbx string
+		wantApp string
+	}{
+		{
+			name:    "defaults_fill_in",
+			policy:  PolicyConfig{},
+			wantSbx: "read-only",
+			wantApp: "never",
+		},
+		{
+			name:    "workspace_write_ok",
+			policy:  PolicyConfig{Sandbox: "workspace-write", Approval: "on-failure"},
+			wantSbx: "workspace-write",
+			wantApp: "on-failure",
+		},
+		{
+			name:    "danger_full_access_ok",
+			policy:  PolicyConfig{Sandbox: "danger-full-access", Approval: "via-approver"},
+			wantSbx: "danger-full-access",
+			wantApp: "via-approver",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			agent := &AgentConfig{
+				Name:    "agentm-dev",
+				Runtime: RuntimeAgentM,
+				Policy:  tc.policy,
+			}
+			warnings, err := NormalizeAgentConfig(agent)
+			if err != nil {
+				t.Fatalf("NormalizeAgentConfig: unexpected error: %v (warnings=%v)", err, warnings)
+			}
+			if agent.Runtime != RuntimeAgentM {
+				t.Errorf("Runtime was rewritten to %q; agentm must stay agentm", agent.Runtime)
+			}
+			if agent.Policy.Sandbox != tc.wantSbx {
+				t.Errorf("Policy.Sandbox = %q, want %q", agent.Policy.Sandbox, tc.wantSbx)
+			}
+			if agent.Policy.Approval != tc.wantApp {
+				t.Errorf("Policy.Approval = %q, want %q", agent.Policy.Approval, tc.wantApp)
+			}
+		})
+	}
+}
+
+// TestNormalizeAgentConfig_RejectsBadAgentMPolicy verifies the policy matrix
+// rejects clearly-invalid combinations, mirroring the codex matrix.
+func TestNormalizeAgentConfig_RejectsBadAgentMPolicy(t *testing.T) {
+	t.Helper()
+
+	cases := []PolicyConfig{
+		{Sandbox: "no-such-sandbox", Approval: "never"},
+		{Sandbox: "read-only", Approval: "no-such-approval"},
+	}
+	for _, p := range cases {
+		agent := &AgentConfig{
+			Name:    "agentm-dev",
+			Runtime: RuntimeAgentM,
+			Policy:  p,
+		}
+		if _, err := NormalizeAgentConfig(agent); err == nil {
+			t.Errorf("policy %+v: expected error, got nil", p)
+		}
+	}
+}
+
+// TestLoadConfig_AcceptsAgentMAgentFile covers AC-1-1 end-to-end: an agent
+// frontmatter declaring `runtime: agentm` loads cleanly from disk via
+// LoadConfig.
+func TestLoadConfig_AcceptsAgentMAgentFile(t *testing.T) {
+	t.Helper()
+
+	configDir := t.TempDir()
+	agentsDir := filepath.Join(configDir, "agents")
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		t.Fatalf("mkdir agents: %v", err)
+	}
+
+	agentMD := "---\n" +
+		"name: agentm-dev\n" +
+		"description: AgentM-powered dev agent (v0.5 contract only)\n" +
+		"role: dev\n" +
+		"runtime: agentm\n" +
+		"triggers:\n" +
+		"  - state: developing\n" +
+		"context:\n" +
+		"  - Repo\n" +
+		"  - Issue.Number\n" +
+		"policy:\n" +
+		"  sandbox: workspace-write\n" +
+		"  approval: never\n" +
+		"  timeout: 30m\n" +
+		"---\n\n" +
+		"Implement issue {{.Issue.Number}} in {{.Repo}}.\n"
+	path := filepath.Join(agentsDir, "agentm-dev.md")
+	if err := os.WriteFile(path, []byte(agentMD), 0o644); err != nil {
+		t.Fatalf("write agent: %v", err)
+	}
+
+	cfg, _, err := LoadConfig(configDir)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	agent, ok := cfg.Agents["agentm-dev"]
+	if !ok {
+		t.Fatalf("agent agentm-dev not loaded; got %+v", cfg.Agents)
+	}
+	if agent.Runtime != RuntimeAgentM {
+		t.Errorf("Runtime = %q, want %q", agent.Runtime, RuntimeAgentM)
+	}
+	if agent.Policy.Sandbox != "workspace-write" {
+		t.Errorf("Policy.Sandbox = %q, want workspace-write", agent.Policy.Sandbox)
+	}
+}

--- a/internal/validate/cross_refs.go
+++ b/internal/validate/cross_refs.go
@@ -42,6 +42,7 @@ var ValidRuntimes = map[string]struct{}{
 	"codex":            {},
 	"claude-code":      {},
 	"claude-agent-sdk": {},
+	"agentm":           {},
 }
 
 // ValidRoles is the canonical 2-role catalog. The project deliberately

--- a/internal/validate/cross_refs_test.go
+++ b/internal/validate/cross_refs_test.go
@@ -46,7 +46,7 @@ func TestValidateAgentCrossRefs_UnknownRuntime(t *testing.T) {
 }
 
 func TestValidateAgentCrossRefs_KnownRuntimes(t *testing.T) {
-	for _, rt := range []string{"codex", "claude-code", "claude-agent-sdk"} {
+	for _, rt := range []string{"codex", "claude-code", "claude-agent-sdk", "agentm"} {
 		agent := &agentDoc{
 			Path:    "/tmp/agents/dev-agent.md",
 			Name:    "dev-agent",

--- a/internal/validate/semantics.go
+++ b/internal/validate/semantics.go
@@ -50,6 +50,7 @@ var runtimeBinaries = map[string]string{
 	"codex":            "codex",
 	"claude-code":      "claude",
 	"claude-agent-sdk": "claude",
+	"agentm":           "agentm",
 }
 
 type semanticsOptions struct {

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -4842,3 +4842,36 @@ requirements:
       - internal/ghutil/ghutil.go
     tests: []
     deps: []
+
+  - id: REQ-133
+    title: AgentM runtime + invocation contract (v0.5)
+    description: >
+      Per docs/decisions/2026-05-13-k8s-agentm-otel.md (Block 1), AgentM
+      joins claude-code and codex as a first-class runtime. This requirement
+      tracks the v0.5 slice: runtime enum entry, structured-output JSON
+      schema, written invocation/output contract, and config-loader policy
+      matrix that accepts `runtime: agentm`. Host-exec only — actual
+      dispatch wiring (and sandbox/coordinator-managed mode) are tracked
+      separately (issue #319 / v0.6).
+    priority: P1
+    version: v0.5.0
+    status: tested
+    acceptance_criteria:
+      - "AC-133-1: `runtime: agentm` passes config validation; integration test covers a config with this value."
+      - "AC-133-2: schemas/agentm-output.schema.json exists and describes the structured output (success, next_label, artifact_path, session_log_path, failure_reason)."
+      - "AC-133-3: docs/planned/agentm-runtime.md documents the invocation + output contract and how it differs from claude-code / codex."
+      - "AC-133-4: `go build ./... && go vet ./... && go test ./... -count=1` all pass."
+      - "AC-133-5: project-index.yaml has this REQ entry referencing issue #315."
+    code:
+      - internal/config/loader.go
+      - internal/validate/cross_refs.go
+      - internal/validate/semantics.go
+      - schemas/agent.schema.json
+      - schemas/agentm-output.schema.json
+      - docs/planned/agentm-runtime.md
+      - docs/decisions/2026-05-13-k8s-agentm-otel.md
+    tests:
+      - internal/config/loader_test.go
+      - internal/validate/cross_refs_test.go
+    deps:
+      - REQ-132

--- a/schemas/agent.schema.json
+++ b/schemas/agent.schema.json
@@ -24,8 +24,8 @@
     },
     "runtime": {
       "type": "string",
-      "enum": ["codex", "claude-code", "claude-agent-sdk"],
-      "description": "Agent execution backend."
+      "enum": ["codex", "claude-code", "claude-agent-sdk", "agentm"],
+      "description": "Agent execution backend. `agentm` was added in v0.5 (host-exec only in v0.5; coordinator-managed sandbox in v0.6). See docs/planned/agentm-runtime.md for the invocation/output contract."
     },
     "runner": {
       "type": "string",

--- a/schemas/agentm-output.schema.json
+++ b/schemas/agentm-output.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Lincyaw/workbuddy/schemas/agentm-output.schema.json",
+  "title": "AgentM structured output (workbuddy v0.5 host-exec contract)",
+  "description": "Schema for the JSON object an `agentm` runtime invocation MUST emit on its stdout `RESULT:` line so the workbuddy worker can drive the state machine. See docs/planned/agentm-runtime.md for the full invocation/output contract and docs/decisions/2026-05-13-k8s-agentm-otel.md (Block 1) for design context. v0.5 covers host-exec only; v0.6 will extend this contract for coordinator-managed sandbox dispatch.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["success", "next_label"],
+  "properties": {
+    "success": {
+      "type": "boolean",
+      "description": "Whether the agent run satisfied its task. `false` means workbuddy should route the issue down a failure transition; `failure_reason` SHOULD be populated."
+    },
+    "next_label": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^status:[a-z0-9][a-z0-9_-]*$",
+      "description": "The next `status:*` label the agent is asking workbuddy to set on the issue. Mirrors the `gh issue edit --add-label` value other runtimes flip themselves; the agentm runtime delegates the flip to workbuddy so AgentM does not need GitHub credentials in v0.6 coordinator-managed mode."
+    },
+    "artifact_path": {
+      "type": "string",
+      "description": "Absolute path (inside the agent workspace) to the primary artifact the run produced (patch/diff/test-output/etc.). Optional when `success=false` and the run produced nothing usable."
+    },
+    "session_log_path": {
+      "type": "string",
+      "description": "Absolute path to the session-data log AgentM's `observability` atom wrote (conversation events + tool-call history) so workbuddy's session-data layer can ingest it. Required when `success=true`; recommended on failure for debuggability."
+    },
+    "failure_reason": {
+      "type": "string",
+      "description": "Short human-readable reason for failure. REQUIRED when `success=false`. SHOULD be a single line; longer rationale belongs in `session_log_path`."
+    }
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"success": {"const": false}}, "required": ["success"]},
+      "then": {"required": ["failure_reason"]}
+    },
+    {
+      "if": {"properties": {"success": {"const": true}}, "required": ["success"]},
+      "then": {"required": ["session_log_path"]}
+    }
+  ]
+}


### PR DESCRIPTION
Closes #315.

## Summary

Adds `agentm` as a first-class runtime alongside `claude-code` / `codex`, per [docs/decisions/2026-05-13-k8s-agentm-otel.md](../blob/v0.5/agentm-runtime-contract/docs/decisions/2026-05-13-k8s-agentm-otel.md) (Block 1). This PR is **contract + validation only** — dispatch wiring is tracked separately as #319, and sandbox/coordinator-managed mode is v0.6.

## Files touched

- `internal/config/loader.go` — `RuntimeAgentM = "agentm"`, accepted by `validRuntimes` / `publicRuntimes` / `normalizeAgentConfig` (host-exec only; same sandbox/approval matrix as codex; defaults to `read-only` / `never`).
- `internal/validate/cross_refs.go` — WB-X003 (`ValidRuntimes`) recognizes `agentm`.
- `internal/validate/semantics.go` — `runtimeBinaries["agentm"] = "agentm"` for the binary-presence check.
- `schemas/agent.schema.json` — `runtime` enum now includes `"agentm"`.
- `schemas/agentm-output.schema.json` (new) — structured-output contract: `success`, `next_label`, `artifact_path`, `session_log_path`, `failure_reason`. Conditional `required` enforces `failure_reason` when `success=false` and `session_log_path` when `success=true`.
- `docs/planned/agentm-runtime.md` (new) — invocation contract (binary, args, env incl. `TRACEPARENT`, task file, expected workspace state), output contract, and how `agentm` differs from `claude-code` / `codex` in v0.5 host-exec vs v0.6 coordinator-managed.
- `docs/decisions/2026-05-13-k8s-agentm-otel.md` (new) — brought into this branch since the issue references it.
- `internal/config/loader_test.go` — new tests cover normalize + LoadConfig accepting `runtime: agentm` (AC-1-1).
- `internal/validate/cross_refs_test.go` — `agentm` added to the known-runtimes round-trip.
- `project-index.yaml` — REQ-133.

## Acceptance criteria coverage

- AC-1-1 — `runtime: agentm` passes config validation: `TestNormalizeAgentConfig_AcceptsAgentMRuntime`, `TestNormalizeAgentConfig_RejectsBadAgentMPolicy`, `TestLoadConfig_AcceptsAgentMAgentFile` (`internal/config/loader_test.go`), plus the cross-ref test in `internal/validate/cross_refs_test.go`.
- AC-1-2 — `schemas/agentm-output.schema.json` exists with the required fields and conditional constraints.
- AC-1-3 — `docs/planned/agentm-runtime.md` documents the contract end-to-end.
- AC-1-4 — `go build ./... && go vet ./... && go test ./... -count=1` all pass locally.
- AC-1-5 — REQ-133 added; `python3 ~/.autoharness/scripts/validate_index.py project-index.yaml` is green.

## Out of scope (deliberately deferred)

- Dispatch / `internal/runtime/registry.go` wiring for `agentm` — tracked as #319.
- agent-env sandbox + coordinator-managed dispatch — v0.6.
- New agent configs under `.github/workbuddy/agents/` — none added; the 2-role catalog is unchanged.

## Test plan

- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] `go test ./... -count=1`
- [ ] `go run . validate-docs --strict`
- [ ] `python3 ~/.autoharness/scripts/validate_index.py project-index.yaml`

All five run green on this branch.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>