### PR TITLE
v0.6: Workbuddy Helm chart skeleton (REQ-143, closes #331)

### DIFF
--- a/deploy/helm/workbuddy/Chart.yaml
+++ b/deploy/helm/workbuddy/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v2
+name: workbuddy
+description: |
+  Workbuddy coordinator — GitHub Issue-driven agent orchestration platform.
+  This chart deploys the coordinator process for the K8s topology (single-replica,
+  MySQL-backed, OTel-instrumented). Agent execution (claude-code, codex, agentm)
+  and ingress are configured separately; see the decision doc
+  docs/decisions/2026-05-13-k8s-agentm-otel.md for the full v0.6 design.
+type: application
+version: 0.6.0
+appVersion: "v0.6.0"
+keywords:
+  - workbuddy
+  - github
+  - agent
+  - orchestration
+  - coordinator
+home: https://github.com/Lincyaw/workbuddy
+sources:
+  - https://github.com/Lincyaw/workbuddy
+maintainers:
+  - name: Workbuddy maintainers

--- a/deploy/helm/workbuddy/README.md
+++ b/deploy/helm/workbuddy/README.md
@@ -1,0 +1,43 @@
+# workbuddy Helm chart (skeleton)
+
+Skeleton chart for deploying the workbuddy coordinator into a Kubernetes
+cluster. Single-replica, MySQL-backed, OTel-instrumented — the K8s topology
+described in `docs/decisions/2026-05-13-k8s-agentm-otel.md` Block 3.
+
+This chart is intentionally minimal at v0.6.0. The full values surface
+(MySQL host/user/pass/db split, OTel resource attributes, AegisLab topology
+wiring, ingress) is hardened in **#334**. Ingress is **#333**.
+
+## Install
+
+```bash
+helm install my-workbuddy deploy/helm/workbuddy \
+  --set mysql.dsn=mysql://user:pass@mysql.aegislab.svc:3306/workbuddy \
+  --set otel.endpoint=http://otel-collector.aegislab.svc:4317 \
+  --set giteaToken.secretName=workbuddy-gitea
+```
+
+## Required values
+
+| Key | Description |
+|-----|-------------|
+| `mysql.dsn` | MySQL DSN (reused from AegisLab; see decision doc Block 3). |
+| `otel.endpoint` | OTel collector endpoint. Empty disables export. |
+| `giteaToken.secretName` | Name of an existing Secret with key `token`. |
+| `agents.configMapName` | Name of an existing ConfigMap holding `.github/workbuddy/agents/*.md`. |
+
+If `giteaToken.secretName` is empty **and** `giteaToken.token` is set, the
+chart will materialize a Secret for dev use. Likewise, if
+`agents.configMapName` is empty, the chart renders a ConfigMap populated
+from `deploy/helm/workbuddy/agents/*.md` (empty by default — bundle your
+defaults there or override).
+
+## What's not here yet
+
+- Ingress (tracked in **#333**).
+- Full values surface — split MySQL fields, OTel docs, AegisLab topology
+  defaults (tracked in **#334**).
+- Worker deployment — K8s mode collapses worker into the coordinator
+  process per decision doc Block 2 § Architectural consequences. AgentM
+  execution goes through the agent-env Gateway, which has its own Helm
+  release.

--- a/deploy/helm/workbuddy/templates/_helpers.tpl
+++ b/deploy/helm/workbuddy/templates/_helpers.tpl
@@ -1,0 +1,80 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "workbuddy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "workbuddy.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Chart name + version label.
+*/}}
+{{- define "workbuddy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels.
+*/}}
+{{- define "workbuddy.labels" -}}
+helm.sh/chart: {{ include "workbuddy.chart" . }}
+{{ include "workbuddy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "workbuddy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "workbuddy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Image reference (repository:tag), defaulting tag to AppVersion.
+*/}}
+{{- define "workbuddy.image" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+
+{{/*
+Name of the Gitea-token Secret to mount. If user supplied an existing one,
+use it as-is; otherwise refer to the chart-managed Secret.
+*/}}
+{{- define "workbuddy.giteaSecretName" -}}
+{{- if .Values.giteaToken.secretName -}}
+{{- .Values.giteaToken.secretName -}}
+{{- else -}}
+{{- printf "%s-gitea" (include "workbuddy.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Name of the agent-configs ConfigMap to mount. Same pattern as Gitea Secret.
+*/}}
+{{- define "workbuddy.agentsConfigMapName" -}}
+{{- if .Values.agents.configMapName -}}
+{{- .Values.agents.configMapName -}}
+{{- else -}}
+{{- printf "%s-agents" (include "workbuddy.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/workbuddy/templates/configmap.yaml
+++ b/deploy/helm/workbuddy/templates/configmap.yaml
@@ -1,0 +1,23 @@
+{{- /*
+Render an agent-configs ConfigMap only when the user has not pointed at an
+existing one via .Values.agents.configMapName. The chart bundles default
+agent definitions in deploy/helm/workbuddy/agents/*.md; .Files.Glob picks
+them up at render time. If no defaults are bundled the ConfigMap is created
+empty — production deployments should override `agents.configMapName` with
+their organization's ConfigMap (see README, #334 for the full surface).
+*/ -}}
+{{- if not .Values.agents.configMapName }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "workbuddy.agentsConfigMapName" . }}
+  labels:
+    {{- include "workbuddy.labels" . | nindent 4 }}
+{{- $files := .Files.Glob "agents/*.md" }}
+{{- if $files }}
+data:
+{{ ($files).AsConfig | indent 2 }}
+{{- else }}
+data: {}
+{{- end }}
+{{- end }}

--- a/deploy/helm/workbuddy/templates/deployment.yaml
+++ b/deploy/helm/workbuddy/templates/deployment.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "workbuddy.fullname" . }}
+  labels:
+    {{- include "workbuddy.labels" . | nindent 4 }}
+spec:
+  # Single-replica + Recreate per decision doc Block 3 § Storage.
+  # Horizontal scale-out requires leader election and is deferred.
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "workbuddy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "workbuddy.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: coordinator
+          image: {{ include "workbuddy.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          args:
+            - coordinator
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          env:
+            - name: WORKBUDDY_MYSQL_DSN
+              value: {{ .Values.mysql.dsn | quote }}
+            - name: WORKBUDDY_OTEL_ENDPOINT
+              value: {{ .Values.otel.endpoint | quote }}
+            - name: WORKBUDDY_GITEA_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "workbuddy.giteaSecretName" . }}
+                  key: token
+            - name: WORKBUDDY_AGENTS_DIR
+              value: /etc/workbuddy/agents
+          volumeMounts:
+            - name: agents
+              mountPath: /etc/workbuddy/agents
+              readOnly: true
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: agents
+          configMap:
+            name: {{ include "workbuddy.agentsConfigMapName" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/workbuddy/templates/secret.yaml
+++ b/deploy/helm/workbuddy/templates/secret.yaml
@@ -1,0 +1,17 @@
+{{- /*
+Only render a Secret if the user did NOT supply an existing Secret name.
+In production they should pre-create the Secret out-of-band (sealed-secrets,
+ExternalSecrets, etc.) and set .Values.giteaToken.secretName to its name.
+This in-chart path is for dev / quick-start only.
+*/ -}}
+{{- if and (not .Values.giteaToken.secretName) .Values.giteaToken.token }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "workbuddy.giteaSecretName" . }}
+  labels:
+    {{- include "workbuddy.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  token: {{ .Values.giteaToken.token | quote }}
+{{- end }}

--- a/deploy/helm/workbuddy/templates/service.yaml
+++ b/deploy/helm/workbuddy/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "workbuddy.fullname" . }}
+  labels:
+    {{- include "workbuddy.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "workbuddy.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/workbuddy/values.yaml
+++ b/deploy/helm/workbuddy/values.yaml
@@ -1,0 +1,52 @@
+# Default values for workbuddy.
+# This is a minimal skeleton; the full values surface (MySQL, OTel, AegisLab
+# topology) is hardened in issue #334. See deploy/helm/workbuddy/README.md.
+
+image:
+  repository: ghcr.io/lincyaw/workbuddy
+  tag: ""          # defaults to .Chart.AppVersion when empty
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# Coordinator HTTP API + webui port. Verified against cmd/coordinator.go
+# (default 8080, see cmd/init.go).
+service:
+  type: ClusterIP
+  port: 8080
+
+# MySQL DSN — workbuddy reuses AegisLab's MySQL cluster in v0.6.
+# Format: mysql://user:pass@host:3306/dbname (REQ-135/REQ-136).
+# #334 will split this into discrete host/user/pass/db fields.
+mysql:
+  dsn: ""
+
+# OpenTelemetry collector endpoint. Workbuddy reuses AegisLab's collector
+# (decision doc Block 4). Empty disables exporter.
+otel:
+  endpoint: ""
+
+# Gitea (or GitHub) API token used by the coordinator for gh issue read /
+# comment writes. Two modes:
+#   - secretName != "": chart references an existing Secret with key "token".
+#   - secretName == "" && token != "": chart creates a Secret from .token.
+giteaToken:
+  secretName: ""
+  token: ""
+
+# Agent config ConfigMap (.github/workbuddy/agents/*.md). Mounted at
+# /etc/workbuddy/agents in the coordinator pod.
+#   - configMapName != "": chart references an existing ConfigMap.
+#   - configMapName == "": chart creates one from chart-bundled agents/*.md.
+agents:
+  configMapName: ""
+
+resources: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
+podAnnotations: {}
+podSecurityContext: {}
+securityContext: {}

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -5099,6 +5099,69 @@ requirements:
       - REQ-135
       - REQ-136
 
+  - id: REQ-143
+    title: Workbuddy Helm chart skeleton (v0.6)
+    description: >
+      Per docs/decisions/2026-05-13-k8s-agentm-otel.md Block 3
+      § Chart layout, the K8s topology requires a Helm chart that
+      deploys the coordinator as a single-replica Deployment with
+      Recreate strategy, backed by external MySQL (reused from
+      AegisLab) and reporting to an external OTel collector.
+      Issue #331.
+
+      This slice is intentionally the skeleton: just enough to
+      `helm install` a renderable manifest set. Ingress (#333) and
+      the full values surface — MySQL host/user/pass/db split,
+      OTel resource attributes, AegisLab topology defaults (#334)
+      — are tracked separately.
+
+      Layout under deploy/helm/workbuddy/:
+        - Chart.yaml: apiVersion v2, type application, version
+          0.6.0, appVersion v0.6.0.
+        - values.yaml: minimal placeholders — image, mysql.dsn,
+          otel.endpoint, giteaToken.secretName / giteaToken.token,
+          agents.configMapName, service.type/port.
+        - templates/_helpers.tpl: standard helm helpers — name,
+          fullname, chart, labels, selectorLabels, image,
+          giteaSecretName, agentsConfigMapName.
+        - templates/deployment.yaml: single-replica coordinator,
+          strategy.type Recreate, env wired for WORKBUDDY_MYSQL_DSN,
+          WORKBUDDY_OTEL_ENDPOINT, WORKBUDDY_GITEA_TOKEN (from
+          secretKeyRef), WORKBUDDY_AGENTS_DIR. Mounts agents
+          ConfigMap at /etc/workbuddy/agents.
+        - templates/service.yaml: ClusterIP, port 8080 (default
+          coordinator port from cmd/init.go and cmd/coordinator.go).
+        - templates/configmap.yaml: agent-configs ConfigMap, only
+          rendered when agents.configMapName is empty. Uses
+          .Files.Glob "agents/*.md" so chart-bundled defaults are
+          picked up automatically.
+        - templates/secret.yaml: Gitea-token Secret, only rendered
+          when giteaToken.secretName is empty AND giteaToken.token
+          is set. Production deployments reference an existing
+          Secret out-of-band.
+        - README.md: brief install command + values reference +
+          pointer to #333 (ingress) and #334 (full values surface).
+    priority: P1
+    version: v0.6.0
+    status: tested
+    acceptance_criteria:
+      - "AC-143-1: `helm lint deploy/helm/workbuddy/` passes with no failures (the only INFO is the optional icon recommendation)."
+      - "AC-143-2: `helm template my-release deploy/helm/workbuddy/ --set mysql.dsn=mysql://test/test --set giteaToken.secretName=test-gitea` renders Deployment, Service, and ConfigMap manifests without errors."
+      - "AC-143-3: README documents install command and points at #333 / #334 for the deferred surface."
+      - "AC-143-4: project-index.yaml has this REQ entry referencing issue #331 and the decision doc."
+    code:
+      - deploy/helm/workbuddy/Chart.yaml
+      - deploy/helm/workbuddy/values.yaml
+      - deploy/helm/workbuddy/README.md
+      - deploy/helm/workbuddy/templates/_helpers.tpl
+      - deploy/helm/workbuddy/templates/deployment.yaml
+      - deploy/helm/workbuddy/templates/service.yaml
+      - deploy/helm/workbuddy/templates/configmap.yaml
+      - deploy/helm/workbuddy/templates/secret.yaml
+    tests:
+      - deploy/helm/workbuddy/Chart.yaml
+    deps: []
+
   - id: REQ-138
     title: OTel cross-span correlation using persisted root_trace_id (v0.5)
     description: >


### PR DESCRIPTION
## Summary

- Adds `deploy/helm/workbuddy/` — minimal Helm chart for the v0.6 K8s topology per `docs/decisions/2026-05-13-k8s-agentm-otel.md` Block 3.
- Single-replica coordinator Deployment with `strategy: Recreate`, ClusterIP Service on 8080, agent-configs ConfigMap mounted at `/etc/workbuddy/agents`, Gitea token via Secret (referenced or chart-created).
- `Chart.yaml` v0.6.0 / appVersion v0.6.0, helpers, values placeholders for `mysql.dsn`, `otel.endpoint`, `giteaToken.secretName`, `agents.configMapName`.
- `project-index.yaml`: REQ-143 added, status `tested`.

Ingress is **#333**; full values surface (MySQL split, OTel docs, AegisLab topology) is **#334** — both explicitly deferred per the issue body.

## Acceptance criteria

- AC-143-1: `helm lint deploy/helm/workbuddy/` passes (only the optional icon INFO).
- AC-143-2: `helm template my-release deploy/helm/workbuddy/ --set mysql.dsn=mysql://test/test --set giteaToken.secretName=test-gitea` renders Deployment + Service + ConfigMap cleanly.
- AC-143-3: README documents install + values + pointers to #333 / #334.
- AC-143-4: project-index.yaml has REQ-143 referencing #331 and the decision doc.

## Test plan

- [x] `helm lint deploy/helm/workbuddy/`
- [x] `helm template my-release deploy/helm/workbuddy/ --set mysql.dsn=mysql://test/test --set giteaToken.secretName=test-gitea`
- [x] `python3 ~/.autoharness/scripts/validate_index.py project-index.yaml`
- [ ] Reviewer: spot-check `deployment.yaml` env wiring against coordinator's expected env vars (placeholder names — finalized in #334).

Closes #331.