### PR TITLE
labelwriter: coordinator-side label writer for agentm mode (REQ-141, #329)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,7 @@ Simpler code that maps clearly to requirements > clever abstractions.
 - File naming: Go standard — lowercase, underscore separated, `_test.go` suffix for tests
 - Agent config: `command` field MUST include routing instructions (gh issue edit for label changes)
 - Agent config: `runtime` field selects execution backend (claude-code | codex), default claude-code
-- GH call boundary: Go code only reads GitHub (Poller: gh issue/pr list) and writes comments (Reporter: gh issue comment). Label changes are done by agent subprocesses themselves via `gh issue edit`. Do not add GH write operations to Go code for label manipulation.
+- GH call boundary: Go code only reads GitHub (Poller: gh issue/pr list) and writes comments (Reporter: gh issue comment). Label changes are done by agent subprocesses themselves via `gh issue edit`. Do not add GH write operations to Go code for label manipulation. **Exception**: For `runtime: agentm` (coordinator-managed mode), label changes are applied by coordinator via `internal/labelwriter`. This is the only sanctioned Go-side label write path.
 - Session audit: Agent execution produces session artifacts (conversation logs, tool call history) that must be captured and stored alongside stdout/stderr
 - Editor JSON Schemas: `schemas/agent.schema.json` and `schemas/workflow.schema.json` describe the YAML frontmatter for `.github/workbuddy/agents/*.md` and `.github/workbuddy/workflows/*.md`. Wire them up in your editor (e.g. VSCode `yaml.schemas`) for autocomplete + inline lints. The state-machine YAML embedded in the workflow Markdown body is enforced by `workbuddy validate`, not by the workflow JSON Schema.
 

--- a/internal/labelwriter/labelwriter.go
+++ b/internal/labelwriter/labelwriter.go
@@ -1,0 +1,228 @@
+// Package labelwriter applies issue label changes from the coordinator
+// process when an agent runs in coordinator-managed mode (runtime=agentm).
+//
+// CLAUDE.md forbids Go-side label writes as a general rule — agents drive
+// the workbuddy state machine by calling `gh issue edit` themselves. This
+// package is the single, narrow exception sanctioned by docs/decisions/
+// 2026-05-13-k8s-agentm-otel.md Block 2 § Two execution modes: when the
+// agent runs inside a sandbox (agent-env) with no credentials, the
+// coordinator owns the GH/Gitea write surface and must apply the label
+// transition the agent suggests in its structured Result.
+//
+// This package is intentionally dormant until the dispatch path wires it
+// (tracked in #332). It compiles and is unit-tested, but no production
+// code path imports ApplyNextLabel yet.
+package labelwriter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/Lincyaw/workbuddy/internal/store"
+	"github.com/Lincyaw/workbuddy/internal/tracing"
+)
+
+// HostKindGitHub identifies repos that talk to api.github.com via the gh CLI.
+const HostKindGitHub = "github"
+
+// HostKindGitea identifies repos hosted on a Gitea instance, addressed via
+// the Gitea REST API and a token in the GITEA_TOKEN env var.
+const HostKindGitea = "gitea"
+
+// registrationLookup loads the coordinator-side registration record for repo.
+// Defined narrowly so tests can supply a fake without pulling in store.Store.
+type registrationLookup func(repo string) (*store.RepoRegistrationRecord, error)
+
+// commandRunner runs an external command (the gh CLI by default) and returns
+// its combined output. Tests swap this for an in-memory fake.
+type commandRunner func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+// httpDoer is the minimal interface ApplyNextLabel needs from net/http.Client
+// so tests can intercept Gitea API calls.
+type httpDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// Writer applies label changes for coordinator-managed agent runs.
+//
+// All collaborators (registration lookup, gh CLI runner, HTTP client used
+// for Gitea) are indirected so that tests can assert exact wire args
+// without touching the real GitHub / Gitea API.
+type Writer struct {
+	lookup   registrationLookup
+	lookPath func(string) (string, error)
+	run      commandRunner
+	http     httpDoer
+	// giteaToken, if non-empty, overrides os.Getenv("GITEA_TOKEN").
+	// Tests use this so they don't touch process env.
+	giteaToken string
+}
+
+// New constructs a Writer wired to the real store and exec.LookPath / exec.Command.
+func New(s store.Store) *Writer {
+	w := &Writer{
+		lookup:   func(repo string) (*store.RepoRegistrationRecord, error) { return s.GetRepoRegistration(repo) },
+		lookPath: exec.LookPath,
+		http:     http.DefaultClient,
+	}
+	w.run = defaultRun
+	return w
+}
+
+func defaultRun(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	return cmd.CombinedOutput()
+}
+
+// ApplyNextLabel adds `label` to issue #issueNum in `repo`. It is a no-op
+// when label is empty so callers don't have to pre-check the agent's
+// Result.Meta map.
+//
+// The repo's registration is consulted to pick the wire protocol:
+//
+//   - host_kind=github (or absent): shells out to `gh issue edit <issueNum>
+//     --repo <repo> --add-label <label>`. gh resolves auth from the
+//     coordinator process's gh login.
+//   - host_kind=gitea: POSTs to <gitea_base_url>/api/v1/repos/<repo>/issues/
+//     <issueNum>/labels with the GITEA_TOKEN bearer.
+//
+// The single OTel span emitted by this function carries
+// wb.label_change.source="coordinator-managed" so dashboards can separate
+// coordinator-applied labels from agent-applied ones (which currently emit
+// no such span — they happen inside the agent subprocess).
+func (w *Writer) ApplyNextLabel(ctx context.Context, repo string, issueNum int, label string) error {
+	if strings.TrimSpace(label) == "" {
+		return nil
+	}
+	if w == nil {
+		return errors.New("labelwriter: nil Writer")
+	}
+
+	ctx, span := tracing.Start(ctx, "labelwriter.apply_next_label",
+		attribute.String("wb.label_change.source", "coordinator-managed"),
+		attribute.String("workbuddy.repo", repo),
+		attribute.Int("workbuddy.issue.number", issueNum),
+		attribute.String("workbuddy.label", label),
+	)
+	defer span.End()
+
+	kind, giteaBase, err := w.resolveHostKind(repo)
+	if err != nil {
+		return fmt.Errorf("labelwriter: resolve host kind for %s: %w", repo, err)
+	}
+	span.SetAttributes(attribute.String("wb.label_change.host_kind", kind))
+
+	switch kind {
+	case HostKindGitHub:
+		return w.applyViaGH(ctx, repo, issueNum, label)
+	case HostKindGitea:
+		return w.applyViaGitea(ctx, giteaBase, repo, issueNum, label)
+	default:
+		return fmt.Errorf("labelwriter: unsupported host_kind %q for repo %s", kind, repo)
+	}
+}
+
+// resolveHostKind reads the repo's registration ConfigJSON for a host_kind
+// field. Missing / unregistered repos default to GitHub so that today's
+// only-GitHub deployments don't have to migrate their registrations.
+func (w *Writer) resolveHostKind(repo string) (kind, giteaBase string, err error) {
+	if w.lookup == nil {
+		return HostKindGitHub, "", nil
+	}
+	rec, err := w.lookup(repo)
+	if err != nil {
+		return "", "", err
+	}
+	// rec == nil signals "no registration row" (store.GetRepoRegistration
+	// returns nil, nil for sql.ErrNoRows). Coordinator-managed runs on
+	// unregistered repos are allowed at bootstrap time — default to
+	// GitHub so existing single-host deployments work.
+	if rec == nil || strings.TrimSpace(rec.ConfigJSON) == "" {
+		return HostKindGitHub, "", nil
+	}
+	var cfg struct {
+		HostKind     string `json:"host_kind"`
+		GiteaBaseURL string `json:"gitea_base_url"`
+	}
+	if err := json.Unmarshal([]byte(rec.ConfigJSON), &cfg); err != nil {
+		// Tolerate malformed ConfigJSON: fall back to GitHub.
+		return HostKindGitHub, "", nil
+	}
+	kind = strings.ToLower(strings.TrimSpace(cfg.HostKind))
+	if kind == "" {
+		kind = HostKindGitHub
+	}
+	return kind, strings.TrimRight(cfg.GiteaBaseURL, "/"), nil
+}
+
+func (w *Writer) applyViaGH(ctx context.Context, repo string, issueNum int, label string) error {
+	lookPath := w.lookPath
+	if lookPath == nil {
+		lookPath = exec.LookPath
+	}
+	bin, err := lookPath("gh")
+	if err != nil {
+		return fmt.Errorf("labelwriter: gh CLI not found on PATH: %w", err)
+	}
+	run := w.run
+	if run == nil {
+		run = defaultRun
+	}
+	args := []string{
+		"issue", "edit", fmt.Sprintf("%d", issueNum),
+		"--repo", repo,
+		"--add-label", label,
+	}
+	out, err := run(ctx, bin, args...)
+	if err != nil {
+		return fmt.Errorf("labelwriter: gh issue edit %d on %s: %w (output: %s)", issueNum, repo, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func (w *Writer) applyViaGitea(ctx context.Context, baseURL, repo string, issueNum int, label string) error {
+	if baseURL == "" {
+		return fmt.Errorf("labelwriter: gitea_base_url missing for repo %s", repo)
+	}
+	token := w.giteaToken
+	if token == "" {
+		token = os.Getenv("GITEA_TOKEN")
+	}
+	if token == "" {
+		return fmt.Errorf("labelwriter: GITEA_TOKEN not set for gitea repo %s", repo)
+	}
+	url := fmt.Sprintf("%s/api/v1/repos/%s/issues/%d/labels", baseURL, repo, issueNum)
+	body, _ := json.Marshal(map[string]any{"labels": []string{label}})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("labelwriter: build gitea request: %w", err)
+	}
+	req.Header.Set("Authorization", "token "+token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	client := w.http
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("labelwriter: gitea POST %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("labelwriter: gitea POST %s: status %d body=%s", url, resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	return nil
+}

--- a/internal/labelwriter/labelwriter_test.go
+++ b/internal/labelwriter/labelwriter_test.go
@@ -1,0 +1,257 @@
+package labelwriter
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Lincyaw/workbuddy/internal/store"
+)
+
+// fakeRegistration returns a registrationLookup backed by an in-memory map.
+func fakeRegistration(configByRepo map[string]string) registrationLookup {
+	return func(repo string) (*store.RepoRegistrationRecord, error) {
+		cfg, ok := configByRepo[repo]
+		if !ok {
+			return nil, nil
+		}
+		return &store.RepoRegistrationRecord{Repo: repo, ConfigJSON: cfg}, nil
+	}
+}
+
+type capturedExec struct {
+	name string
+	args []string
+}
+
+func newWriterWithCapture() (*Writer, *capturedExec) {
+	cap := &capturedExec{}
+	w := &Writer{
+		lookup:   func(string) (*store.RepoRegistrationRecord, error) { return nil, nil },
+		lookPath: func(string) (string, error) { return "/usr/bin/gh", nil },
+		run: func(_ context.Context, name string, args ...string) ([]byte, error) {
+			cap.name = name
+			cap.args = args
+			return []byte("ok"), nil
+		},
+	}
+	return w, cap
+}
+
+func TestApplyNextLabel_EmptyLabelIsNoop(t *testing.T) {
+	w, cap := newWriterWithCapture()
+	if err := w.ApplyNextLabel(context.Background(), "org/repo", 7, ""); err != nil {
+		t.Fatalf("empty label should be no-op, got err: %v", err)
+	}
+	if cap.name != "" {
+		t.Fatalf("empty label invoked exec: name=%q args=%v", cap.name, cap.args)
+	}
+}
+
+func TestApplyNextLabel_GitHubGHArgs(t *testing.T) {
+	w, cap := newWriterWithCapture()
+	// No registration -> defaults to GitHub host_kind.
+	if err := w.ApplyNextLabel(context.Background(), "org/repo", 42, "status:in-progress"); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if cap.name != "/usr/bin/gh" {
+		t.Fatalf("expected gh binary, got %q", cap.name)
+	}
+	want := []string{"issue", "edit", "42", "--repo", "org/repo", "--add-label", "status:in-progress"}
+	if !equalStrings(cap.args, want) {
+		t.Fatalf("gh args mismatch:\n got %v\nwant %v", cap.args, want)
+	}
+}
+
+func TestApplyNextLabel_HostKindGitHubExplicit(t *testing.T) {
+	w, cap := newWriterWithCapture()
+	w.lookup = fakeRegistration(map[string]string{
+		"org/repo": `{"host_kind":"github"}`,
+	})
+	if err := w.ApplyNextLabel(context.Background(), "org/repo", 9, "status:done"); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if cap.args[len(cap.args)-1] != "status:done" {
+		t.Fatalf("expected label as last arg, got %v", cap.args)
+	}
+}
+
+func TestApplyNextLabel_GHMissingOnPath(t *testing.T) {
+	w := &Writer{
+		lookup:   func(string) (*store.RepoRegistrationRecord, error) { return nil, nil },
+		lookPath: func(string) (string, error) { return "", errors.New("not found") },
+		run: func(context.Context, string, ...string) ([]byte, error) {
+			t.Fatal("run should not be called when lookPath fails")
+			return nil, nil
+		},
+	}
+	err := w.ApplyNextLabel(context.Background(), "org/repo", 1, "x")
+	if err == nil || !strings.Contains(err.Error(), "gh CLI not found") {
+		t.Fatalf("expected gh-not-found error, got %v", err)
+	}
+}
+
+func TestApplyNextLabel_GHRunError(t *testing.T) {
+	w, _ := newWriterWithCapture()
+	w.run = func(context.Context, string, ...string) ([]byte, error) {
+		return []byte("bad credentials"), errors.New("exit 1")
+	}
+	err := w.ApplyNextLabel(context.Background(), "org/repo", 3, "x")
+	if err == nil || !strings.Contains(err.Error(), "bad credentials") {
+		t.Fatalf("expected wrapped output in error, got %v", err)
+	}
+}
+
+func TestApplyNextLabel_LookupError(t *testing.T) {
+	boom := errors.New("db down")
+	w, _ := newWriterWithCapture()
+	w.lookup = func(string) (*store.RepoRegistrationRecord, error) { return nil, boom }
+	err := w.ApplyNextLabel(context.Background(), "org/repo", 4, "x")
+	if err == nil || !errors.Is(err, boom) {
+		t.Fatalf("expected wrapped lookup error, got %v", err)
+	}
+}
+
+func TestApplyNextLabel_UnsupportedHostKind(t *testing.T) {
+	w, _ := newWriterWithCapture()
+	w.lookup = fakeRegistration(map[string]string{
+		"org/repo": `{"host_kind":"bitbucket"}`,
+	})
+	err := w.ApplyNextLabel(context.Background(), "org/repo", 5, "x")
+	if err == nil || !strings.Contains(err.Error(), "unsupported host_kind") {
+		t.Fatalf("expected unsupported host_kind error, got %v", err)
+	}
+}
+
+func TestApplyNextLabel_MalformedConfigDefaultsToGitHub(t *testing.T) {
+	w, cap := newWriterWithCapture()
+	w.lookup = fakeRegistration(map[string]string{
+		"org/repo": `{not json`,
+	})
+	if err := w.ApplyNextLabel(context.Background(), "org/repo", 6, "y"); err != nil {
+		t.Fatalf("malformed config should fall back to gh, got err %v", err)
+	}
+	if cap.name == "" {
+		t.Fatalf("expected gh to be invoked")
+	}
+}
+
+// --- Gitea path ---
+
+type fakeHTTP struct {
+	req      *http.Request
+	body     []byte
+	respCode int
+	respBody string
+	err      error
+}
+
+func (f *fakeHTTP) Do(req *http.Request) (*http.Response, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	f.req = req
+	if req.Body != nil {
+		f.body, _ = io.ReadAll(req.Body)
+	}
+	code := f.respCode
+	if code == 0 {
+		code = http.StatusOK
+	}
+	body := f.respBody
+	if body == "" {
+		body = "[]"
+	}
+	return &http.Response{
+		StatusCode: code,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func TestApplyNextLabel_GiteaHappyPath(t *testing.T) {
+	hc := &fakeHTTP{}
+	w := &Writer{
+		lookup: fakeRegistration(map[string]string{
+			"org/repo": `{"host_kind":"gitea","gitea_base_url":"https://gitea.example.com/"}`,
+		}),
+		http:       hc,
+		giteaToken: "secret-token",
+	}
+	if err := w.ApplyNextLabel(context.Background(), "org/repo", 11, "status:in-progress"); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if hc.req == nil {
+		t.Fatal("expected HTTP request to be issued")
+	}
+	if got, want := hc.req.URL.String(), "https://gitea.example.com/api/v1/repos/org/repo/issues/11/labels"; got != want {
+		t.Fatalf("url mismatch:\n got %s\nwant %s", got, want)
+	}
+	if got := hc.req.Header.Get("Authorization"); got != "token secret-token" {
+		t.Fatalf("auth header mismatch: %q", got)
+	}
+	if got := hc.req.Header.Get("Content-Type"); got != "application/json" {
+		t.Fatalf("content-type mismatch: %q", got)
+	}
+	if !strings.Contains(string(hc.body), `"status:in-progress"`) {
+		t.Fatalf("body missing label: %s", hc.body)
+	}
+}
+
+func TestApplyNextLabel_GiteaMissingBaseURL(t *testing.T) {
+	w := &Writer{
+		lookup: fakeRegistration(map[string]string{
+			"org/repo": `{"host_kind":"gitea"}`,
+		}),
+		http:       &fakeHTTP{},
+		giteaToken: "tok",
+	}
+	err := w.ApplyNextLabel(context.Background(), "org/repo", 1, "x")
+	if err == nil || !strings.Contains(err.Error(), "gitea_base_url missing") {
+		t.Fatalf("expected gitea_base_url error, got %v", err)
+	}
+}
+
+func TestApplyNextLabel_GiteaMissingToken(t *testing.T) {
+	t.Setenv("GITEA_TOKEN", "")
+	w := &Writer{
+		lookup: fakeRegistration(map[string]string{
+			"org/repo": `{"host_kind":"gitea","gitea_base_url":"https://g.example/"}`,
+		}),
+		http: &fakeHTTP{},
+	}
+	err := w.ApplyNextLabel(context.Background(), "org/repo", 1, "x")
+	if err == nil || !strings.Contains(err.Error(), "GITEA_TOKEN not set") {
+		t.Fatalf("expected token-missing error, got %v", err)
+	}
+}
+
+func TestApplyNextLabel_GiteaErrorStatus(t *testing.T) {
+	hc := &fakeHTTP{respCode: 422, respBody: `{"message":"bad label"}`}
+	w := &Writer{
+		lookup: fakeRegistration(map[string]string{
+			"org/repo": `{"host_kind":"gitea","gitea_base_url":"https://g.example"}`,
+		}),
+		http:       hc,
+		giteaToken: "tok",
+	}
+	err := w.ApplyNextLabel(context.Background(), "org/repo", 1, "x")
+	if err == nil || !strings.Contains(err.Error(), "status 422") {
+		t.Fatalf("expected status 422 error, got %v", err)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -5178,3 +5178,63 @@ requirements:
       - internal/store/root_trace_test.go
     deps:
       - REQ-137
+
+  - id: REQ-141
+    title: Coordinator-side label writer for agentm coordinator-managed mode (v0.6)
+    description: >
+      Per docs/decisions/2026-05-13-k8s-agentm-otel.md Block 2
+      § Two execution modes, the agentm runtime executes inside an
+      agent-env sandbox with no credentials, so the agent cannot drive
+      the workbuddy state machine via `gh issue edit` itself. The
+      coordinator owns the GH / Gitea write surface and must apply the
+      next-state label change that the agent returns in its structured
+      Result.Meta.
+
+      This requirement introduces the dormant internal/labelwriter
+      package that lays down ApplyNextLabel(ctx, repo, issueNum, label)
+      and its unit tests. The function is **not** wired into any
+      dispatch path yet — that wiring is tracked separately under #332.
+      Until then it must compile and stay covered by tests so #332 can
+      flip the switch in a small follow-up PR.
+
+      Implementation:
+
+      - internal/labelwriter/labelwriter.go exports Writer (constructed
+        with store.Store) and the package-level ApplyNextLabel method.
+        It is a no-op for empty labels; otherwise it consults the
+        coordinator-side repo registration's ConfigJSON for a
+        host_kind field. host_kind=github (or absent) shells out to
+        `gh issue edit <issueNum> --repo <repo> --add-label <label>`
+        through an exec.LookPath indirection so tests can fake the
+        binary; host_kind=gitea POSTs to
+        <gitea_base_url>/api/v1/repos/<repo>/issues/<issueNum>/labels
+        with a GITEA_TOKEN bearer.
+
+      - A single OTel span "labelwriter.apply_next_label" is emitted
+        with wb.label_change.source="coordinator-managed" so dashboards
+        can separate coordinator-applied labels from agent-applied
+        labels (which today emit no such span — they happen inside the
+        agent subprocess).
+
+      - CLAUDE.md's "label changes are done by agent subprocesses
+        themselves" rule gains the explicit narrow exception for
+        runtime=agentm via internal/labelwriter.
+    priority: P1
+    version: v0.6.0
+    status: tested
+    acceptance_criteria:
+      - "AC-141-1: internal/labelwriter exports ApplyNextLabel with the documented (ctx, repo, issueNum, label) signature."
+      - "AC-141-2: Unit tests assert the exact gh CLI args (`issue edit <n> --repo <repo> --add-label <label>`) for a representative label change."
+      - "AC-141-3: Unit tests assert the Gitea API call (URL, Authorization header, JSON body) for host_kind=gitea registrations."
+      - "AC-141-4: Empty label is a no-op (no exec, no HTTP request)."
+      - "AC-141-5: CLAUDE.md GH-call-boundary rule includes the narrow exception sentence for runtime=agentm."
+      - "AC-141-6: `go build ./... && go vet ./... && go test ./... -count=1` all pass."
+      - "AC-141-7: project-index.yaml has this REQ entry referencing issue #329."
+      - "AC-141-8: ApplyNextLabel is NOT imported by any production dispatch path (dormant until #332)."
+    code:
+      - internal/labelwriter/labelwriter.go
+      - CLAUDE.md
+    tests:
+      - internal/labelwriter/labelwriter_test.go
+    deps:
+      - REQ-134


### PR DESCRIPTION
## Summary

- Add dormant `internal/labelwriter` package exporting `ApplyNextLabel(ctx, repo, issueNum, label)` for coordinator-managed agentm runs (per docs/decisions/2026-05-13-k8s-agentm-otel.md Block 2 § Two execution modes).
- Resolve wire protocol from repo registration `ConfigJSON.host_kind`: `github` (default) → `gh issue edit --add-label` via a `LookPath` indirection; `gitea` → `POST /api/v1/repos/<repo>/issues/<n>/labels` with `GITEA_TOKEN`.
- Emit one OTel span `labelwriter.apply_next_label` with `wb.label_change.source="coordinator-managed"` so dashboards can split coordinator-applied vs agent-applied labels.
- Update `CLAUDE.md`'s GH-call-boundary rule with the narrow exception sentence for `runtime: agentm`.
- Add `REQ-141` to `project-index.yaml` (status `tested`).

The function is **not** wired into any dispatch path yet — that wiring lives in #332. The package compiles and is unit-tested so #332 can flip the switch in a small follow-up PR.

Closes #329.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1` all green (labelwriter unit tests cover gh-args, gitea URL/auth/body, empty-label no-op, malformed-config fallback, missing-gh, lookup error, unsupported host_kind, gitea base-URL / token / status-error paths)
- [x] No production import of `internal/labelwriter` outside its tests (dormant until #332)

🤖 Generated with [Claude Code](https://claude.com/claude-code)