### PR TITLE
gitops: coordinator-side git push + PR creation for AgentM runs (REQ-142, #330)

### DIFF
--- a/internal/gitops/gitops.go
+++ b/internal/gitops/gitops.go
@@ -1,0 +1,248 @@
+// Package gitops centralizes coordinator-side git and PR operations used by
+// the v0.6 coordinator-managed AgentM dispatch path. Other runtimes
+// (claude-code, codex) remain self-managed: they invoke `gh issue edit`,
+// `git push`, and `gh pr create` from inside the agent subprocess.
+//
+// The AgentM runtime, by design, does not hold GitHub credentials. After a
+// successful run it returns a structured Output containing an artifact
+// path (patch/diff). The coordinator (v0.6: still in-process within the
+// worker bridge) applies that artifact onto a fresh branch, commits with a
+// well-known bot identity, pushes, and opens a PR. See
+// docs/decisions/2026-05-13-k8s-agentm-otel.md (Block 2 § Two execution
+// modes).
+//
+// This package shells out to the local `git` and `gh` CLIs rather than
+// depending on go-git: workbuddy already requires both binaries on the
+// dispatch host, and reusing them keeps the auth/credential surface
+// consistent with the rest of the coordinator (reporter, ghadapter).
+package gitops
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// DefaultBotAuthor is the identity coordinator-managed commits are made
+// under. Anything that pushes on behalf of an AgentM run uses this unless
+// the caller overrides it (e.g. per-repo policy in a future iteration).
+var DefaultBotAuthor = Author{
+	Name:  "workbuddy-bot",
+	Email: "bot@workbuddy.internal",
+}
+
+// Author is the git identity attached to a commit. Both fields are
+// required; empty values are rejected at CommitAndPush time so we fail
+// fast instead of producing a commit with an "unknown" trailer.
+type Author struct {
+	Name  string
+	Email string
+}
+
+// CommandRunner is the subprocess boundary used by every shell-out in this
+// package. Tests inject a fake runner; production uses the package-level
+// ExecRunner that wraps os/exec.
+type CommandRunner interface {
+	Run(ctx context.Context, dir string, env []string, name string, args ...string) (stdout string, stderr string, err error)
+}
+
+// ExecRunner is the default CommandRunner. It invokes the binary on PATH.
+type ExecRunner struct{}
+
+// Run implements CommandRunner using os/exec.CommandContext.
+func (ExecRunner) Run(ctx context.Context, dir string, env []string, name string, args ...string) (string, string, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	if len(env) > 0 {
+		cmd.Env = append(os.Environ(), env...)
+	}
+	var outBuf, errBuf strings.Builder
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	return outBuf.String(), errBuf.String(), err
+}
+
+// Client is the public entry point for callers. The zero value is usable
+// and uses ExecRunner + DefaultBotAuthor / `gh` for PR creation.
+type Client struct {
+	// Runner shells commands out. Defaults to ExecRunner.
+	Runner CommandRunner
+	// GHBinary names the GitHub CLI binary (defaults to "gh"). Tests
+	// inject a fake to assert the arguments passed to `gh pr create`.
+	GHBinary string
+	// GitBinary names the git CLI binary (defaults to "git").
+	GitBinary string
+}
+
+func (c *Client) runner() CommandRunner {
+	if c != nil && c.Runner != nil {
+		return c.Runner
+	}
+	return ExecRunner{}
+}
+
+func (c *Client) git() string {
+	if c != nil && c.GitBinary != "" {
+		return c.GitBinary
+	}
+	return "git"
+}
+
+func (c *Client) gh() string {
+	if c != nil && c.GHBinary != "" {
+		return c.GHBinary
+	}
+	return "gh"
+}
+
+// CommitAndPush stages every change in repoLocalPath's working tree,
+// creates (or resets) the named branch, makes a single commit authored by
+// `author` with `message`, and pushes the branch to `origin` (force-with-
+// lease so re-dispatch of the same issue overwrites stale remote state
+// without losing protected history). repoLocalPath MUST be an existing
+// git working tree with a remote named `origin`.
+//
+// Returns ErrNoChanges if the working tree had no changes to commit:
+// AgentM occasionally produces no-op artifacts (e.g. the agent decided the
+// task was already satisfied), and the caller should treat that as a
+// successful but PR-less run.
+func CommitAndPush(ctx context.Context, repoLocalPath, branch, message string, author Author) error {
+	c := Client{}
+	return c.CommitAndPush(ctx, repoLocalPath, branch, message, author)
+}
+
+// CommitAndPush is the method-receiver form of the package-level function.
+// Use this when you need to inject a custom Runner (tests, isolation).
+func (c *Client) CommitAndPush(ctx context.Context, repoLocalPath, branch, message string, author Author) error {
+	if repoLocalPath == "" {
+		return errors.New("gitops: empty repoLocalPath")
+	}
+	if branch == "" {
+		return errors.New("gitops: empty branch")
+	}
+	if message == "" {
+		return errors.New("gitops: empty commit message")
+	}
+	if author.Name == "" || author.Email == "" {
+		return errors.New("gitops: author name and email required")
+	}
+	if info, err := os.Stat(filepath.Join(repoLocalPath, ".git")); err != nil || !(info.IsDir() || info.Mode().IsRegular()) {
+		return fmt.Errorf("gitops: %s is not a git working tree", repoLocalPath)
+	}
+
+	run := c.runner()
+	git := c.git()
+
+	// Create or reset the branch off the current HEAD. We use -B so a
+	// previously-leftover branch with the same name (from a re-dispatch)
+	// is overwritten rather than producing "branch already exists".
+	if _, stderr, err := run.Run(ctx, repoLocalPath, nil, git, "checkout", "-B", branch); err != nil {
+		return fmt.Errorf("gitops: git checkout -B %s: %w (%s)", branch, err, strings.TrimSpace(stderr))
+	}
+
+	// Stage everything in the worktree (the artifact has already been
+	// applied by the caller before this call, or AgentM wrote files
+	// directly into the workspace).
+	if _, stderr, err := run.Run(ctx, repoLocalPath, nil, git, "add", "-A"); err != nil {
+		return fmt.Errorf("gitops: git add: %w (%s)", err, strings.TrimSpace(stderr))
+	}
+
+	// If there are no staged changes, return ErrNoChanges. Distinguishing
+	// this from a real failure matters: we don't want to push an empty
+	// branch or open a PR with no diff.
+	if stdout, _, err := run.Run(ctx, repoLocalPath, nil, git, "status", "--porcelain"); err == nil {
+		if strings.TrimSpace(stdout) == "" {
+			return ErrNoChanges
+		}
+	}
+
+	env := []string{
+		"GIT_AUTHOR_NAME=" + author.Name,
+		"GIT_AUTHOR_EMAIL=" + author.Email,
+		"GIT_COMMITTER_NAME=" + author.Name,
+		"GIT_COMMITTER_EMAIL=" + author.Email,
+	}
+	if _, stderr, err := run.Run(ctx, repoLocalPath, env, git, "commit", "-m", message); err != nil {
+		// `nothing to commit` can still slip through if status reported
+		// untracked-but-ignored entries; treat it the same as the
+		// status check above.
+		if strings.Contains(stderr, "nothing to commit") {
+			return ErrNoChanges
+		}
+		return fmt.Errorf("gitops: git commit: %w (%s)", err, strings.TrimSpace(stderr))
+	}
+
+	if _, stderr, err := run.Run(ctx, repoLocalPath, nil, git, "push", "--force-with-lease", "origin", branch); err != nil {
+		return fmt.Errorf("gitops: git push: %w (%s)", err, strings.TrimSpace(stderr))
+	}
+	return nil
+}
+
+// ErrNoChanges is returned by CommitAndPush when the working tree had no
+// changes to commit after `git add -A`. The caller MUST NOT call OpenPR
+// in this case.
+var ErrNoChanges = errors.New("gitops: no changes to commit")
+
+// OpenPR creates a pull request on `repo` (owner/name form) from
+// `branch` against the repo's default base branch, with the given title
+// and body. Returns the PR URL emitted by `gh pr create` on success.
+//
+// `gh` already handles authentication (it reads GH_TOKEN/GITHUB_TOKEN or
+// the gh keyring), and `gh pr create` works against both github.com and
+// Gitea installations the user has logged into.
+func OpenPR(ctx context.Context, repo, branch, title, body string) (string, error) {
+	c := Client{}
+	return c.OpenPR(ctx, repo, branch, title, body)
+}
+
+// OpenPR is the method-receiver form of the package-level function.
+func (c *Client) OpenPR(ctx context.Context, repo, branch, title, body string) (string, error) {
+	if repo == "" {
+		return "", errors.New("gitops: empty repo")
+	}
+	if branch == "" {
+		return "", errors.New("gitops: empty branch")
+	}
+	if title == "" {
+		return "", errors.New("gitops: empty PR title")
+	}
+
+	args := []string{
+		"pr", "create",
+		"--repo", repo,
+		"--head", branch,
+		"--title", title,
+		"--body", body,
+	}
+	stdout, stderr, err := c.runner().Run(ctx, "", nil, c.gh(), args...)
+	if err != nil {
+		// gh prints the URL on success; on failure stderr carries the
+		// reason. Surface it so the reporter can render the issue
+		// comment.
+		return "", fmt.Errorf("gitops: gh pr create: %w (%s)", err, strings.TrimSpace(stderr))
+	}
+	// gh emits the PR URL as the last non-empty line of stdout.
+	url := lastNonEmptyLine(stdout)
+	if url == "" {
+		return "", fmt.Errorf("gitops: gh pr create returned no URL (stdout=%q)", stdout)
+	}
+	return url, nil
+}
+
+func lastNonEmptyLine(s string) string {
+	lines := strings.Split(strings.TrimSpace(s), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line != "" {
+			return line
+		}
+	}
+	return ""
+}

--- a/internal/gitops/gitops_test.go
+++ b/internal/gitops/gitops_test.go
@@ -1,0 +1,237 @@
+package gitops
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// gitInit creates a bare upstream and a working clone pre-populated with
+// one commit so subsequent CommitAndPush calls have a sane starting
+// point. Returns (workdir, bareRepoPath).
+func gitInit(t *testing.T) (string, string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	root := t.TempDir()
+	bare := filepath.Join(root, "upstream.git")
+	work := filepath.Join(root, "work")
+	mustRun(t, "", "git", "init", "--bare", bare)
+	mustRun(t, "", "git", "init", "-b", "main", work)
+	if err := os.WriteFile(filepath.Join(work, "README.md"), []byte("hello\n"), 0644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	mustRun(t, work, "git", "config", "user.name", "init")
+	mustRun(t, work, "git", "config", "user.email", "init@example.test")
+	mustRun(t, work, "git", "add", "-A")
+	mustRun(t, work, "git", "commit", "-m", "init")
+	mustRun(t, work, "git", "remote", "add", "origin", bare)
+	mustRun(t, work, "git", "push", "origin", "main")
+	return work, bare
+}
+
+func mustRun(t *testing.T, dir, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %v: %v: %s", name, args, err, string(out))
+	}
+}
+
+func TestCommitAndPush_HappyPath(t *testing.T) {
+	work, bare := gitInit(t)
+
+	// Drop a fresh file into the worktree — simulates AgentM having
+	// applied its artifact.
+	if err := os.WriteFile(filepath.Join(work, "feature.txt"), []byte("agentm output\n"), 0644); err != nil {
+		t.Fatalf("write feature: %v", err)
+	}
+
+	ctx := context.Background()
+	branch := "workbuddy/issue-330"
+	err := CommitAndPush(ctx, work, branch, "workbuddy: ship issue #330", DefaultBotAuthor)
+	if err != nil {
+		t.Fatalf("CommitAndPush: %v", err)
+	}
+
+	// Verify the branch reached the bare upstream.
+	cmd := exec.Command("git", "--git-dir", bare, "branch", "--list", branch)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git branch on bare: %v: %s", err, string(out))
+	}
+	if !strings.Contains(string(out), branch) {
+		t.Fatalf("expected branch %q on upstream, got %q", branch, string(out))
+	}
+
+	// Verify author identity on the tip commit.
+	cmd = exec.Command("git", "--git-dir", bare, "log", branch, "-1", "--format=%an <%ae>")
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git log: %v: %s", err, string(out))
+	}
+	want := DefaultBotAuthor.Name + " <" + DefaultBotAuthor.Email + ">"
+	if got := strings.TrimSpace(string(out)); got != want {
+		t.Fatalf("author = %q, want %q", got, want)
+	}
+}
+
+func TestCommitAndPush_NoChanges(t *testing.T) {
+	work, _ := gitInit(t)
+	ctx := context.Background()
+	err := CommitAndPush(ctx, work, "workbuddy/issue-330", "noop", DefaultBotAuthor)
+	if !errors.Is(err, ErrNoChanges) {
+		t.Fatalf("err = %v, want ErrNoChanges", err)
+	}
+}
+
+func TestCommitAndPush_RejectsBadInput(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name string
+		path string
+		br   string
+		msg  string
+		auth Author
+	}{
+		{"empty path", "", "b", "m", DefaultBotAuthor},
+		{"empty branch", "/tmp", "", "m", DefaultBotAuthor},
+		{"empty msg", "/tmp", "b", "", DefaultBotAuthor},
+		{"empty author name", "/tmp", "b", "m", Author{Email: "x@y"}},
+		{"empty author email", "/tmp", "b", "m", Author{Name: "x"}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := CommitAndPush(ctx, tc.path, tc.br, tc.msg, tc.auth)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func TestCommitAndPush_NonGitDir(t *testing.T) {
+	dir := t.TempDir()
+	err := CommitAndPush(context.Background(), dir, "b", "m", DefaultBotAuthor)
+	if err == nil {
+		t.Fatal("expected error for non-git dir")
+	}
+}
+
+// fakeRunner records each invocation and returns scripted results so we
+// can assert OpenPR's argv shape without needing a real `gh` install.
+type fakeRunner struct {
+	calls []fakeCall
+	// next is consumed left-to-right; each entry is the (stdout,
+	// stderr, err) returned for the matching call.
+	next []fakeResult
+}
+
+type fakeCall struct {
+	dir  string
+	name string
+	args []string
+}
+
+type fakeResult struct {
+	stdout string
+	stderr string
+	err    error
+}
+
+func (f *fakeRunner) Run(_ context.Context, dir string, _ []string, name string, args ...string) (string, string, error) {
+	f.calls = append(f.calls, fakeCall{dir: dir, name: name, args: append([]string{}, args...)})
+	if len(f.next) == 0 {
+		return "", "", nil
+	}
+	res := f.next[0]
+	f.next = f.next[1:]
+	return res.stdout, res.stderr, res.err
+}
+
+func TestOpenPR_HappyPath(t *testing.T) {
+	fr := &fakeRunner{next: []fakeResult{
+		{stdout: "https://github.com/Lincyaw/workbuddy/pull/999\n"},
+	}}
+	c := Client{Runner: fr, GHBinary: "gh"}
+	url, err := c.OpenPR(context.Background(), "Lincyaw/workbuddy", "workbuddy/issue-330", "title", "body referencing #330")
+	if err != nil {
+		t.Fatalf("OpenPR: %v", err)
+	}
+	if url != "https://github.com/Lincyaw/workbuddy/pull/999" {
+		t.Fatalf("url = %q", url)
+	}
+	if len(fr.calls) != 1 {
+		t.Fatalf("expected one call, got %d", len(fr.calls))
+	}
+	call := fr.calls[0]
+	if call.name != "gh" {
+		t.Fatalf("name = %q", call.name)
+	}
+	want := []string{"pr", "create", "--repo", "Lincyaw/workbuddy", "--head", "workbuddy/issue-330", "--title", "title", "--body", "body referencing #330"}
+	if !stringSlicesEqual(call.args, want) {
+		t.Fatalf("args = %v\nwant %v", call.args, want)
+	}
+}
+
+func TestOpenPR_GHFailure(t *testing.T) {
+	fr := &fakeRunner{next: []fakeResult{
+		{stderr: "GraphQL: not authorized", err: errors.New("exit 1")},
+	}}
+	c := Client{Runner: fr}
+	_, err := c.OpenPR(context.Background(), "Lincyaw/workbuddy", "b", "t", "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "not authorized") {
+		t.Fatalf("error should carry stderr, got %v", err)
+	}
+}
+
+func TestOpenPR_NoURL(t *testing.T) {
+	fr := &fakeRunner{next: []fakeResult{{stdout: "   \n"}}}
+	c := Client{Runner: fr}
+	_, err := c.OpenPR(context.Background(), "r/r", "b", "t", "")
+	if err == nil {
+		t.Fatal("expected error when gh returns no URL")
+	}
+}
+
+func TestOpenPR_RejectsBadInput(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name, repo, branch, title string
+	}{
+		{"empty repo", "", "b", "t"},
+		{"empty branch", "r/r", "", "t"},
+		{"empty title", "r/r", "b", ""},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := OpenPR(ctx, tc.repo, tc.branch, tc.title, ""); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/launcher/gitops_bridge.go
+++ b/internal/launcher/gitops_bridge.go
@@ -1,0 +1,49 @@
+package launcher
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/Lincyaw/workbuddy/internal/gitops"
+	runtimepkg "github.com/Lincyaw/workbuddy/internal/runtime"
+)
+
+// agentmGitOpsAdapter implements runtimepkg.AgentMGitOps on top of
+// internal/gitops. It is the v0.6 coordinator-managed publish bridge:
+// AgentM declares success, the bridge invokes this adapter, the adapter
+// shells out to `git` + `gh` to commit and open a PR. Per
+// docs/decisions/2026-05-13-k8s-agentm-otel.md (Block 2) only AgentM
+// participates — claude-code and codex remain self-managed.
+type agentmGitOpsAdapter struct {
+	client *gitops.Client
+	author gitops.Author
+}
+
+// NewAgentMGitOpsAdapter builds the production adapter that the AgentM
+// bridge consults after a successful run. Passing a nil client falls back
+// to the gitops package zero value (ExecRunner + `git`/`gh` binaries on
+// PATH); passing an empty author falls back to gitops.DefaultBotAuthor.
+func NewAgentMGitOpsAdapter(client *gitops.Client, author gitops.Author) runtimepkg.AgentMGitOps {
+	if client == nil {
+		client = &gitops.Client{}
+	}
+	if author.Name == "" || author.Email == "" {
+		author = gitops.DefaultBotAuthor
+	}
+	return &agentmGitOpsAdapter{client: client, author: author}
+}
+
+func (a *agentmGitOpsAdapter) PublishArtifact(ctx context.Context, req runtimepkg.AgentMPublishRequest) (string, error) {
+	if err := a.client.CommitAndPush(ctx, req.RepoLocalPath, req.Branch, req.CommitMessage, a.author); err != nil {
+		if errors.Is(err, gitops.ErrNoChanges) {
+			return "", runtimepkg.ErrNoChangesToPublish
+		}
+		return "", fmt.Errorf("commit-push: %w", err)
+	}
+	prURL, err := a.client.OpenPR(ctx, req.Repo, req.Branch, req.PRTitle, req.PRBody)
+	if err != nil {
+		return "", fmt.Errorf("open-pr: %w", err)
+	}
+	return prURL, nil
+}

--- a/internal/launcher/gitops_bridge_test.go
+++ b/internal/launcher/gitops_bridge_test.go
@@ -1,0 +1,102 @@
+package launcher
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Lincyaw/workbuddy/internal/gitops"
+	runtimepkg "github.com/Lincyaw/workbuddy/internal/runtime"
+)
+
+// scriptedRunner returns canned (stdout, stderr, err) results for
+// sequential calls so the adapter test asserts both halves of
+// PublishArtifact (git commit/push then gh pr create) without touching
+// the network. The .git/ precondition check still runs against a real
+// temp directory.
+type scriptedRunner struct {
+	calls []string
+	idx   int
+	out   []scriptedResult
+}
+
+type scriptedResult struct {
+	stdout string
+	stderr string
+	err    error
+}
+
+func (s *scriptedRunner) Run(_ context.Context, _ string, _ []string, name string, args ...string) (string, string, error) {
+	s.calls = append(s.calls, name+" "+strings.Join(args, " "))
+	if s.idx >= len(s.out) {
+		return "", "", nil
+	}
+	res := s.out[s.idx]
+	s.idx++
+	return res.stdout, res.stderr, res.err
+}
+
+func TestAgentMGitOpsAdapter_HappyPath(t *testing.T) {
+	sr := &scriptedRunner{out: []scriptedResult{
+		{}, // git checkout
+		{}, // git add
+		{stdout: " M feature.txt\n"},             // git status --porcelain
+		{}, // git commit
+		{}, // git push
+		{stdout: "https://example.com/pull/9\n"}, // gh pr create
+	}}
+	client := &gitops.Client{Runner: sr}
+	adapter := NewAgentMGitOpsAdapter(client, gitops.Author{})
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+	prURL, err := adapter.PublishArtifact(context.Background(), runtimepkg.AgentMPublishRequest{
+		Repo:          "Lincyaw/workbuddy",
+		IssueNumber:   330,
+		Branch:        "workbuddy/issue-330",
+		CommitMessage: "msg",
+		PRTitle:       "title",
+		PRBody:        "body",
+		RepoLocalPath: dir,
+	})
+	if err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if prURL != "https://example.com/pull/9" {
+		t.Fatalf("pr url = %q", prURL)
+	}
+	if len(sr.calls) != 6 {
+		t.Fatalf("expected 6 subprocess calls, got %d: %v", len(sr.calls), sr.calls)
+	}
+}
+
+func TestAgentMGitOpsAdapter_TranslatesNoChanges(t *testing.T) {
+	sr := &scriptedRunner{out: []scriptedResult{
+		{}, // checkout
+		{}, // add
+		{}, // status (empty stdout -> no changes)
+	}}
+	client := &gitops.Client{Runner: sr}
+	adapter := NewAgentMGitOpsAdapter(client, gitops.Author{})
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+	_, err := adapter.PublishArtifact(context.Background(), runtimepkg.AgentMPublishRequest{
+		Repo:          "r/r",
+		IssueNumber:   1,
+		Branch:        "b",
+		CommitMessage: "m",
+		PRTitle:       "t",
+		RepoLocalPath: dir,
+	})
+	if !errors.Is(err, runtimepkg.ErrNoChangesToPublish) {
+		t.Fatalf("err = %v, want ErrNoChangesToPublish", err)
+	}
+}

--- a/internal/launcher/launcher.go
+++ b/internal/launcher/launcher.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Lincyaw/workbuddy/internal/agent/agentm"
 	"github.com/Lincyaw/workbuddy/internal/agent/codex"
 	"github.com/Lincyaw/workbuddy/internal/config"
+	"github.com/Lincyaw/workbuddy/internal/gitops"
 	runtimepkg "github.com/Lincyaw/workbuddy/internal/runtime"
 	supclient "github.com/Lincyaw/workbuddy/internal/supervisor/client"
 )
@@ -45,7 +46,13 @@ func RegisterBuiltins(l *runtimepkg.Registry) {
 	l.Register(newAgentBridgeRuntime(config.RuntimeCodex, func() (agent.Backend, error) {
 		return codex.NewBackend(codex.Config{})
 	}), config.RuntimeCodex, config.RuntimeCodexServer)
-	l.Register(newAgentBridgeRuntime(config.RuntimeAgentM, func() (agent.Backend, error) {
+	agentMRuntime := newAgentBridgeRuntime(config.RuntimeAgentM, func() (agent.Backend, error) {
 		return agentm.NewBackend(), nil
-	}), config.RuntimeAgentM)
+	})
+	// Coordinator-managed publish path for AgentM only (REQ-142).
+	// claude-code / codex stay self-managed (no GitOps adapter wired on
+	// those runtimes), so they keep calling `gh issue edit` / `git push`
+	// from inside the agent subprocess as today.
+	agentMRuntime.GitOps = NewAgentMGitOpsAdapter(nil, gitops.Author{})
+	l.Register(agentMRuntime, config.RuntimeAgentM)
 }

--- a/internal/runtime/agent_bridge.go
+++ b/internal/runtime/agent_bridge.go
@@ -37,6 +37,45 @@ type AgentBridgeRuntime struct {
 	BackendMu   sync.Mutex
 	NewBackend  func() (agent.Backend, error)
 	RuntimeName string
+	// GitOps, when non-nil, is invoked by the AgentM bridge after a
+	// successful run with a non-empty artifact: the coordinator commits
+	// the artifact to a `workbuddy/issue-N` branch, pushes, and opens a
+	// PR. v0.6 coordinator-managed dispatch per
+	// docs/decisions/2026-05-13-k8s-agentm-otel.md (Block 2). Other
+	// runtimes (claude-code, codex) remain self-managed; this hook is
+	// only consulted when the underlying session is AgentM.
+	GitOps AgentMGitOps
+}
+
+// AgentMGitOps is the bridge between the runtime package and
+// internal/gitops. Defined locally so runtime stays a leaf-of-leaves;
+// production wiring constructs an adapter that satisfies this interface
+// around a *gitops.Client.
+type AgentMGitOps interface {
+	// PublishArtifact commits whatever is staged in req.RepoLocalPath
+	// (the AgentM workspace) onto req.Branch, pushes, and opens a PR.
+	// Returns the PR URL on success. An ErrNoChangesToPublish return
+	// means the agent produced no diff; the caller MUST treat that as
+	// a no-op publish, not a failure.
+	PublishArtifact(ctx context.Context, req AgentMPublishRequest) (prURL string, err error)
+}
+
+// ErrNoChangesToPublish signals that an AgentMGitOps.PublishArtifact call
+// found no working-tree changes — the agent declared success but its
+// workspace is identical to the base branch. Callers surface this as
+// metadata, not as a failure.
+var ErrNoChangesToPublish = fmt.Errorf("agent bridge: agentm produced no changes to publish")
+
+// AgentMPublishRequest is the input to AgentMGitOps.PublishArtifact.
+type AgentMPublishRequest struct {
+	Repo          string
+	IssueNumber   int
+	IssueTitle    string
+	Branch        string
+	CommitMessage string
+	PRTitle       string
+	PRBody        string
+	RepoLocalPath string
 }
 
 func NewAgentBridgeRuntime(runtimeName string, factory func() (agent.Backend, error)) *AgentBridgeRuntime {
@@ -114,6 +153,7 @@ func (r *AgentBridgeRuntime) Start(ctx context.Context, agentCfg *config.AgentCo
 		Handle:   handle,
 		AgentCfg: agentCfg,
 		Task:     task,
+		GitOps:   r.GitOps,
 	}, nil
 }
 
@@ -147,6 +187,9 @@ type AgentBridgeSession struct {
 	Handle   BridgeSessionHandle
 	AgentCfg *config.AgentConfig
 	Task     *TaskContext
+	// GitOps, when non-nil and the underlying session is AgentM,
+	// publishes the artifact (commit/push/PR) after a successful run.
+	GitOps AgentMGitOps
 }
 
 func (s *AgentBridgeSession) Run(ctx context.Context, events chan<- launcherevents.Event) (*Result, error) {
@@ -250,6 +293,23 @@ func (s *AgentBridgeSession) Run(ctx context.Context, events chan<- launchereven
 			if !out.Success {
 				meta["agentm_failure_reason"] = out.FailureReason
 			}
+			// Coordinator-managed publish path (REQ-142 / #330).
+			// Only invoked when the run succeeded; failed runs already
+			// surface failure_reason for the reporter to comment on.
+			if out.Success && s.GitOps != nil && s.Task != nil {
+				prURL, pubMeta, pubErr := s.publishAgentMArtifact(ctx, out)
+				for k, v := range pubMeta {
+					meta[k] = v
+				}
+				if pubErr != nil {
+					// Publish failure is infra failure: AgentM did its
+					// job, but the coordinator couldn't ship the diff.
+					meta[MetaInfraFailure] = "true"
+					meta[MetaInfraFailureReason] = "agentm publish: " + pubErr.Error()
+				} else if prURL != "" {
+					meta["pr_url"] = prURL
+				}
+			}
 		}
 	}
 
@@ -268,6 +328,85 @@ func (s *AgentBridgeSession) Run(ctx context.Context, events chan<- launchereven
 			Kind: agentResult.SessionRef.Kind,
 		},
 	}, err
+}
+
+// publishAgentMArtifact is the coordinator-managed commit+push+PR step
+// (REQ-142). It runs only when the underlying session is AgentM and the
+// bridge runtime has a GitOps adapter configured.
+func (s *AgentBridgeSession) publishAgentMArtifact(ctx context.Context, out *agentm.Output) (string, map[string]string, error) {
+	if s.Task == nil {
+		return "", nil, nil
+	}
+	repo := s.Task.Repo
+	issueNum := s.Task.Issue.Number
+	if repo == "" || issueNum <= 0 {
+		return "", nil, nil
+	}
+	workdir := s.Task.WorkDir
+	if workdir == "" {
+		workdir = s.Task.RepoRoot
+	}
+	if workdir == "" {
+		return "", nil, fmt.Errorf("no workdir on task context")
+	}
+
+	branch := fmt.Sprintf("workbuddy/issue-%d", issueNum)
+	commitMsg := fmt.Sprintf("workbuddy(agentm): resolve issue #%d", issueNum)
+	title := s.Task.Issue.Title
+	if title == "" {
+		title = fmt.Sprintf("workbuddy: resolve issue #%d", issueNum)
+	} else {
+		title = fmt.Sprintf("workbuddy: %s", title)
+	}
+	body := buildAgentMPRBody(repo, issueNum, out)
+
+	req := AgentMPublishRequest{
+		Repo:          repo,
+		IssueNumber:   issueNum,
+		IssueTitle:    s.Task.Issue.Title,
+		Branch:        branch,
+		CommitMessage: commitMsg,
+		PRTitle:       title,
+		PRBody:        body,
+		RepoLocalPath: workdir,
+	}
+
+	prURL, err := s.GitOps.PublishArtifact(ctx, req)
+	meta := map[string]string{}
+	if err != nil {
+		if isNoChangesErr(err) {
+			meta["agentm_publish"] = "no_changes"
+			return "", meta, nil
+		}
+		return "", meta, err
+	}
+	meta["agentm_publish"] = "published"
+	meta["agentm_pr_branch"] = branch
+	return prURL, meta, nil
+}
+
+func buildAgentMPRBody(repo string, issueNum int, out *agentm.Output) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Resolves %s#%d.\n\n", repo, issueNum)
+	b.WriteString("Generated by workbuddy AgentM coordinator-managed dispatch.\n")
+	if out != nil && out.NextLabel != "" {
+		fmt.Fprintf(&b, "\nAgent next_label: `%s`\n", out.NextLabel)
+	}
+	if out != nil && out.SessionLogPath != "" {
+		fmt.Fprintf(&b, "\nSession log: `%s`\n", out.SessionLogPath)
+	}
+	return b.String()
+}
+
+func isNoChangesErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if err == ErrNoChangesToPublish {
+		return true
+	}
+	return strings.Contains(err.Error(), "no changes to commit") ||
+		strings.Contains(err.Error(), "no changes to publish")
 }
 
 func (s *AgentBridgeSession) SetApprover(Approver) error { return ErrNotSupported }

--- a/internal/runtime/agentm_publish_test.go
+++ b/internal/runtime/agentm_publish_test.go
@@ -1,0 +1,192 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Lincyaw/workbuddy/internal/agent"
+	"github.com/Lincyaw/workbuddy/internal/agent/agentm"
+	"github.com/Lincyaw/workbuddy/internal/agent/agentm/agentmtest"
+	"github.com/Lincyaw/workbuddy/internal/config"
+)
+
+// fakeGitOps records the PublishArtifact calls so tests can assert the
+// bridge wired the right repo/branch/title/body off of the AgentM output.
+type fakeGitOps struct {
+	calls  []AgentMPublishRequest
+	prURL  string
+	err    error
+	noDiff bool
+}
+
+func (f *fakeGitOps) PublishArtifact(_ context.Context, req AgentMPublishRequest) (string, error) {
+	f.calls = append(f.calls, req)
+	if f.noDiff {
+		return "", ErrNoChangesToPublish
+	}
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.prURL, nil
+}
+
+// AC-1-1 / AC-1-2: successful AgentM run with a GitOps adapter must
+// trigger PublishArtifact and surface the PR URL on Result.Meta.
+func TestAgentMBridge_PublishOnSuccess(t *testing.T) {
+	fake := agentmtest.BuildFake(t, agentmtest.Config{Mode: agentmtest.ModeSuccess})
+	gops := &fakeGitOps{prURL: "https://github.com/Lincyaw/workbuddy/pull/501"}
+	rt := NewAgentBridgeRuntime(config.RuntimeAgentM, func() (agent.Backend, error) {
+		return &agentm.Backend{Binary: fake}, nil
+	})
+	rt.GitOps = gops
+
+	work := t.TempDir()
+	task := &TaskContext{
+		Repo:    "Lincyaw/workbuddy",
+		WorkDir: work,
+		Issue:   IssueContext{Number: 330, Title: "AgentM publish"},
+		Session: SessionContext{ID: "test-session"},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	res, err := rt.Launch(ctx, &config.AgentConfig{Name: "dev-agent", Runtime: config.RuntimeAgentM}, task)
+	if err != nil {
+		t.Fatalf("Launch: %v", err)
+	}
+	if len(gops.calls) != 1 {
+		t.Fatalf("expected 1 publish call, got %d", len(gops.calls))
+	}
+	call := gops.calls[0]
+	if call.Repo != "Lincyaw/workbuddy" || call.IssueNumber != 330 {
+		t.Fatalf("bad call routing: %+v", call)
+	}
+	if call.Branch != "workbuddy/issue-330" {
+		t.Fatalf("branch = %q", call.Branch)
+	}
+	// AC-1-2: PR body references the originating issue.
+	if !contains(call.PRBody, "#330") {
+		t.Fatalf("PR body should reference #330, got %q", call.PRBody)
+	}
+	if res.Meta["pr_url"] != "https://github.com/Lincyaw/workbuddy/pull/501" {
+		t.Fatalf("pr_url meta = %q", res.Meta["pr_url"])
+	}
+	if res.Meta["agentm_publish"] != "published" {
+		t.Fatalf("agentm_publish meta = %q", res.Meta["agentm_publish"])
+	}
+	if IsInfraFailure(res) {
+		t.Fatalf("successful publish should not be infra failure")
+	}
+}
+
+// AC-1-3: failed AgentM runs (success=false) must NOT push/PR. The
+// reporter surfaces the failure_reason instead via the existing
+// agentm_failure_reason meta key.
+func TestAgentMBridge_NoPublishOnFailure(t *testing.T) {
+	fake := agentmtest.BuildFake(t, agentmtest.Config{
+		Mode:          agentmtest.ModeFailure,
+		NextLabel:     "status:failed",
+		FailureReason: "tests did not pass",
+	})
+	gops := &fakeGitOps{}
+	rt := NewAgentBridgeRuntime(config.RuntimeAgentM, func() (agent.Backend, error) {
+		return &agentm.Backend{Binary: fake}, nil
+	})
+	rt.GitOps = gops
+
+	work := t.TempDir()
+	task := &TaskContext{
+		Repo:    "Lincyaw/workbuddy",
+		WorkDir: work,
+		Issue:   IssueContext{Number: 330},
+		Session: SessionContext{ID: "test-session"},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	res, err := rt.Launch(ctx, &config.AgentConfig{Name: "dev-agent", Runtime: config.RuntimeAgentM}, task)
+	if err == nil {
+		t.Fatal("expected non-nil err for clean failure")
+	}
+	if len(gops.calls) != 0 {
+		t.Fatalf("expected 0 publish calls, got %d", len(gops.calls))
+	}
+	if res.Meta["agentm_failure_reason"] != "tests did not pass" {
+		t.Fatalf("failure_reason meta = %q", res.Meta["agentm_failure_reason"])
+	}
+	if res.Meta["pr_url"] != "" {
+		t.Fatalf("pr_url should be empty on failure, got %q", res.Meta["pr_url"])
+	}
+}
+
+// Publish-side infrastructure failure: AgentM succeeded but the
+// coordinator could not commit/push. We mark the result as infra failure
+// so the reporter shows it distinctly.
+func TestAgentMBridge_PublishFailureIsInfraFailure(t *testing.T) {
+	fake := agentmtest.BuildFake(t, agentmtest.Config{Mode: agentmtest.ModeSuccess})
+	gops := &fakeGitOps{err: errors.New("commit-push: git push: permission denied")}
+	rt := NewAgentBridgeRuntime(config.RuntimeAgentM, func() (agent.Backend, error) {
+		return &agentm.Backend{Binary: fake}, nil
+	})
+	rt.GitOps = gops
+
+	work := t.TempDir()
+	task := &TaskContext{
+		Repo:    "Lincyaw/workbuddy",
+		WorkDir: work,
+		Issue:   IssueContext{Number: 330},
+		Session: SessionContext{ID: "test-session"},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	res, _ := rt.Launch(ctx, &config.AgentConfig{Name: "dev-agent", Runtime: config.RuntimeAgentM}, task)
+	if !IsInfraFailure(res) {
+		t.Fatalf("expected infra failure on publish error, meta=%v", res.Meta)
+	}
+	if !contains(res.Meta[MetaInfraFailureReason], "permission denied") {
+		t.Fatalf("infra reason should carry git error, got %q", res.Meta[MetaInfraFailureReason])
+	}
+}
+
+// No-changes from gitops should NOT escalate to infra failure: AgentM is
+// telling us the task was already satisfied.
+func TestAgentMBridge_PublishNoChanges(t *testing.T) {
+	fake := agentmtest.BuildFake(t, agentmtest.Config{Mode: agentmtest.ModeSuccess})
+	gops := &fakeGitOps{noDiff: true}
+	rt := NewAgentBridgeRuntime(config.RuntimeAgentM, func() (agent.Backend, error) {
+		return &agentm.Backend{Binary: fake}, nil
+	})
+	rt.GitOps = gops
+
+	work := t.TempDir()
+	task := &TaskContext{
+		Repo:    "Lincyaw/workbuddy",
+		WorkDir: work,
+		Issue:   IssueContext{Number: 330},
+		Session: SessionContext{ID: "test-session"},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	res, err := rt.Launch(ctx, &config.AgentConfig{Name: "dev-agent", Runtime: config.RuntimeAgentM}, task)
+	if err != nil {
+		t.Fatalf("Launch: %v", err)
+	}
+	if IsInfraFailure(res) {
+		t.Fatal("no-changes must not be infra failure")
+	}
+	if res.Meta["agentm_publish"] != "no_changes" {
+		t.Fatalf("agentm_publish meta = %q", res.Meta["agentm_publish"])
+	}
+	if res.Meta["pr_url"] != "" {
+		t.Fatalf("pr_url should be empty when no changes, got %q", res.Meta["pr_url"])
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -5366,3 +5366,70 @@ requirements:
     tests:
       - internal/config/loader_test.go
       - internal/runtime/agentm_bridge_test.go
+
+  - id: REQ-142
+    title: Coordinator-side git push + PR creation for AgentM runs (v0.6)
+    description: >
+      Per docs/decisions/2026-05-13-k8s-agentm-otel.md Block 2
+      § Two execution modes, AgentM runs in coordinator-managed mode:
+      the agent does not hold GitHub credentials, returns a structured
+      Output containing an artifact path, and the coordinator commits
+      the artifact onto a fresh `workbuddy/issue-N` branch, pushes,
+      and opens a PR. Other runtimes (claude-code, codex) remain
+      self-managed and call `gh issue edit` / `git push` themselves.
+
+      Implementation:
+
+      - New `internal/gitops/` package centralizes the two write
+        operations: CommitAndPush (shells out to `git` CLI, no go-git
+        dependency, surfaces ErrNoChanges so no-op artifacts don't
+        produce empty branches) and OpenPR (shells out to `gh pr
+        create`, works against github.com and Gitea instances the
+        user has logged into). Both have a Client form for runner
+        injection in tests.
+
+      - `internal/runtime/agent_bridge.go` grows an AgentMGitOps
+        interface + AgentMPublishRequest type and an optional GitOps
+        field on AgentBridgeRuntime / AgentBridgeSession. After the
+        bridge resolves AgentM's structured Output and the run
+        succeeded, it invokes GitOps.PublishArtifact with the issue
+        repo/number, a branch name of `workbuddy/issue-N`, a bot
+        commit message, and a PR body that references the issue.
+        On AgentM failure (success=false) the bridge does NOT call
+        the adapter; failure_reason continues to flow into
+        Result.Meta so the existing reporter machinery surfaces it
+        as an issue comment.
+
+      - `internal/launcher/gitops_bridge.go` adapts gitops.Client
+        to the AgentMGitOps interface and wires it onto the AgentM
+        runtime in RegisterBuiltins. The default author is
+        `workbuddy-bot <bot@workbuddy.internal>`. Other runtimes do
+        not receive the adapter.
+
+      - Publish failure (commit/push/gh errors) is marked as infra
+        failure on the Result so the reporter renders it with the
+        distinct infra header. ErrNoChanges from a successful AgentM
+        run is surfaced as `agentm_publish=no_changes` metadata but
+        is NOT escalated to infra failure (the agent's success
+        signal is preserved).
+    priority: P1
+    version: v0.6.0
+    status: tested
+    acceptance_criteria:
+      - "AC-1-1: After a successful AgentM run with a non-empty artifact, coordinator opens a PR on a fresh `workbuddy/issue-N` branch authored by `workbuddy-bot <bot@workbuddy.internal>` and surfaces the PR URL on Result.Meta.pr_url."
+      - "AC-1-2: PR body references the originating `{repo}#{issue_number}`."
+      - "AC-1-3: Failed AgentM runs (success=false) do NOT trigger commit/push/PR; the bridge surfaces failure_reason on Result.Meta so the existing reporter machinery posts the issue comment."
+      - "AC-1-4: `go build ./... && go vet ./... && go test ./... -count=1` all pass."
+      - "AC-1-5: project-index.yaml has this REQ entry referencing issue #330."
+      - "AC-1-6: Other runtimes (claude-code, codex) are not wired to the GitOps adapter and continue to manage their own git/gh writes from inside the agent subprocess."
+    code:
+      - internal/gitops/gitops.go
+      - internal/runtime/agent_bridge.go
+      - internal/launcher/gitops_bridge.go
+      - internal/launcher/launcher.go
+    tests:
+      - internal/gitops/gitops_test.go
+      - internal/runtime/agentm_publish_test.go
+      - internal/launcher/gitops_bridge_test.go
+    deps:
+      - REQ-134


### PR DESCRIPTION
## Summary

v0.6 coordinator-managed dispatch path for the AgentM runtime per [the decision doc](docs/decisions/2026-05-13-k8s-agentm-otel.md) Block 2. Closes #330.

- New \`internal/gitops/\` package: \`CommitAndPush\` + \`OpenPR\` via the local \`git\` and \`gh\` CLIs (no go-git). \`ErrNoChanges\` surfaces no-op artifacts cleanly. Both ops have a Client form for test-injected runners.
- \`internal/runtime/agent_bridge.go\`: optional \`GitOps\` hook on the bridge runtime, invoked only when the underlying session is AgentM **and** the run succeeded. Failed runs do not push/PR; \`failure_reason\` continues flowing through \`Result.Meta\` to the existing reporter machinery.
- \`internal/launcher/gitops_bridge.go\`: adapter wiring \`gitops.Client\` onto the AgentM runtime in \`RegisterBuiltins\`. Default author \`workbuddy-bot <bot@workbuddy.internal>\`. **claude-code and codex runtimes are not wired and continue to manage their own writes.**

## AC coverage

- AC-1-1: success path opens PR on \`workbuddy/issue-N\` with the bot author; PR URL surfaced on \`Result.Meta.pr_url\` — covered by \`TestAgentMBridge_PublishOnSuccess\` and \`TestCommitAndPush_HappyPath\`.
- AC-1-2: PR body references \`{repo}#{issue_number}\` — covered by \`TestAgentMBridge_PublishOnSuccess\`.
- AC-1-3: \`success=false\` runs do not push/PR; failure flows through reporter — covered by \`TestAgentMBridge_NoPublishOnFailure\`.
- AC-1-4: \`go build ./... && go vet ./... && go test ./... -count=1\` all pass.
- AC-1-5: project-index.yaml REQ-142 added with status \`tested\`.
- AC-1-6: only the AgentM runtime is wired with the adapter (verified by inspection of \`RegisterBuiltins\`).

## Test plan

- [x] \`go build ./... && go vet ./... && go test ./... -count=1\` green locally.
- [x] gitops package tests cover commit/push against a local bare repo (no real remote) and mocked gh CLI for \`OpenPR\` (success / failure / no URL / bad input).
- [x] runtime bridge tests cover publish-on-success, no-publish-on-failure, publish-error-as-infra-failure, and no-changes-is-not-failure.
- [x] launcher adapter test covers the gitops.Client wiring and the \`ErrNoChanges -> ErrNoChangesToPublish\` translation.

## Deviations

- Branch is force-pushed with \`--force-with-lease\` so re-dispatch of the same issue overwrites stale remote state without losing protected history. This is hidden inside \`gitops.CommitAndPush\`; callers see only success/no-changes.
- The bridge invokes \`PublishArtifact\` even when the AgentM artifact path is empty: AgentM may write changes directly into the workspace (per its v0.5 contract), so we stage \`-A\` and rely on \`git status --porcelain\` to detect no-changes rather than gating on \`Meta.agentm_artifact_path\`.
- \`internal/labelwriter/\` from a sibling branch is not present here and is not touched.
- \`internal/webui/dist/index.html\` was not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)