### PR TITLE
deploy/helm: add Ingress for webui + webhook (REQ-144, #333)

### DIFF
--- a/deploy/helm/workbuddy/README.md
+++ b/deploy/helm/workbuddy/README.md
@@ -6,7 +6,7 @@ described in `docs/decisions/2026-05-13-k8s-agentm-otel.md` Block 3.
 
 This chart is intentionally minimal at v0.6.0. The full values surface
 (MySQL host/user/pass/db split, OTel resource attributes, AegisLab topology
-wiring, ingress) is hardened in **#334**. Ingress is **#333**.
+wiring) is hardened in **#334**. Ingress shipped via **#333** (REQ-144).
 
 ## Install
 
@@ -32,9 +32,39 @@ chart will materialize a Secret for dev use. Likewise, if
 from `deploy/helm/workbuddy/agents/*.md` (empty by default — bundle your
 defaults there or override).
 
+## Ingress
+
+Disabled by default. Enable to expose the coordinator's webui, JSON API,
+and webhook entrypoint through a single host:
+
+```bash
+helm install my-workbuddy deploy/helm/workbuddy \
+  --set mysql.dsn=mysql://user:pass@mysql.aegislab.svc:3306/workbuddy \
+  --set giteaToken.secretName=workbuddy-gitea \
+  --set ingress.enabled=true \
+  --set ingress.host=workbuddy.example.com
+```
+
+The chart renders one `Ingress` resource with three Prefix routes, all
+backed by the coordinator Service on port `service.port` (default 8080):
+
+| Path | Purpose |
+|------|---------|
+| `/webui` | SPA served from `internal/webui/dist`. |
+| `/api`   | JSON API consumed by the webui and by `workbuddy worker` long-poll. |
+| `/webhook` | Gitea / GitHub push webhook entrypoint. |
+
+Optional fields:
+
+| Key | Description |
+|-----|-------------|
+| `ingress.className` | Sets `ingressClassName` (omit to use cluster default). |
+| `ingress.annotations` | Free-form annotations (e.g. nginx rewrite rules). |
+| `ingress.tls.enabled` | Render a `tls:` block on the Ingress. |
+| `ingress.tls.secretName` | Existing TLS Secret name. cert-manager / ACME is out of scope — wire it externally. |
+
 ## What's not here yet
 
-- Ingress (tracked in **#333**).
 - Full values surface — split MySQL fields, OTel docs, AegisLab topology
   defaults (tracked in **#334**).
 - Worker deployment — K8s mode collapses worker into the coordinator

--- a/deploy/helm/workbuddy/templates/ingress.yaml
+++ b/deploy/helm/workbuddy/templates/ingress.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "workbuddy.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "workbuddy.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      {{- if .Values.ingress.tls.secretName }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+      {{- end }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          # webui SPA served by the coordinator (internal/webui).
+          - path: /webui
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          # JSON API consumed by the webui and by `workbuddy worker` long-poll.
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          # Gitea / GitHub push webhook entrypoint.
+          - path: /webhook
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+{{- end }}

--- a/deploy/helm/workbuddy/values.yaml
+++ b/deploy/helm/workbuddy/values.yaml
@@ -43,6 +43,21 @@ giteaToken:
 agents:
   configMapName: ""
 
+# Ingress for the coordinator Service. Disabled by default; enable in K8s
+# topologies that need external webui + webhook access (decision doc Block 3
+# § Chart layout). Three routes are exposed when enabled: /webui, /api,
+# and /webhook — all backed by the same coordinator Service port.
+# cert-manager / ACME integration is out of scope: set tls.secretName to an
+# existing TLS Secret if you need HTTPS.
+ingress:
+  enabled: false
+  className: ""
+  host: ""
+  annotations: {}
+  tls:
+    enabled: false
+    secretName: ""
+
 resources: {}
 nodeSelector: {}
 tolerations: []

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -5162,6 +5162,51 @@ requirements:
       - deploy/helm/workbuddy/Chart.yaml
     deps: []
 
+  - id: REQ-144
+    title: Workbuddy Helm chart Ingress for webui + webhook (v0.6)
+    description: >
+      Per docs/decisions/2026-05-13-k8s-agentm-otel.md Block 3
+      § Chart layout ("Service: ClusterIP + Ingress (webui + webhook
+      entrypoint)"), the K8s topology exposes the coordinator webui,
+      JSON API, and webhook entrypoint through an Ingress. Issue #333,
+      depends on the chart skeleton from REQ-143 / #331.
+
+      Implementation:
+
+      - deploy/helm/workbuddy/templates/ingress.yaml renders a single
+        networking.k8s.io/v1 Ingress only when .Values.ingress.enabled.
+        Three Prefix routes — /webui, /api, /webhook — all backed by
+        the coordinator Service (chart skeleton uses one port for
+        both API and webui, see values.yaml service.port comment).
+        ingressClassName is rendered only when set; the tls: block is
+        gated by .Values.ingress.tls.enabled and uses an existing
+        Secret name (cert-manager / ACME wiring is intentionally out
+        of scope — users bring their own TLS Secret).
+
+      - deploy/helm/workbuddy/values.yaml adds the ingress sub-tree:
+        enabled (default false), className, host, annotations, and
+        tls.{enabled,secretName}.
+
+      - deploy/helm/workbuddy/README.md documents the install command
+        (`--set ingress.enabled=true --set ingress.host=...`) and the
+        three routes.
+    priority: P1
+    version: v0.6.0
+    status: tested
+    acceptance_criteria:
+      - "AC-144-1: `helm template ... --set ingress.enabled=true --set ingress.host=workbuddy.example.com` renders an Ingress with the /webui, /api, /webhook routes pointing at the coordinator Service."
+      - "AC-144-2: With `ingress.enabled=false` (default), no Ingress resource is rendered."
+      - "AC-144-3: `helm lint deploy/helm/workbuddy/` passes in both ingress.enabled=true and =false modes."
+      - "AC-144-4: project-index.yaml has this REQ entry referencing issue #333 and the decision doc."
+    code:
+      - deploy/helm/workbuddy/templates/ingress.yaml
+      - deploy/helm/workbuddy/values.yaml
+      - deploy/helm/workbuddy/README.md
+    tests:
+      - deploy/helm/workbuddy/templates/ingress.yaml
+    deps:
+      - REQ-143
+
   - id: REQ-138
     title: OTel cross-span correlation using persisted root_trace_id (v0.5)
     description: >


### PR DESCRIPTION
Closes #333.

## Summary

- Adds `deploy/helm/workbuddy/templates/ingress.yaml` rendering one `networking.k8s.io/v1` Ingress with three Prefix routes (`/webui`, `/api`, `/webhook`), all backed by the coordinator Service on `service.port` (default 8080).
- Extends `values.yaml` with `ingress.{enabled,className,host,annotations,tls.{enabled,secretName}}`, all disabled by default — existing installs are untouched.
- `ingressClassName` is rendered only when set; the `tls:` block is gated by `ingress.tls.enabled`. cert-manager / ACME wiring is intentionally out of scope per the decision doc.
- README documents the install flag and the three routes.
- `project-index.yaml`: REQ-144 marked `tested`, depends on REQ-143 (the skeleton landed in #336).

Per `docs/decisions/2026-05-13-k8s-agentm-otel.md` Block 3 § Chart layout ("Service: ClusterIP + Ingress (webui + webhook entrypoint)").

## AC coverage

- AC-1-1: `helm template my-release deploy/helm/workbuddy/ --set mysql.dsn=mysql://test/test --set giteaToken.secretName=test --set ingress.enabled=true --set ingress.host=workbuddy.example.com` renders one Ingress with `/webui`, `/api`, `/webhook` routes backed by `my-release-workbuddy:8080`.
- AC-1-2: Default `ingress.enabled=false` renders zero Ingress resources (verified via `grep -c 'kind: Ingress'` on the default template output).
- AC-1-3: `helm lint` passes in both `ingress.enabled=true` and `=false` modes (only the pre-existing `[INFO] Chart.yaml: icon is recommended`).
- AC-1-4: `project-index.yaml` REQ-144 added, referencing #333 and the decision doc; `validate_index.py` passes.

## Test plan

- [x] `helm lint deploy/helm/workbuddy/ ...` (both ingress modes)
- [x] `helm template ... --set ingress.enabled=true --set ingress.host=workbuddy.example.com`
- [x] `helm template ...` (default) — no Ingress rendered
- [x] `helm template ... --set ingress.className=nginx --set ingress.tls.enabled=true --set ingress.tls.secretName=wb-tls` — Ingress carries `ingressClassName` and `tls:` block
- [x] `python3 ~/.autoharness/scripts/validate_index.py project-index.yaml`

## Out of scope

- cert-manager / ACME integration (decision doc Block 3, issue scope).
- Authentication on the webui (the coordinator handles that).

🤖 Generated with [Claude Code](https://claude.com/claude-code)