### PR TITLE
Add dev_container_image agent-config field + pass to AgentM (#328)

### DIFF
--- a/docs/planned/agentm-runtime.md
+++ b/docs/planned/agentm-runtime.md
@@ -87,6 +87,7 @@ inherits):
 | `WORKBUDDY_REPO` | yes | `owner/repo` form. |
 | `GH_TOKEN` | host-exec only | Same PAT codex/claude-code receive today. **In v0.6 sandbox mode this MUST NOT be injected.** |
 | `ANTHROPIC_API_KEY` / provider keys | provider-dependent | AgentM expects its provider extension to find these in env. |
+| `WORKBUDDY_DEV_CONTAINER_IMAGE` | optional, v0.6+ | Dev container image AgentM should run the task inside, sourced from the agent config field `dev_container_image` (issue #328 / REQ-140). Injected only when the agent's `runtime` is `agentm` and the field is non-empty. When unset, AgentM falls back to its own default image. workbuddy passes the image name through verbatim and does NOT talk to agent-env directly — sandbox dispatch is AgentM's job (see decision doc Block 2). Setting `dev_container_image` on other runtimes is a config warning, not an error. |
 
 ### stdin
 

--- a/internal/agent/agentm/agentmtest/fake.go
+++ b/internal/agent/agentm/agentmtest/fake.go
@@ -51,6 +51,12 @@ type Config struct {
 	NextLabel string
 	// FailureReason overrides the default reason in ModeFailure.
 	FailureReason string
+	// EnvDumpPath, when non-empty, makes the fake write its full process
+	// environment (one `KEY=VALUE` per line) to this absolute path before
+	// emitting RESULT:. Tests use it to assert workbuddy-injected env vars
+	// (TRACEPARENT, WORKBUDDY_DEV_CONTAINER_IMAGE, …) actually reach the
+	// AgentM subprocess.
+	EnvDumpPath string
 }
 
 // BuildFake writes a shell-script fake to a temp file marked executable and
@@ -130,6 +136,9 @@ fi
 echo "fake agentm starting in $WORKSPACE"
 echo "task file: $TASK_FILE"
 `
+	if cfg.EnvDumpPath != "" {
+		script += fmt.Sprintf("env > %q\n", cfg.EnvDumpPath)
+	}
 	if emitResult != "" {
 		script += emitResult + "\n"
 		script += `echo "RESULT: $BODY"` + "\n"

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -361,6 +361,18 @@ func normalizeAgentConfig(agent *AgentConfig) ([]Warning, error) {
 		return warnings, fmt.Errorf("unsupported runtime %q", agent.Runtime)
 	}
 
+	// dev_container_image is only meaningful for the agentm runtime, which
+	// forwards it to the AgentM subprocess as WORKBUDDY_DEV_CONTAINER_IMAGE
+	// (see docs/planned/agentm-runtime.md). Setting it on claude-code /
+	// codex is a no-op today; warn (do not error) so configs that pre-stage
+	// the field for a planned runtime swap still validate.
+	if strings.TrimSpace(agent.DevContainerImage) != "" && agent.Runtime != RuntimeAgentM {
+		warnings = append(warnings, Warning{Message: fmt.Sprintf(
+			"agent %q: dev_container_image is set but runtime is %q; the field is only honored for runtime=%q (workbuddy passes WORKBUDDY_DEV_CONTAINER_IMAGE to AgentM only)",
+			agent.Name, agent.Runtime, RuntimeAgentM,
+		)})
+	}
+
 	return warnings, nil
 }
 

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -236,6 +237,73 @@ func TestNormalizeAgentConfig_AcceptsAgentMRuntime(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestNormalizeAgentConfig_DevContainerImage covers REQ-140 / issue #328
+// AC-1-1 + AC-1-2: dev_container_image validates cleanly with runtime=agentm
+// (no warning, no error); setting it on runtime=claude-code produces a
+// warning (not an error) so configs can stage the field for an upcoming
+// runtime swap.
+func TestNormalizeAgentConfig_DevContainerImage(t *testing.T) {
+	t.Helper()
+
+	t.Run("agentm_no_warning", func(t *testing.T) {
+		agent := &AgentConfig{
+			Name:              "agentm-dev",
+			Runtime:           RuntimeAgentM,
+			DevContainerImage: "ghcr.io/lincyaw/workbuddy-dev:latest",
+		}
+		warnings, err := NormalizeAgentConfig(agent)
+		if err != nil {
+			t.Fatalf("NormalizeAgentConfig: %v", err)
+		}
+		for _, w := range warnings {
+			if strings.Contains(w.Message, "dev_container_image") {
+				t.Fatalf("unexpected dev_container_image warning for agentm runtime: %s", w.Message)
+			}
+		}
+		if agent.DevContainerImage != "ghcr.io/lincyaw/workbuddy-dev:latest" {
+			t.Fatalf("DevContainerImage should be preserved, got %q", agent.DevContainerImage)
+		}
+	})
+
+	t.Run("claude_code_warns_not_errors", func(t *testing.T) {
+		agent := &AgentConfig{
+			Name:              "claude-dev",
+			Runtime:           RuntimeClaudeCode,
+			Policy:            PolicyConfig{Sandbox: "read-only", Approval: "never"},
+			DevContainerImage: "ghcr.io/x:y",
+		}
+		warnings, err := NormalizeAgentConfig(agent)
+		if err != nil {
+			t.Fatalf("NormalizeAgentConfig: expected nil error, got %v", err)
+		}
+		found := false
+		for _, w := range warnings {
+			if strings.Contains(w.Message, "dev_container_image") && strings.Contains(w.Message, "claude-code") {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("expected dev_container_image warning for runtime=claude-code, got warnings=%v", warnings)
+		}
+	})
+
+	t.Run("agentm_empty_no_warning", func(t *testing.T) {
+		agent := &AgentConfig{
+			Name:    "agentm-dev",
+			Runtime: RuntimeAgentM,
+		}
+		warnings, err := NormalizeAgentConfig(agent)
+		if err != nil {
+			t.Fatalf("NormalizeAgentConfig: %v", err)
+		}
+		for _, w := range warnings {
+			if strings.Contains(w.Message, "dev_container_image") {
+				t.Fatalf("unexpected warning when field unset: %s", w.Message)
+			}
+		}
+	})
 }
 
 // TestNormalizeAgentConfig_RejectsBadAgentMPolicy verifies the policy matrix

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -134,7 +134,18 @@ type AgentConfig struct {
 	GitHubActions  GitHubActionsRunnerConfig `yaml:"github_actions"`
 	OutputContract OutputContractConfig      `yaml:"output_contract"`
 	Timeout        time.Duration             `yaml:"timeout"`
-	SourcePath     string                    `yaml:"-"`
+	// DevContainerImage names the dev container image AgentM should run
+	// inside when the runtime is `agentm`. workbuddy passes the value
+	// through to the AgentM subprocess as the env var
+	// WORKBUDDY_DEV_CONTAINER_IMAGE; AgentM is responsible for the actual
+	// sandbox dispatch (workbuddy does not talk to agent-env directly).
+	// See docs/planned/agentm-runtime.md for the invocation contract and
+	// docs/decisions/2026-05-13-k8s-agentm-otel.md (Block 2) for design
+	// context. Optional; only meaningful for `runtime: agentm`. Setting
+	// it on other runtimes emits a config warning (not an error) so a
+	// per-agent override can be staged ahead of an upcoming migration.
+	DevContainerImage string `yaml:"dev_container_image,omitempty"`
+	SourcePath        string `yaml:"-"`
 }
 
 // TriggerRule defines when an agent is activated. The agent references workflow

--- a/internal/runtime/agent_bridge.go
+++ b/internal/runtime/agent_bridge.go
@@ -87,7 +87,7 @@ func (r *AgentBridgeRuntime) Start(ctx context.Context, agentCfg *config.AgentCo
 		Model:    agentCfg.Policy.Model,
 		Sandbox:  agentCfg.Policy.Sandbox,
 		Approval: agentCfg.Policy.Approval,
-		Env:      injectTraceContext(ctx, envSliceToMap(BuildScopedEnv(agentCfg, task)), task),
+		Env:      injectAgentMEnv(agentCfg, injectTraceContext(ctx, envSliceToMap(BuildScopedEnv(agentCfg, task)), task)),
 		Tags: map[string]string{
 			"agent": agentCfg.Name,
 			"repo":  task.Repo,
@@ -318,6 +318,34 @@ func injectTraceContext(ctx context.Context, env map[string]string, task *TaskCo
 		if _, ok := env["WORKBUDDY_RUN_ID"]; !ok && task.Session.ID != "" {
 			env["WORKBUDDY_RUN_ID"] = task.Session.ID
 		}
+	}
+	return env
+}
+
+// EnvDevContainerImage is the env var workbuddy injects into the AgentM
+// subprocess to tell it which dev container image to dispatch into.
+// AgentM owns the actual agent-env Gateway call; workbuddy just forwards
+// the agent-config field. See docs/planned/agentm-runtime.md and
+// docs/decisions/2026-05-13-k8s-agentm-otel.md (Block 2).
+const EnvDevContainerImage = "WORKBUDDY_DEV_CONTAINER_IMAGE"
+
+// injectAgentMEnv adds AgentM-specific env vars derived from the agent
+// config. Today that's just dev_container_image → WORKBUDDY_DEV_CONTAINER_IMAGE,
+// injected only when runtime=agentm; other runtimes ignore the field
+// (and config validation already warned about it).
+func injectAgentMEnv(agentCfg *config.AgentConfig, env map[string]string) map[string]string {
+	if agentCfg == nil || agentCfg.Runtime != config.RuntimeAgentM {
+		return env
+	}
+	image := strings.TrimSpace(agentCfg.DevContainerImage)
+	if image == "" {
+		return env
+	}
+	if env == nil {
+		env = map[string]string{}
+	}
+	if _, exists := env[EnvDevContainerImage]; !exists {
+		env[EnvDevContainerImage] = image
 	}
 	return env
 }

--- a/internal/runtime/agentm_bridge_test.go
+++ b/internal/runtime/agentm_bridge_test.go
@@ -2,6 +2,8 @@ package runtime
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -124,5 +126,76 @@ func TestAgentMBridge_TaskFailure(t *testing.T) {
 	// from the agent, not a contract violation.
 	if IsInfraFailure(res) {
 		t.Fatalf("clean failure should NOT be infra-failure")
+	}
+}
+
+// TestAgentMBridge_DevContainerImageEnv covers REQ-140 / issue #328 AC-1-1:
+// when the agent config sets dev_container_image and runtime=agentm, the
+// AgentM subprocess MUST receive WORKBUDDY_DEV_CONTAINER_IMAGE in its env.
+// workbuddy passes the image name only — AgentM owns the actual sandbox
+// dispatch, so this is a pass-through assertion, not an end-to-end one.
+func TestAgentMBridge_DevContainerImageEnv(t *testing.T) {
+	envDump := filepath.Join(t.TempDir(), "env.dump")
+	fake := agentmtest.BuildFake(t, agentmtest.Config{
+		Mode:        agentmtest.ModeSuccess,
+		EnvDumpPath: envDump,
+	})
+	rt := NewAgentBridgeRuntime(config.RuntimeAgentM, func() (agent.Backend, error) {
+		return &agentm.Backend{Binary: fake}, nil
+	})
+
+	work := t.TempDir()
+	task := &TaskContext{
+		Repo:     "Lincyaw/workbuddy",
+		WorkDir:  work,
+		RepoRoot: work,
+		Issue:    IssueContext{Number: 328},
+		Session:  SessionContext{ID: "test-session"},
+	}
+	agentCfg := &config.AgentConfig{
+		Name:              "dev-agent",
+		Runtime:           config.RuntimeAgentM,
+		Role:              "dev",
+		Prompt:            "ship REQ-140",
+		DevContainerImage: "ghcr.io/lincyaw/workbuddy-dev:latest",
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if _, err := rt.Launch(ctx, agentCfg, task); err != nil {
+		t.Fatalf("Launch: %v", err)
+	}
+
+	data, err := os.ReadFile(envDump)
+	if err != nil {
+		t.Fatalf("read env dump: %v", err)
+	}
+	want := EnvDevContainerImage + "=ghcr.io/lincyaw/workbuddy-dev:latest"
+	if !strings.Contains(string(data), want) {
+		t.Fatalf("env dump missing %q; got:\n%s", want, data)
+	}
+}
+
+// TestAgentMBridge_DevContainerImageNotInjectedForOtherRuntimes asserts the
+// pass-through is gated on runtime=agentm; for hypothetical claude-code /
+// codex agents that happen to carry the field (config validation warns but
+// permits it) the env var MUST NOT appear, since only AgentM understands it.
+func TestAgentMBridge_DevContainerImageNotInjectedForOtherRuntimes(t *testing.T) {
+	env := injectAgentMEnv(&config.AgentConfig{
+		Name:              "dev-agent",
+		Runtime:           config.RuntimeClaudeCode,
+		DevContainerImage: "ghcr.io/x:y",
+	}, map[string]string{})
+	if _, ok := env[EnvDevContainerImage]; ok {
+		t.Fatalf("dev_container_image must not leak into non-agentm runtime env, got %v", env)
+	}
+
+	env2 := injectAgentMEnv(&config.AgentConfig{
+		Name:    "dev-agent",
+		Runtime: config.RuntimeAgentM,
+		// no DevContainerImage: AgentM falls back to its own default
+	}, map[string]string{})
+	if _, ok := env2[EnvDevContainerImage]; ok {
+		t.Fatalf("empty dev_container_image must not be injected, got %v", env2)
 	}
 }

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -5301,3 +5301,68 @@ requirements:
       - internal/labelwriter/labelwriter_test.go
     deps:
       - REQ-134
+
+  - id: REQ-140
+    title: dev_container_image agent-config field + AgentM env pass-through (v0.6)
+    description: >
+      Per docs/decisions/2026-05-13-k8s-agentm-otel.md Block 2 v0.6
+      plan, workbuddy stays at host-exec for AgentM. AgentM internally
+      requests a sandbox from agent-env using the dev container image
+      workbuddy declares; workbuddy does NOT talk to agent-env
+      directly — that is AgentM's implementation detail. This
+      requirement adds the single config field workbuddy needs to
+      expose (which image AgentM should run inside) and the
+      env-passing wiring.
+
+      Implementation:
+
+      - internal/config/types.go AgentConfig adds an optional
+        `dev_container_image` string field (yaml tag omitempty).
+
+      - internal/config/loader.go normalizeAgentConfig appends a
+        warning (not an error) when dev_container_image is set on a
+        runtime other than agentm. This lets configs pre-stage the
+        field for a planned runtime swap without breaking validation.
+
+      - internal/runtime/agent_bridge.go declares the env-var name
+        EnvDevContainerImage = "WORKBUDDY_DEV_CONTAINER_IMAGE" and
+        adds injectAgentMEnv(agentCfg, env) which only injects the
+        var when runtime == agentm and dev_container_image is
+        non-empty. The injection runs after injectTraceContext so
+        it cannot accidentally override TRACEPARENT / WORKBUDDY_*
+        plumbing.
+
+      - schemas/agent.schema.json adds the dev_container_image
+        property to the frontmatter schema so editors get
+        autocomplete + inline lints.
+
+      - docs/planned/agentm-runtime.md adds the env var to the
+        invocation contract's environment table so AgentM
+        contributors know to consume it.
+
+      Out of scope (explicit non-goals):
+
+      - agent-env Gateway client (AgentM handles it).
+      - Sandbox dispatch logic (workbuddy stays host-exec for AgentM).
+      - Image registry validation.
+      - .devcontainer/devcontainer.json parsing.
+    priority: P1
+    version: v0.6.0
+    status: tested
+    acceptance_criteria:
+      - "AC-140-1: Agent config with `dev_container_image: foo:bar` and `runtime: agentm` validates; the value reaches the AgentM subprocess env as WORKBUDDY_DEV_CONTAINER_IMAGE (asserted via env-dump fake)."
+      - "AC-140-2: Agent config with `dev_container_image` set on `runtime: claude-code` produces a config validation warning (not an error)."
+      - "AC-140-3: When `dev_container_image` is unset for `runtime: agentm`, the env var is NOT injected (AgentM falls back to its own default image)."
+      - "AC-140-4: docs/planned/agentm-runtime.md documents the env var."
+      - "AC-140-5: `go build ./... && go vet ./... && go test ./... -count=1` all pass."
+      - "AC-140-6: project-index.yaml has this REQ entry referencing issue #328."
+    code:
+      - internal/config/types.go
+      - internal/config/loader.go
+      - internal/runtime/agent_bridge.go
+      - internal/agent/agentm/agentmtest/fake.go
+      - schemas/agent.schema.json
+      - docs/planned/agentm-runtime.md
+    tests:
+      - internal/config/loader_test.go
+      - internal/runtime/agentm_bridge_test.go

--- a/schemas/agent.schema.json
+++ b/schemas/agent.schema.json
@@ -113,6 +113,11 @@
       "type": "string",
       "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
       "description": "Deprecated alias of policy.timeout, kept for back-compat."
+    },
+    "dev_container_image": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Dev container image AgentM should run the task inside. Only meaningful for runtime=agentm; workbuddy injects it into the AgentM subprocess env as WORKBUDDY_DEV_CONTAINER_IMAGE (see docs/planned/agentm-runtime.md). Setting it on other runtimes produces a config warning, not an error. workbuddy does NOT talk to agent-env directly — image dispatch is AgentM's job."
     }
   }
 }


### PR DESCRIPTION
Closes #328 (REQ-140).

## Summary
- Add optional `dev_container_image` string to `AgentConfig` (yaml `omitempty`).
- Forward the value to the AgentM subprocess as `WORKBUDDY_DEV_CONTAINER_IMAGE`, gated on `runtime: agentm`; layered after `injectTraceContext` so it cannot shadow trace plumbing.
- Config validation: warn (not error) when the field is set on a non-agentm runtime, so configs can stage the field ahead of a runtime swap.
- Update `schemas/agent.schema.json` and `docs/planned/agentm-runtime.md`.

Per the v0.6 design doc (`docs/decisions/2026-05-13-k8s-agentm-otel.md` Block 2), workbuddy stays at host-exec for AgentM. AgentM internally requests a sandbox from agent-env using the image workbuddy declares — workbuddy does NOT talk to agent-env directly.

Out of scope (explicit non-goals): agent-env Gateway client, sandbox dispatch logic, image registry validation, devcontainer.json parsing.

## AC coverage
- AC-1-1: `TestAgentMBridge_DevContainerImageEnv` builds an agentm fake with `EnvDumpPath`, runs the bridge, and asserts `WORKBUDDY_DEV_CONTAINER_IMAGE=...` appears in the subprocess env dump. `TestNormalizeAgentConfig_DevContainerImage/agentm_no_warning` covers the validation half.
- AC-1-2: `TestNormalizeAgentConfig_DevContainerImage/claude_code_warns_not_errors` asserts a warning (not an error) for `runtime: claude-code` + `dev_container_image`. `TestAgentMBridge_DevContainerImageNotInjectedForOtherRuntimes` asserts the env var is NOT injected for non-agentm runtimes (and not injected when the field is empty).
- AC-1-3: `docs/planned/agentm-runtime.md` environment table now documents `WORKBUDDY_DEV_CONTAINER_IMAGE`.
- AC-1-4: `go build ./... && go vet ./... && go test ./... -count=1` all pass locally.
- AC-1-5: `project-index.yaml` adds REQ-140 (`status: tested`, deps REQ-134), validates via `~/.autoharness/scripts/validate_index.py`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1`
- [x] `python3 ~/.autoharness/scripts/validate_index.py project-index.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)