### PR TITLE
v0.5: AgentM host-exec dispatch + session artifact wiring (#319)

### DIFF
--- a/internal/agent/agentm/agentm-output.schema.json
+++ b/internal/agent/agentm/agentm-output.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Lincyaw/workbuddy/schemas/agentm-output.schema.json",
+  "title": "AgentM structured output (workbuddy v0.5 host-exec contract)",
+  "description": "Schema for the JSON object an `agentm` runtime invocation MUST emit on its stdout `RESULT:` line so the workbuddy worker can drive the state machine. See docs/planned/agentm-runtime.md for the full invocation/output contract and docs/decisions/2026-05-13-k8s-agentm-otel.md (Block 1) for design context. v0.5 covers host-exec only; v0.6 will extend this contract for coordinator-managed sandbox dispatch.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["success", "next_label"],
+  "properties": {
+    "success": {
+      "type": "boolean",
+      "description": "Whether the agent run satisfied its task. `false` means workbuddy should route the issue down a failure transition; `failure_reason` SHOULD be populated."
+    },
+    "next_label": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^status:[a-z0-9][a-z0-9_-]*$",
+      "description": "The next `status:*` label the agent is asking workbuddy to set on the issue. Mirrors the `gh issue edit --add-label` value other runtimes flip themselves; the agentm runtime delegates the flip to workbuddy so AgentM does not need GitHub credentials in v0.6 coordinator-managed mode."
+    },
+    "artifact_path": {
+      "type": "string",
+      "description": "Absolute path (inside the agent workspace) to the primary artifact the run produced (patch/diff/test-output/etc.). Optional when `success=false` and the run produced nothing usable."
+    },
+    "session_log_path": {
+      "type": "string",
+      "description": "Absolute path to the session-data log AgentM's `observability` atom wrote (conversation events + tool-call history) so workbuddy's session-data layer can ingest it. Required when `success=true`; recommended on failure for debuggability."
+    },
+    "failure_reason": {
+      "type": "string",
+      "description": "Short human-readable reason for failure. REQUIRED when `success=false`. SHOULD be a single line; longer rationale belongs in `session_log_path`."
+    }
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"success": {"const": false}}, "required": ["success"]},
+      "then": {"required": ["failure_reason"]}
+    },
+    {
+      "if": {"properties": {"success": {"const": true}}, "required": ["success"]},
+      "then": {"required": ["session_log_path"]}
+    }
+  ]
+}

--- a/internal/agent/agentm/agentmtest/fake.go
+++ b/internal/agent/agentm/agentmtest/fake.go
@@ -1,0 +1,148 @@
+// Package agentmtest provides a fake AgentM binary builder for unit tests.
+// It mirrors the codextest pattern (sibling fake harness for the codex
+// app-server) but for AgentM's stdout-RESULT contract.
+//
+// Usage:
+//
+//	bin := agentmtest.BuildFake(t, agentmtest.Config{Mode: agentmtest.ModeSuccess})
+//	be := &agentm.Backend{Binary: bin}
+//	sess, _ := be.NewSession(ctx, agent.Spec{...})
+//	res, _ := sess.Wait(ctx)
+package agentmtest
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// Mode picks the fake's behaviour. The fake is a shell script so it runs on
+// any host workbuddy itself builds on (no compile step in the inner test loop).
+type Mode string
+
+const (
+	// ModeSuccess emits a well-formed RESULT: line with success=true plus a
+	// dummy session log path, then exits 0.
+	ModeSuccess Mode = "success"
+	// ModeFailure emits a well-formed RESULT: line with success=false plus
+	// a failure_reason and exits 0. The bridge MUST still surface the
+	// failure_reason and apply the agent's next_label.
+	ModeFailure Mode = "failure"
+	// ModeMalformedJSON emits a RESULT: line whose body is not valid JSON
+	// (and no result file). This MUST be classified as an infra failure.
+	ModeMalformedJSON Mode = "malformed-json"
+	// ModeNoResult emits stdout/stderr transcript but no RESULT: line.
+	// MUST be classified as an infra failure.
+	ModeNoResult Mode = "no-result"
+	// ModeMissingRequired emits a JSON object that is missing a required
+	// field per the output schema (no next_label). MUST surface a schema
+	// violation as the failure_reason.
+	ModeMissingRequired Mode = "missing-required"
+)
+
+// Config configures the fake binary.
+type Config struct {
+	Mode Mode
+	// NextLabel overrides the default "status:review" in ModeSuccess /
+	// "status:failed" in ModeFailure.
+	NextLabel string
+	// FailureReason overrides the default reason in ModeFailure.
+	FailureReason string
+}
+
+// BuildFake writes a shell-script fake to a temp file marked executable and
+// returns its absolute path. The script is removed via t.Cleanup.
+func BuildFake(t *testing.T, cfg Config) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("agentmtest: fake binary is a POSIX shell script; skip on windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agentm")
+
+	mode := cfg.Mode
+	if mode == "" {
+		mode = ModeSuccess
+	}
+	nextLabel := cfg.NextLabel
+	failureReason := cfg.FailureReason
+
+	// emitResult is a bash snippet that writes the RESULT: line to stdout
+	// AND the result file. Variables $SESSION_LOG / $RESULT_FILE are bash
+	// expansions; everything else must be safe inside single-quotes.
+	var emitResult string
+	switch mode {
+	case ModeSuccess:
+		if nextLabel == "" {
+			nextLabel = "status:review"
+		}
+		emitResult = fmt.Sprintf(`BODY='{"success":true,"next_label":"%s","session_log_path":"'"$SESSION_LOG"'"}'`, nextLabel)
+	case ModeFailure:
+		if nextLabel == "" {
+			nextLabel = "status:failed"
+		}
+		if failureReason == "" {
+			failureReason = "fake agentm reports failure"
+		}
+		emitResult = fmt.Sprintf(`BODY='{"success":false,"next_label":"%s","failure_reason":"%s","session_log_path":"'"$SESSION_LOG"'"}'`,
+			nextLabel, failureReason)
+	case ModeMalformedJSON:
+		emitResult = `BODY='{not valid json at all'`
+	case ModeNoResult:
+		emitResult = ""
+	case ModeMissingRequired:
+		emitResult = `BODY='{"success":true,"session_log_path":"'"$SESSION_LOG"'"}'`
+	default:
+		t.Fatalf("agentmtest: unknown mode %q", mode)
+	}
+
+	// Parse --result-file / --session-log / --task-file out of $@. The fake
+	// always touches the session log so the host can ingest a non-empty
+	// artifact even when the contract is malformed.
+	script := `#!/usr/bin/env bash
+set -eu
+WORKSPACE=""
+TASK_FILE=""
+SESSION_LOG=""
+RESULT_FILE=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workspace) WORKSPACE="$2"; shift 2 ;;
+    --task-file) TASK_FILE="$2"; shift 2 ;;
+    --session-log) SESSION_LOG="$2"; shift 2 ;;
+    --result-file) RESULT_FILE="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+if [[ -n "$SESSION_LOG" ]]; then
+  mkdir -p "$(dirname "$SESSION_LOG")"
+  cat > "$SESSION_LOG" <<'JSONL'
+{"kind":"turn.started","ts":"2026-05-13T00:00:00Z"}
+{"kind":"agent.message","ts":"2026-05-13T00:00:01Z","text":"fake agentm running"}
+{"kind":"turn.completed","ts":"2026-05-13T00:00:02Z"}
+JSONL
+fi
+
+echo "fake agentm starting in $WORKSPACE"
+echo "task file: $TASK_FILE"
+`
+	if emitResult != "" {
+		script += emitResult + "\n"
+		script += `echo "RESULT: $BODY"` + "\n"
+		script += `if [[ -n "$RESULT_FILE" ]]; then echo "$BODY" > "$RESULT_FILE"; fi` + "\n"
+	}
+	script += "exit 0\n"
+
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("agentmtest: write fake: %v", err)
+	}
+	// Quick sanity: ensure bash is present.
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skipf("agentmtest: bash not on PATH: %v", err)
+	}
+	return path
+}

--- a/internal/agent/agentm/backend.go
+++ b/internal/agent/agentm/backend.go
@@ -1,0 +1,417 @@
+// Package agentm implements the agent.Backend interface for the AgentM
+// pluggable agent SDK (../AgentM). v0.5 ships host-exec only: the worker
+// spawns the `agentm` binary as a subprocess, feeds it task context via a
+// JSON file, then parses a single stdout line beginning with `RESULT: {…}`
+// for the structured outcome. The structured output is validated against
+// schemas/agentm-output.schema.json; malformed/missing output is classified
+// as an infra failure surfaced through the standard reporter path.
+//
+// See docs/planned/agentm-runtime.md for the invocation/output contract and
+// docs/decisions/2026-05-13-k8s-agentm-otel.md (Block 1) for design context.
+// Sandbox / coordinator-managed mode is v0.6.
+package agentm
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/Lincyaw/workbuddy/internal/agent"
+	"github.com/google/uuid"
+)
+
+// resultLinePrefix is the literal stdout marker AgentM uses to signal the
+// structured outcome. Anything before this prefix is logged as conversation
+// transcript; the rest of the matching line is parsed as JSON.
+const resultLinePrefix = "RESULT:"
+
+// DefaultBinary is the executable name workbuddy looks for on PATH when
+// dispatching `runtime: agentm`. Mirrors the entry in
+// internal/validate/semantics.go runtimeBinaries.
+const DefaultBinary = "agentm"
+
+// Backend is the workbuddy-level agent.Backend for AgentM. It spawns one
+// subprocess per NewSession.
+type Backend struct {
+	// Binary overrides the executable name (default: "agentm"). Set this
+	// from tests pointing at a fake.
+	Binary string
+}
+
+// NewBackend returns a Backend wired to the production binary name. Tests
+// construct Backend{Binary: …} directly.
+func NewBackend() *Backend { return &Backend{Binary: DefaultBinary} }
+
+func (b *Backend) NewSession(ctx context.Context, spec agent.Spec) (agent.Session, error) {
+	id := uuid.New().String()
+
+	workspace := spec.Workdir
+	if workspace == "" {
+		workspace = "."
+	}
+
+	// Sidecar files: task input + result + session log. We let AgentM write
+	// the result/session log inside a per-session temp dir so multiple
+	// dispatches don't collide.
+	tmpDir, err := os.MkdirTemp("", "workbuddy-agentm-"+id+"-")
+	if err != nil {
+		return nil, fmt.Errorf("agentm: create temp dir: %w", err)
+	}
+	taskFile := filepath.Join(tmpDir, "task.json")
+	resultFile := filepath.Join(tmpDir, "result.json")
+	sessionLog := filepath.Join(tmpDir, "session.jsonl")
+
+	if err := writeTaskFile(taskFile, spec); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return nil, fmt.Errorf("agentm: write task file: %w", err)
+	}
+
+	binary := b.Binary
+	if binary == "" {
+		binary = DefaultBinary
+	}
+
+	args := []string{
+		"run",
+		"--workspace", workspace,
+		"--task-file", taskFile,
+		"--session-log", sessionLog,
+		"--result-file", resultFile,
+	}
+	args = append(args, spec.Args...)
+
+	cmd := exec.CommandContext(ctx, binary, args...)
+	cmd.Dir = workspace
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	cmd.Env = os.Environ()
+	// Spec.Env already carries scoped GH_TOKEN, WORKBUDDY_*, and
+	// TRACEPARENT/WORKBUDDY_RUN_ID set by the bridge.
+	for k, v := range spec.Env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return nil, fmt.Errorf("agentm: stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return nil, fmt.Errorf("agentm: stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return nil, fmt.Errorf("agentm: start %s: %w", binary, err)
+	}
+
+	events := make(chan agent.Event, 64)
+	s := &session{
+		id:         id,
+		cmd:        cmd,
+		events:     events,
+		done:       make(chan struct{}),
+		start:      time.Now(),
+		tmpDir:     tmpDir,
+		taskFile:   taskFile,
+		resultFile: resultFile,
+		sessionLog: sessionLog,
+		sessionRef: agent.SessionRef{ID: id, Kind: "agentm"},
+	}
+
+	// Stderr drained into log events so they surface in session audit.
+	var stderrWG sync.WaitGroup
+	stderrWG.Add(1)
+	go func() {
+		defer stderrWG.Done()
+		scanner := bufio.NewScanner(stderr)
+		scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+		for scanner.Scan() {
+			line := scanner.Text()
+			body, _ := json.Marshal(map[string]string{"stream": "stderr", "line": line})
+			emit(events, agent.Event{Kind: "log", Body: body})
+		}
+	}()
+
+	// Stdout reader: extracts the RESULT: line and forwards every line as a
+	// log event for transcript capture.
+	go func() {
+		defer close(events)
+		defer close(s.done)
+		// Intentionally do NOT remove tmpDir here: the session-log file is
+		// referenced by Result.SessionPath / session_log_path and consumed by
+		// the audit layer after Wait returns. Lifecycle cleanup is the
+		// caller's responsibility (worker session manager).
+
+		s.scanStdout(stdout)
+		stderrWG.Wait()
+
+		waitErr := cmd.Wait()
+		exitCode := 0
+		if waitErr != nil {
+			var exitErr *exec.ExitError
+			if errors.As(waitErr, &exitErr) {
+				exitCode = exitErr.ExitCode()
+			} else {
+				exitCode = -1
+			}
+		}
+
+		// Prefer the stdout RESULT: line. Fall back to the result file
+		// (the contract permits both; #321's schema description names the
+		// stdout RESULT: line as the canonical signal).
+		out, parseErr := s.resolveOutput()
+
+		s.mu.Lock()
+		s.exitCode = exitCode
+		s.duration = time.Since(s.start)
+		s.waitErr = waitErr
+		s.output = out
+		s.parseErr = parseErr
+		if out != nil {
+			s.finalMsg = strings.TrimSpace(out.FailureReason)
+			if out.Success && out.NextLabel != "" {
+				s.finalMsg = out.NextLabel
+			}
+		}
+		s.mu.Unlock()
+	}()
+
+	return s, nil
+}
+
+func (b *Backend) Shutdown(_ context.Context) error { return nil }
+
+type session struct {
+	id     string
+	cmd    *exec.Cmd
+	events chan agent.Event
+	done   chan struct{}
+	start  time.Time
+
+	tmpDir     string
+	taskFile   string
+	resultFile string
+	sessionLog string
+
+	mu             sync.Mutex
+	exitCode       int
+	duration       time.Duration
+	waitErr        error
+	finalMsg       string
+	sessionRef     agent.SessionRef
+	output         *Output
+	parseErr       error
+	resultLineRaw  string
+}
+
+func (s *session) ID() string                 { return s.id }
+func (s *session) Events() <-chan agent.Event { return s.events }
+
+func (s *session) Wait(ctx context.Context) (agent.Result, error) {
+	select {
+	case <-s.done:
+	case <-ctx.Done():
+		return agent.Result{}, ctx.Err()
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	res := agent.Result{
+		ExitCode:   s.exitCode,
+		FinalMsg:   s.finalMsg,
+		Duration:   s.duration,
+		SessionRef: s.sessionRef,
+	}
+	// If the run produced no parseable structured output, surface that as
+	// the wait error so the bridge can mark an infra failure. We keep the
+	// process exit code separate so the caller can tell apart "agent
+	// reported task failure" from "agent never reported anything".
+	if s.parseErr != nil {
+		return res, s.parseErr
+	}
+	if s.output != nil && !s.output.Success {
+		return res, fmt.Errorf("agentm: task failure: %s", s.output.FailureReason)
+	}
+	return res, s.waitErr
+}
+
+func (s *session) Interrupt(ctx context.Context) error {
+	if s.cmd.Process == nil {
+		return nil
+	}
+	pgid := -s.cmd.Process.Pid
+	_ = syscall.Kill(pgid, syscall.SIGTERM)
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	select {
+	case <-s.done:
+		return nil
+	case <-timer.C:
+		_ = syscall.Kill(pgid, syscall.SIGKILL)
+	case <-ctx.Done():
+		_ = syscall.Kill(pgid, syscall.SIGKILL)
+		return ctx.Err()
+	}
+	select {
+	case <-s.done:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return nil
+}
+
+func (s *session) Close() error { return nil }
+
+// Output exposes the parsed structured output for callers that need to
+// route on next_label / failure_reason / artifact_path. Returns (nil, err)
+// if the run produced no parseable RESULT: line. Safe to call after Wait
+// returns.
+func (s *session) Output() (*Output, error) {
+	<-s.done
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.parseErr != nil {
+		return nil, s.parseErr
+	}
+	return s.output, nil
+}
+
+// SessionLogPath returns the path to the session JSONL the run wrote (or
+// would have written, in the fake-binary case). Returns "" if no session
+// log was emitted.
+func (s *session) SessionLogPath() string {
+	<-s.done
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.output != nil && s.output.SessionLogPath != "" {
+		return s.output.SessionLogPath
+	}
+	if fileExists(s.sessionLog) {
+		return s.sessionLog
+	}
+	return ""
+}
+
+func (s *session) scanStdout(stdout io.Reader) {
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, resultLinePrefix) {
+			s.mu.Lock()
+			s.resultLineRaw = strings.TrimSpace(strings.TrimPrefix(trimmed, resultLinePrefix))
+			s.mu.Unlock()
+			body, _ := json.Marshal(map[string]string{"stream": "stdout", "line": line, "kind": "result"})
+			emit(s.events, agent.Event{Kind: "task.complete", Body: body})
+			continue
+		}
+		body, _ := json.Marshal(map[string]string{"stream": "stdout", "line": line})
+		emit(s.events, agent.Event{Kind: "agent.message", Body: body})
+	}
+}
+
+// resolveOutput returns the parsed structured output. The stdout RESULT: line
+// is the canonical signal (per #321 schema description). If absent, we fall
+// back to the --result-file written by AgentM. Returns (nil, err) when
+// neither is parseable.
+func (s *session) resolveOutput() (*Output, error) {
+	s.mu.Lock()
+	resultLine := s.resultLineRaw
+	resultPath := s.resultFile
+	sessionPath := s.sessionLog
+	s.mu.Unlock()
+
+	if resultLine != "" {
+		out, err := ParseAndValidate([]byte(resultLine))
+		if err != nil {
+			return nil, fmt.Errorf("agentm: invalid RESULT: line: %w", err)
+		}
+		if out.SessionLogPath == "" && fileExists(sessionPath) {
+			out.SessionLogPath = sessionPath
+		}
+		return out, nil
+	}
+
+	if data, err := os.ReadFile(resultPath); err == nil {
+		out, perr := ParseAndValidate(data)
+		if perr != nil {
+			return nil, fmt.Errorf("agentm: invalid result file %s: %w", resultPath, perr)
+		}
+		if out.SessionLogPath == "" && fileExists(sessionPath) {
+			out.SessionLogPath = sessionPath
+		}
+		return out, nil
+	}
+
+	return nil, fmt.Errorf("agentm: no RESULT: line on stdout and no result file at %s", resultPath)
+}
+
+// Output is the host representation of schemas/agentm-output.schema.json.
+type Output struct {
+	Success        bool   `json:"success"`
+	NextLabel      string `json:"next_label"`
+	ArtifactPath   string `json:"artifact_path,omitempty"`
+	SessionLogPath string `json:"session_log_path,omitempty"`
+	FailureReason  string `json:"failure_reason,omitempty"`
+}
+
+func emit(ch chan<- agent.Event, evt agent.Event) {
+	defer func() { _ = recover() }()
+	select {
+	case ch <- evt:
+	default:
+		// Drop on slow consumer to avoid blocking the read goroutine.
+	}
+}
+
+func writeTaskFile(path string, spec agent.Spec) error {
+	doc := map[string]any{
+		"schema_version": 1,
+		"workspace":      spec.Workdir,
+		"prompt":         spec.Prompt,
+		"model":          spec.Model,
+		"sandbox":        spec.Sandbox,
+		"approval":       spec.Approval,
+		"tags":           spec.Tags,
+	}
+	// Pull workbuddy-* env into structured fields so AgentM doesn't have
+	// to read them from process env to populate spans/audit.
+	if v := spec.Env["WORKBUDDY_ISSUE_NUMBER"]; v != "" {
+		doc["issue_number"] = v
+	}
+	if v := spec.Env["WORKBUDDY_ISSUE_TITLE"]; v != "" {
+		doc["issue_title"] = v
+	}
+	if v := spec.Env["WORKBUDDY_REPO"]; v != "" {
+		doc["repo"] = v
+	}
+	if v := spec.Env["WORKBUDDY_SESSION_ID"]; v != "" {
+		doc["session_id"] = v
+	}
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+func fileExists(p string) bool {
+	if p == "" {
+		return false
+	}
+	_, err := os.Stat(p)
+	return err == nil
+}

--- a/internal/agent/agentm/backend_test.go
+++ b/internal/agent/agentm/backend_test.go
@@ -1,0 +1,212 @@
+package agentm_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Lincyaw/workbuddy/internal/agent"
+	"github.com/Lincyaw/workbuddy/internal/agent/agentm"
+	"github.com/Lincyaw/workbuddy/internal/agent/agentm/agentmtest"
+)
+
+func newSpec(t *testing.T) agent.Spec {
+	t.Helper()
+	work := t.TempDir()
+	return agent.Spec{
+		Backend: "agentm",
+		Workdir: work,
+		Prompt:  "do the thing",
+		Env: map[string]string{
+			"WORKBUDDY_ISSUE_NUMBER": "319",
+			"WORKBUDDY_REPO":         "Lincyaw/workbuddy",
+			"WORKBUDDY_SESSION_ID":   "test-session",
+			"TRACEPARENT":            "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+		},
+	}
+}
+
+func TestBackend_HappyPath_Success(t *testing.T) {
+	fake := agentmtest.BuildFake(t, agentmtest.Config{Mode: agentmtest.ModeSuccess})
+	be := &agentm.Backend{Binary: fake}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	sess, err := be.NewSession(ctx, newSpec(t))
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	// Drain events in the background; the channel must close.
+	doneEvt := make(chan struct{})
+	go func() {
+		for range sess.Events() {
+		}
+		close(doneEvt)
+	}()
+	res, err := sess.Wait(ctx)
+	if err != nil {
+		t.Fatalf("Wait returned error: %v", err)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("expected exit 0, got %d", res.ExitCode)
+	}
+	<-doneEvt
+
+	extractor, ok := sess.(interface {
+		Output() (*agentm.Output, error)
+		SessionLogPath() string
+	})
+	if !ok {
+		t.Fatalf("session does not expose Output()")
+	}
+	out, perr := extractor.Output()
+	if perr != nil {
+		t.Fatalf("Output(): %v", perr)
+	}
+	if !out.Success {
+		t.Fatalf("expected success=true")
+	}
+	if out.NextLabel != "status:review" {
+		t.Fatalf("expected next_label=status:review, got %q", out.NextLabel)
+	}
+	logPath := extractor.SessionLogPath()
+	if logPath == "" {
+		t.Fatalf("expected session log path")
+	}
+	if _, err := os.Stat(logPath); err != nil {
+		t.Fatalf("session log missing: %v", err)
+	}
+}
+
+func TestBackend_MalformedJSON_IsInfraFailure(t *testing.T) {
+	fake := agentmtest.BuildFake(t, agentmtest.Config{Mode: agentmtest.ModeMalformedJSON})
+	be := &agentm.Backend{Binary: fake}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	sess, err := be.NewSession(ctx, newSpec(t))
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	go func() {
+		for range sess.Events() {
+		}
+	}()
+	_, err = sess.Wait(ctx)
+	if err == nil {
+		t.Fatalf("expected wait error for malformed RESULT")
+	}
+	extractor := sess.(interface {
+		Output() (*agentm.Output, error)
+	})
+	out, perr := extractor.Output()
+	if perr == nil {
+		t.Fatalf("expected Output() parse error, got out=%+v", out)
+	}
+}
+
+func TestBackend_MissingRequired_SchemaError(t *testing.T) {
+	fake := agentmtest.BuildFake(t, agentmtest.Config{Mode: agentmtest.ModeMissingRequired})
+	be := &agentm.Backend{Binary: fake}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	sess, err := be.NewSession(ctx, newSpec(t))
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	go func() {
+		for range sess.Events() {
+		}
+	}()
+	_, err = sess.Wait(ctx)
+	if err == nil {
+		t.Fatalf("expected wait error for missing required field")
+	}
+}
+
+func TestBackend_Failure_SurfacesReason(t *testing.T) {
+	fake := agentmtest.BuildFake(t, agentmtest.Config{
+		Mode:          agentmtest.ModeFailure,
+		FailureReason: "tests fail",
+		NextLabel:     "status:failed",
+	})
+	be := &agentm.Backend{Binary: fake}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	sess, err := be.NewSession(ctx, newSpec(t))
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	go func() {
+		for range sess.Events() {
+		}
+	}()
+	_, err = sess.Wait(ctx)
+	if err == nil {
+		t.Fatalf("expected wait error for task failure")
+	}
+	extractor := sess.(interface {
+		Output() (*agentm.Output, error)
+	})
+	out, perr := extractor.Output()
+	if perr != nil {
+		t.Fatalf("Output(): %v", perr)
+	}
+	if out.Success {
+		t.Fatalf("expected success=false")
+	}
+	if out.FailureReason != "tests fail" {
+		t.Fatalf("got failure_reason=%q", out.FailureReason)
+	}
+	if out.NextLabel != "status:failed" {
+		t.Fatalf("got next_label=%q", out.NextLabel)
+	}
+}
+
+func TestBackend_NoResult_IsInfraFailure(t *testing.T) {
+	fake := agentmtest.BuildFake(t, agentmtest.Config{Mode: agentmtest.ModeNoResult})
+	be := &agentm.Backend{Binary: fake}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	sess, err := be.NewSession(ctx, newSpec(t))
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	go func() {
+		for range sess.Events() {
+		}
+	}()
+	_, err = sess.Wait(ctx)
+	if err == nil {
+		t.Fatalf("expected wait error when no RESULT emitted")
+	}
+}
+
+func TestParseAndValidate_RejectsBadLabel(t *testing.T) {
+	_, err := agentm.ParseAndValidate([]byte(`{"success":true,"next_label":"NotAStatus","session_log_path":"/tmp/x"}`))
+	if err == nil {
+		t.Fatalf("expected schema error for invalid next_label pattern")
+	}
+}
+
+func TestSchemaEmbedMatchesRepo(t *testing.T) {
+	// Guardrail: keep the embedded schema in lockstep with the canonical
+	// schemas/agentm-output.schema.json so contributors who touch one are
+	// nudged to touch the other.
+	repoSchema, err := os.ReadFile(filepath.Join("..", "..", "..", "schemas", "agentm-output.schema.json"))
+	if err != nil {
+		t.Fatalf("read canonical schema: %v", err)
+	}
+	embedded, err := os.ReadFile("agentm-output.schema.json")
+	if err != nil {
+		t.Fatalf("read embedded schema: %v", err)
+	}
+	if string(repoSchema) != string(embedded) {
+		t.Fatalf("internal/agent/agentm/agentm-output.schema.json drifted from schemas/agentm-output.schema.json; please re-copy")
+	}
+}

--- a/internal/agent/agentm/output.go
+++ b/internal/agent/agentm/output.go
@@ -1,0 +1,61 @@
+package agentm
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/xeipuuv/gojsonschema"
+)
+
+// schemaJSON embeds the canonical structured-output contract that ships with
+// the repo at schemas/agentm-output.schema.json. Keeping it embedded means
+// validation works regardless of the worker process's cwd at dispatch time.
+//
+//go:embed agentm-output.schema.json
+var schemaJSON []byte
+
+var compiledSchema *gojsonschema.Schema
+
+func init() {
+	loader := gojsonschema.NewBytesLoader(schemaJSON)
+	schema, err := gojsonschema.NewSchema(loader)
+	if err != nil {
+		// Embedded schema is part of the binary; a parse failure here is a
+		// build-time bug, not a runtime condition. Panic is acceptable.
+		panic(fmt.Sprintf("agentm: compile embedded output schema: %v", err))
+	}
+	compiledSchema = schema
+}
+
+// ParseAndValidate parses raw JSON (the body of a RESULT: line or a result
+// file) and returns the typed Output. It returns an error if the JSON is
+// malformed OR if it fails schema validation; the error message is single-
+// line and safe to drop into an issue comment as a failure_reason.
+func ParseAndValidate(raw []byte) (*Output, error) {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" {
+		return nil, fmt.Errorf("empty structured output")
+	}
+
+	documentLoader := gojsonschema.NewStringLoader(trimmed)
+	res, err := compiledSchema.Validate(documentLoader)
+	if err != nil {
+		return nil, fmt.Errorf("validate: %w", err)
+	}
+	if !res.Valid() {
+		issues := res.Errors()
+		msgs := make([]string, 0, len(issues))
+		for _, e := range issues {
+			msgs = append(msgs, e.String())
+		}
+		return nil, fmt.Errorf("schema violations: %s", strings.Join(msgs, "; "))
+	}
+
+	var out Output
+	if err := json.Unmarshal([]byte(trimmed), &out); err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+	return &out, nil
+}

--- a/internal/launcher/launcher.go
+++ b/internal/launcher/launcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/Lincyaw/workbuddy/internal/agent"
+	"github.com/Lincyaw/workbuddy/internal/agent/agentm"
 	"github.com/Lincyaw/workbuddy/internal/agent/codex"
 	"github.com/Lincyaw/workbuddy/internal/config"
 	runtimepkg "github.com/Lincyaw/workbuddy/internal/runtime"
@@ -44,4 +45,7 @@ func RegisterBuiltins(l *runtimepkg.Registry) {
 	l.Register(newAgentBridgeRuntime(config.RuntimeCodex, func() (agent.Backend, error) {
 		return codex.NewBackend(codex.Config{})
 	}), config.RuntimeCodex, config.RuntimeCodexServer)
+	l.Register(newAgentBridgeRuntime(config.RuntimeAgentM, func() (agent.Backend, error) {
+		return agentm.NewBackend(), nil
+	}), config.RuntimeAgentM)
 }

--- a/internal/runtime/agent_bridge.go
+++ b/internal/runtime/agent_bridge.go
@@ -9,10 +9,14 @@ import (
 	"time"
 
 	"github.com/Lincyaw/workbuddy/internal/agent"
+	"github.com/Lincyaw/workbuddy/internal/agent/agentm"
 	"github.com/Lincyaw/workbuddy/internal/agent/claude"
 	"github.com/Lincyaw/workbuddy/internal/agent/codex"
 	"github.com/Lincyaw/workbuddy/internal/config"
 	launcherevents "github.com/Lincyaw/workbuddy/internal/launcher/events"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 )
 
 func NewBackendFromConfig(runtimeName string) (agent.Backend, error) {
@@ -21,6 +25,8 @@ func NewBackendFromConfig(runtimeName string) (agent.Backend, error) {
 		return codex.NewBackend(codex.Config{})
 	case config.RuntimeClaudeCode, config.RuntimeClaudeShot:
 		return claude.NewBackend(), nil
+	case config.RuntimeAgentM:
+		return agentm.NewBackend(), nil
 	default:
 		return nil, fmt.Errorf("agent: unsupported runtime %q", runtimeName)
 	}
@@ -81,7 +87,7 @@ func (r *AgentBridgeRuntime) Start(ctx context.Context, agentCfg *config.AgentCo
 		Model:    agentCfg.Policy.Model,
 		Sandbox:  agentCfg.Policy.Sandbox,
 		Approval: agentCfg.Policy.Approval,
-		Env:      envSliceToMap(BuildScopedEnv(agentCfg, task)),
+		Env:      injectTraceContext(ctx, envSliceToMap(BuildScopedEnv(agentCfg, task)), task),
 		Tags: map[string]string{
 			"agent": agentCfg.Name,
 			"repo":  task.Repo,
@@ -212,13 +218,44 @@ func (s *AgentBridgeSession) Run(ctx context.Context, events chan<- launchereven
 	}
 	<-pumpDone
 
-	var meta map[string]string
+	meta := map[string]string{}
 	if len(agentResult.FilesChanged) > 0 {
-		meta = map[string]string{
-			"files_changed": strings.Join(agentResult.FilesChanged, ","),
-		}
+		meta["files_changed"] = strings.Join(agentResult.FilesChanged, ",")
 	}
 	sessionPath := bridgeSessionPath(s.Handle)
+
+	// AgentM exposes a structured RESULT: contract. If the underlying
+	// session is an AgentM session, surface next_label/failure_reason on
+	// the Result so reporter/audit can render it and route the state
+	// machine. A malformed/missing RESULT is an infra failure.
+	if extractor, ok := s.Session.(interface {
+		Output() (*agentm.Output, error)
+		SessionLogPath() string
+	}); ok {
+		if logPath := extractor.SessionLogPath(); logPath != "" {
+			sessionPath = logPath
+		}
+		out, perr := extractor.Output()
+		switch {
+		case perr != nil:
+			// Build a Result we can mark as infra failure; the bridge
+			// returns the wait error so the worker treats this as failed.
+			meta[MetaInfraFailure] = "true"
+			meta[MetaInfraFailureReason] = perr.Error()
+		case out != nil:
+			meta["agentm_next_label"] = out.NextLabel
+			if out.ArtifactPath != "" {
+				meta["agentm_artifact_path"] = out.ArtifactPath
+			}
+			if !out.Success {
+				meta["agentm_failure_reason"] = out.FailureReason
+			}
+		}
+	}
+
+	if len(meta) == 0 {
+		meta = nil
+	}
 	return &Result{
 		ExitCode:       agentResult.ExitCode,
 		Duration:       agentResult.Duration,
@@ -257,6 +294,32 @@ func resolvePrompt(agentCfg *config.AgentConfig, task *TaskContext) string {
 		return cmd
 	}
 	return ""
+}
+
+// injectTraceContext adds W3C TraceContext (TRACEPARENT, TRACESTATE) and
+// workbuddy run/issue identifiers to the agent env so OTel-aware runtimes
+// (today: AgentM) can continue the parent span. Idempotent: if env already
+// contains TRACEPARENT, it is preserved.
+func injectTraceContext(ctx context.Context, env map[string]string, task *TaskContext) map[string]string {
+	if env == nil {
+		env = map[string]string{}
+	}
+	carrier := propagation.MapCarrier{}
+	otel.GetTextMapPropagator().Inject(ctx, carrier)
+	for k, v := range carrier {
+		// MapCarrier keys are lowercase; uppercase them for env-var
+		// convention (TRACEPARENT, TRACESTATE, BAGGAGE).
+		upper := strings.ToUpper(k)
+		if _, exists := env[upper]; !exists {
+			env[upper] = v
+		}
+	}
+	if task != nil {
+		if _, ok := env["WORKBUDDY_RUN_ID"]; !ok && task.Session.ID != "" {
+			env["WORKBUDDY_RUN_ID"] = task.Session.ID
+		}
+	}
+	return env
 }
 
 func envSliceToMap(entries []string) map[string]string {

--- a/internal/runtime/agentm_bridge_test.go
+++ b/internal/runtime/agentm_bridge_test.go
@@ -1,0 +1,128 @@
+package runtime
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Lincyaw/workbuddy/internal/agent"
+	"github.com/Lincyaw/workbuddy/internal/agent/agentm"
+	"github.com/Lincyaw/workbuddy/internal/agent/agentm/agentmtest"
+	"github.com/Lincyaw/workbuddy/internal/config"
+)
+
+// TestAgentMBridge_HappyPath wires an AgentMBackend (pointed at the fake
+// binary) into the bridge runtime and walks the full Start → Run → Result
+// path. This is the v0.5 host-exec happy-path covered by AC-1-1.
+func TestAgentMBridge_HappyPath(t *testing.T) {
+	fake := agentmtest.BuildFake(t, agentmtest.Config{Mode: agentmtest.ModeSuccess})
+	rt := NewAgentBridgeRuntime(config.RuntimeAgentM, func() (agent.Backend, error) {
+		return &agentm.Backend{Binary: fake}, nil
+	})
+
+	work := t.TempDir()
+	task := &TaskContext{
+		Repo:     "Lincyaw/workbuddy",
+		WorkDir:  work,
+		RepoRoot: work,
+		Issue:    IssueContext{Number: 319, Title: "test"},
+		Session:  SessionContext{ID: "test-session", TaskID: "task-1", Attempt: 1},
+	}
+	agentCfg := &config.AgentConfig{
+		Name:    "dev-agent",
+		Runtime: config.RuntimeAgentM,
+		Role:    "dev",
+		Prompt:  "ship REQ-134",
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	res, err := rt.Launch(ctx, agentCfg, task)
+	if err != nil {
+		t.Fatalf("Launch: %v", err)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("exit=%d", res.ExitCode)
+	}
+	if got := res.Meta["agentm_next_label"]; got != "status:review" {
+		t.Fatalf("next_label meta = %q", got)
+	}
+	if res.SessionPath == "" {
+		t.Fatalf("expected SessionPath populated from agentm session_log_path")
+	}
+}
+
+// TestAgentMBridge_MalformedRESULT covers AC-1-2: a malformed RESULT line
+// is classified as infra failure with failure_reason captured in
+// Result.Meta so the reporter can surface it.
+func TestAgentMBridge_MalformedRESULT(t *testing.T) {
+	fake := agentmtest.BuildFake(t, agentmtest.Config{Mode: agentmtest.ModeMalformedJSON})
+	rt := NewAgentBridgeRuntime(config.RuntimeAgentM, func() (agent.Backend, error) {
+		return &agentm.Backend{Binary: fake}, nil
+	})
+
+	work := t.TempDir()
+	task := &TaskContext{
+		Repo:    "Lincyaw/workbuddy",
+		WorkDir: work,
+		Issue:   IssueContext{Number: 319},
+		Session: SessionContext{ID: "test-session"},
+	}
+	agentCfg := &config.AgentConfig{Name: "dev-agent", Runtime: config.RuntimeAgentM}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	res, err := rt.Launch(ctx, agentCfg, task)
+	if err == nil {
+		t.Fatalf("expected error for malformed RESULT")
+	}
+	if res == nil {
+		t.Fatalf("expected result even on failure")
+	}
+	if !IsInfraFailure(res) {
+		t.Fatalf("expected infra failure marker, meta=%v", res.Meta)
+	}
+	reason := res.Meta[MetaInfraFailureReason]
+	if !strings.Contains(reason, "invalid RESULT") && !strings.Contains(reason, "invalid result file") {
+		t.Fatalf("failure_reason should mention invalid RESULT, got %q", reason)
+	}
+}
+
+// TestAgentMBridge_TaskFailure covers the case where AgentM cleanly reports
+// success=false. next_label MUST still be present and the reason MUST flow
+// into Meta so the reporter comment carries it.
+func TestAgentMBridge_TaskFailure(t *testing.T) {
+	fake := agentmtest.BuildFake(t, agentmtest.Config{
+		Mode:          agentmtest.ModeFailure,
+		NextLabel:     "status:failed",
+		FailureReason: "acceptance criteria not met",
+	})
+	rt := NewAgentBridgeRuntime(config.RuntimeAgentM, func() (agent.Backend, error) {
+		return &agentm.Backend{Binary: fake}, nil
+	})
+
+	work := t.TempDir()
+	task := &TaskContext{
+		Repo: "Lincyaw/workbuddy", WorkDir: work,
+		Issue:   IssueContext{Number: 319},
+		Session: SessionContext{ID: "test-session"},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	res, err := rt.Launch(ctx, &config.AgentConfig{Name: "dev-agent", Runtime: config.RuntimeAgentM}, task)
+	if err == nil {
+		t.Fatalf("expected error when agentm reports failure")
+	}
+	if res.Meta["agentm_next_label"] != "status:failed" {
+		t.Fatalf("next_label meta = %q", res.Meta["agentm_next_label"])
+	}
+	if res.Meta["agentm_failure_reason"] != "acceptance criteria not met" {
+		t.Fatalf("failure_reason meta = %q", res.Meta["agentm_failure_reason"])
+	}
+	// Task failure is distinct from infra failure: this is a clean signal
+	// from the agent, not a contract violation.
+	if IsInfraFailure(res) {
+		t.Fatalf("clean failure should NOT be infra-failure")
+	}
+}

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -4920,3 +4920,39 @@ requirements:
       - internal/store/store_session_routes_test.go
       - internal/store/store_supervisor_agent_id_test.go
     deps: []
+
+  - id: REQ-134
+    title: AgentM host-exec dispatch + session artifact wiring (v0.5)
+    description: >
+      Implements the dispatch slice of the AgentM runtime introduced by
+      REQ-133. The worker recognizes `runtime: agentm`, exec's the AgentM
+      CLI as a subprocess (host-exec, self-managed), assembles inputs per
+      docs/planned/agentm-runtime.md (workspace, task file, env including
+      TRACEPARENT propagated from the current OTel context, WORKBUDDY_*),
+      parses the structured RESULT: line on stdout, validates it against
+      schemas/agentm-output.schema.json, emits the standard session
+      artifact shape, and surfaces next_label / failure_reason on the
+      runtime Result so reporter/audit render it. Malformed RESULT or
+      missing required schema fields are classified as infra failures.
+      Sandbox / coordinator-managed mode is v0.6.
+    priority: P1
+    version: v0.5.0
+    status: tested
+    acceptance_criteria:
+      - "AC-1-1: Issue with `runtime: agentm` dispatched on a worker that has `agentm` CLI on PATH completes a happy-path cycle in integration test (using fake AgentM)."
+      - "AC-1-2: Malformed JSON output from AgentM is caught and surfaces as a `status:failed` with a clear failure_reason in the issue comment."
+      - "AC-1-3: Session artifact for an AgentM run is readable through the same session-view UI as claude-code runs."
+      - "AC-1-4: `go build ./... && go vet ./... && go test ./... -count=1` all pass."
+      - "AC-1-5: `project-index.yaml` REQ updated with status `tested`."
+    code:
+      - internal/agent/agentm/backend.go
+      - internal/agent/agentm/output.go
+      - internal/agent/agentm/agentm-output.schema.json
+      - internal/agent/agentm/agentmtest/fake.go
+      - internal/runtime/agent_bridge.go
+      - internal/launcher/launcher.go
+    tests:
+      - internal/agent/agentm/backend_test.go
+      - internal/runtime/agentm_bridge_test.go
+    deps:
+      - REQ-133


### PR DESCRIPTION
Closes #319. Implements the v0.5 host-exec dispatch path for the AgentM
runtime contract that landed in #321 (REQ-133).

## Summary

- New `internal/agent/agentm` package: `agent.Backend` that exec's the
  `agentm` binary, parses the `RESULT: {…}` stdout line (the canonical
  contract per `schemas/agentm-output.schema.json`), validates against
  the embedded schema, and surfaces structured output.
- New `internal/agent/agentm/agentmtest` fake-binary harness mirroring
  the codextest pattern.
- Bridge wiring: `runtime/agent_bridge.go` recognises the AgentM
  session, surfaces `next_label` / `failure_reason` / `artifact_path` on
  the runtime `Result`, classifies malformed/missing RESULT as infra
  failures, and routes the AgentM-written session log into
  `Result.SessionPath` so the existing session-view UI ingests it.
- Trace propagation: a new `injectTraceContext` helper writes the
  current OTel `TRACEPARENT` + `WORKBUDDY_RUN_ID` into every bridged
  agent's env (no-op when no active span; AgentM is the first runtime to
  consume it).
- Registry: `launcher.RegisterBuiltins` and
  `runtime.NewBackendFromConfig` now know about `runtime: agentm`.
- REQ-134 added to `project-index.yaml` with status `tested`.

## AC coverage

- **AC-1-1** — `TestAgentMBridge_HappyPath`
  (`internal/runtime/agentm_bridge_test.go`): bridge dispatches with
  `runtime: agentm`, fake binary produces a valid RESULT line, cycle
  completes, `next_label` propagates, session artifact is readable.
- **AC-1-2** — `TestAgentMBridge_MalformedRESULT` +
  `TestBackend_MalformedJSON_IsInfraFailure`: malformed RESULT marks
  infra failure with the parse error captured in
  `Meta[infra_failure_reason]` so the reporter comment surfaces it. A
  clean `success=false` outcome (`TestAgentMBridge_TaskFailure`) is
  routed as a task failure with `failure_reason` in
  `Meta[agentm_failure_reason]`.
- **AC-1-3** — `TestBackend_HappyPath_Success` asserts the session log
  path is populated and the file exists; the bridge promotes it to
  `Result.SessionPath`, the same field the session-view UI consumes for
  claude-code / codex.
- **AC-1-4** — `go build ./... && go vet ./... && go test ./... -count=1`
  all green locally.
- **AC-1-5** — `project-index.yaml` adds REQ-134 with `status: tested`;
  `validate_index.py` passes.

## Constraints honored

- Host-exec self-managed only — no sandbox / coordinator-managed work
  (v0.6).
- Honors the stdout `RESULT:` convention from #321; the `--result-file`
  fallback the doc also describes is a defense-in-depth fallback, not a
  replacement.
- No new GitHub write operations in Go code (label flips remain agent-
  side); the worker captures `next_label` for observability only.
- `internal/webui/dist/index.html` untouched.

## Deviations / notes

- Embedded schema copy at `internal/agent/agentm/agentm-output.schema.json`
  duplicates `schemas/agentm-output.schema.json` because Go's `go:embed`
  forbids `..` paths. A guardrail test (`TestSchemaEmbedMatchesRepo`)
  fails if the two drift.
- The per-session temp dir (task-file + result-file + session-log) is
  not auto-cleaned at session close because the session log is consumed
  by the audit layer after `Wait` returns; lifecycle cleanup belongs to
  the worker session manager.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1`
- [x] `go run . validate-docs --strict`
- [x] `python3 ~/.autoharness/scripts/validate_index.py project-index.yaml`
- [ ] Manual smoke: dispatch a real `runtime: agentm` config against the
      upstream `agentm` CLI once the cross-repo adapter lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)