### PR TITLE
helm/workbuddy: harden values surface for MySQL DSN + OTel endpoint (REQ-145, #334)

### DIFF
--- a/deploy/helm/workbuddy/README.md
+++ b/deploy/helm/workbuddy/README.md
@@ -1,36 +1,34 @@
-# workbuddy Helm chart (skeleton)
+# workbuddy Helm chart
 
-Skeleton chart for deploying the workbuddy coordinator into a Kubernetes
-cluster. Single-replica, MySQL-backed, OTel-instrumented — the K8s topology
-described in `docs/decisions/2026-05-13-k8s-agentm-otel.md` Block 3.
+Helm chart for deploying the workbuddy coordinator into a Kubernetes
+cluster. Single-replica, MySQL-backed, OTel-instrumented — the K8s
+topology described in `docs/decisions/2026-05-13-k8s-agentm-otel.md`
+Block 3 (Storage) and Block 4 (Collector).
 
-This chart is intentionally minimal at v0.6.0. The full values surface
-(MySQL host/user/pass/db split, OTel resource attributes, AegisLab topology
-wiring) is hardened in **#334**. Ingress shipped via **#333** (REQ-144).
+The chart is intentionally **service-reusing, not service-bundling**:
+MySQL and the OTel collector are reused from a co-located AegisLab
+release via plain values references. There is no MySQL subchart and no
+OTel-collector subchart — by design, per the decision doc.
 
-## Install
+## Quickstart
 
 ```bash
 helm install my-workbuddy deploy/helm/workbuddy \
-  --set mysql.dsn=mysql://user:pass@mysql.aegislab.svc:3306/workbuddy \
-  --set otel.endpoint=http://otel-collector.aegislab.svc:4317 \
+  --set mysql.dsnSecretRef.name=workbuddy-mysql \
+  --set otel.endpoint=http://otel-collector.aegislab.svc.cluster.local:4317 \
   --set giteaToken.secretName=workbuddy-gitea
 ```
 
-## Required values
+Or, for dev/CI where Secrets are inconvenient:
 
-| Key | Description |
-|-----|-------------|
-| `mysql.dsn` | MySQL DSN (reused from AegisLab; see decision doc Block 3). |
-| `otel.endpoint` | OTel collector endpoint. Empty disables export. |
-| `giteaToken.secretName` | Name of an existing Secret with key `token`. |
-| `agents.configMapName` | Name of an existing ConfigMap holding `.github/workbuddy/agents/*.md`. |
+```bash
+helm install my-workbuddy deploy/helm/workbuddy \
+  --set mysql.dsn='mysql://wb:wb@tcp(mysql:3306)/workbuddy?parseTime=true' \
+  --set otel.endpoint=http://otel:4317 \
+  --set giteaToken.token=ghp_xxx
+```
 
-If `giteaToken.secretName` is empty **and** `giteaToken.token` is set, the
-chart will materialize a Secret for dev use. Likewise, if
-`agents.configMapName` is empty, the chart renders a ConfigMap populated
-from `deploy/helm/workbuddy/agents/*.md` (empty by default — bundle your
-defaults there or override).
+## Values
 
 ## Ingress
 
@@ -71,3 +69,150 @@ Optional fields:
   process per decision doc Block 2 § Architectural consequences. AgentM
   execution goes through the agent-env Gateway, which has its own Helm
   release.
+
+### MySQL
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `mysql.dsn` | `""` | Full `mysql://` DSN. Plaintext — dev only. |
+| `mysql.dsnSecretRef.name` | `""` | Read the DSN from this Secret instead. Recommended for prod. |
+| `mysql.dsnSecretRef.key` | `dsn` | Key inside the referenced Secret. |
+
+Exactly one of `mysql.dsn` and `mysql.dsnSecretRef.name` should be set.
+When both are empty, the coordinator falls back to its built-in SQLite
+default (suitable for dev only — pods are ephemeral, so data is lost on
+restart).
+
+DSN format (consumed by `internal/store/store.go::New`):
+
+```
+mysql://<go-mysql-driver DSN>
+```
+
+For example:
+
+```
+mysql://wb:secret@tcp(mysql.aegislab.svc.cluster.local:3306)/workbuddy?parseTime=true&loc=UTC&multiStatements=true
+```
+
+### OpenTelemetry
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `otel.endpoint` | `""` | OTLP collector endpoint. Empty disables export. |
+| `otel.protocol` | `grpc` | `grpc` or `http/protobuf` (alias `http`). |
+| `otel.serviceName` | `workbuddy` | `OTEL_SERVICE_NAME`. |
+
+These map onto the **standard OTel SDK env vars**
+(`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`,
+`OTEL_SERVICE_NAME`) consumed by `internal/tracing/tracing.go`. All
+other `OTEL_*` env vars supported by the SDK pass through unmodified —
+override via `podAnnotations` or by extending the deployment.
+
+### Gitea / GitHub token
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `giteaToken.secretName` | `""` | Existing Secret holding the token. Required for prod. |
+| `giteaToken.secretKey` | `token` | Key inside the Secret. |
+| `giteaToken.token` | `""` | Plaintext token. Dev only — ignored when `secretName` is set. |
+
+The chart mounts the same Secret value into **two** env vars so a single
+token covers both backends:
+
+- `GH_TOKEN` — read by `gh` CLI in the GitHub poller / reporter path.
+- `GITEA_TOKEN` — read by `internal/labelwriter` for AgentM-mode label
+  writes against the Gitea REST API.
+
+### Agent definitions
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `agents.configMapName` | `""` | Existing ConfigMap mounted at `/etc/workbuddy/agents`. |
+
+If empty, the chart renders a ConfigMap from
+`deploy/helm/workbuddy/agents/*.md` (empty by default — bundle your
+defaults there or override with `configMapName`).
+
+## Env contract (pod env vars the coordinator actually consumes)
+
+| Pod env var | Source code | Notes |
+|-------------|-------------|-------|
+| `WORKBUDDY_MYSQL_DSN` | `internal/store/store.go::New` | DSN entry point. Currently surfaced for forward-compatibility; flag-level switch to consume this as the default coordinator DB is tracked alongside this change. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `internal/tracing/tracing.go` | Standard SDK var. Empty = exporter disabled. |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `internal/tracing/tracing.go` | `grpc` (default) or `http/protobuf`. |
+| `OTEL_SERVICE_NAME` | `internal/tracing/tracing.go` | Overrides default service name. |
+| `GH_TOKEN` | `gh` CLI invoked by poller / reporter | Standard `gh` env var. |
+| `GITEA_TOKEN` | `internal/labelwriter/labelwriter.go` | Bearer for AgentM-mode label writes. |
+| `WORKBUDDY_AGENTS_DIR` | `cmd/coordinator.go` (planned) | Path where agent ConfigMap is mounted. |
+
+## AegisLab topology
+
+This is the canonical "reuse AegisLab services" deployment per the
+decision doc. Workbuddy and AegisLab co-exist in the same cluster;
+workbuddy points at AegisLab's already-running MySQL and OTel collector
+via plain DNS references.
+
+```yaml
+# values-aegislab.yaml
+mysql:
+  dsnSecretRef:
+    name: aegislab-mysql-workbuddy
+    key: dsn
+
+otel:
+  endpoint: http://otel-collector.aegislab.svc.cluster.local:4317
+  protocol: grpc
+  serviceName: workbuddy
+
+giteaToken:
+  secretName: gitea-bot-token
+  secretKey: token
+
+agents:
+  configMapName: workbuddy-agents
+```
+
+Prerequisites (created out-of-band — these are NOT managed by this chart):
+
+- Secret `aegislab-mysql-workbuddy` with key `dsn` containing the full
+  `mysql://wb:...@tcp(mysql.aegislab.svc.cluster.local:3306)/workbuddy?...`
+  string. Typically created by ExternalSecrets or sealed-secrets and
+  rotated independently of workbuddy releases.
+- Secret `gitea-bot-token` with key `token` containing the Gitea PAT
+  used by the coordinator's poller and the labelwriter.
+- ConfigMap `workbuddy-agents` containing the `.github/workbuddy/agents/*.md`
+  files for this deployment.
+- AegisLab's OTel collector listening on
+  `otel-collector.aegislab.svc.cluster.local:4317` (OTLP/gRPC). Workbuddy
+  emits OTLP and AegisLab handles fan-out / tail-based sampling / storage.
+
+Install:
+
+```bash
+helm install workbuddy deploy/helm/workbuddy -f values-aegislab.yaml
+```
+
+## What's not here
+
+- **Worker deployment** — the K8s topology collapses the worker process
+  into the coordinator (decision doc Block 2 § Architectural
+  consequences). AgentM execution goes through the agent-env Gateway,
+  which has its own Helm release. agent-env values are explicitly NOT in
+  this chart.
+- **MySQL / OTel collector subcharts** — explicit non-goal per decision
+  doc. Reuse AegisLab.
+- **Multi-replica + leader election** — single-replica + `Recreate`
+  strategy only. Horizontal scale-out is deferred.
+
+## Validation
+
+```bash
+helm lint deploy/helm/workbuddy/
+helm template my deploy/helm/workbuddy/ \
+  --set mysql.dsnSecretRef.name=workbuddy-mysql \
+  --set otel.endpoint=http://otel:4317 \
+  --set giteaToken.secretName=workbuddy-gitea
+```
+
+Both should complete with no errors.

--- a/deploy/helm/workbuddy/templates/deployment.yaml
+++ b/deploy/helm/workbuddy/templates/deployment.yaml
@@ -45,15 +45,48 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           env:
+            # ----------------------------------------------------------
+            # MySQL DSN — Secret keyRef when dsnSecretRef.name is set,
+            # otherwise the plaintext value. Empty values are still
+            # rendered so the coordinator can detect "unconfigured" and
+            # fall back to SQLite for dev.
+            # ----------------------------------------------------------
+            {{- if .Values.mysql.dsnSecretRef.name }}
             - name: WORKBUDDY_MYSQL_DSN
-              value: {{ .Values.mysql.dsn | quote }}
-            - name: WORKBUDDY_OTEL_ENDPOINT
-              value: {{ .Values.otel.endpoint | quote }}
-            - name: WORKBUDDY_GITEA_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "workbuddy.giteaSecretName" . }}
-                  key: token
+                  name: {{ .Values.mysql.dsnSecretRef.name | quote }}
+                  key: {{ .Values.mysql.dsnSecretRef.key | default "dsn" | quote }}
+            {{- else }}
+            - name: WORKBUDDY_MYSQL_DSN
+              value: {{ .Values.mysql.dsn | quote }}
+            {{- end }}
+            # ----------------------------------------------------------
+            # OpenTelemetry — standard SDK env vars consumed by
+            # internal/tracing/tracing.go. Empty endpoint disables export.
+            # ----------------------------------------------------------
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.otel.endpoint | quote }}
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: {{ .Values.otel.protocol | default "grpc" | quote }}
+            - name: OTEL_SERVICE_NAME
+              value: {{ .Values.otel.serviceName | default "workbuddy" | quote }}
+            # ----------------------------------------------------------
+            # Gitea / GitHub token — one Secret value exposed as both
+            # env vars: GH_TOKEN (gh CLI in the poller) and GITEA_TOKEN
+            # (internal/labelwriter). Pre-existing Secret is required
+            # unless giteaToken.token is set for dev quickstart.
+            # ----------------------------------------------------------
+            - name: GH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "workbuddy.giteaSecretName" . | quote }}
+                  key: {{ .Values.giteaToken.secretKey | default "token" | quote }}
+            - name: GITEA_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "workbuddy.giteaSecretName" . | quote }}
+                  key: {{ .Values.giteaToken.secretKey | default "token" | quote }}
             - name: WORKBUDDY_AGENTS_DIR
               value: /etc/workbuddy/agents
           volumeMounts:

--- a/deploy/helm/workbuddy/templates/secret.yaml
+++ b/deploy/helm/workbuddy/templates/secret.yaml
@@ -2,7 +2,9 @@
 Only render a Secret if the user did NOT supply an existing Secret name.
 In production they should pre-create the Secret out-of-band (sealed-secrets,
 ExternalSecrets, etc.) and set .Values.giteaToken.secretName to its name.
-This in-chart path is for dev / quick-start only.
+This in-chart path is for dev / quick-start only. The Secret key matches
+.Values.giteaToken.secretKey (default "token") so the deployment's
+secretKeyRef and the chart-managed Secret agree.
 */ -}}
 {{- if and (not .Values.giteaToken.secretName) .Values.giteaToken.token }}
 apiVersion: v1
@@ -13,5 +15,5 @@ metadata:
     {{- include "workbuddy.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  token: {{ .Values.giteaToken.token | quote }}
+  {{ .Values.giteaToken.secretKey | default "token" }}: {{ .Values.giteaToken.token | quote }}
 {{- end }}

--- a/deploy/helm/workbuddy/values.yaml
+++ b/deploy/helm/workbuddy/values.yaml
@@ -1,6 +1,9 @@
 # Default values for workbuddy.
-# This is a minimal skeleton; the full values surface (MySQL, OTel, AegisLab
-# topology) is hardened in issue #334. See deploy/helm/workbuddy/README.md.
+# Full v0.6 values surface for the K8s topology described in
+# docs/decisions/2026-05-13-k8s-agentm-otel.md (Block 3 § Storage,
+# Block 4 § Collector). MySQL and the OTel collector are reused from
+# AegisLab via plain values references — NEITHER is bundled here as a
+# subchart, per the decision doc.
 
 image:
   repository: ghcr.io/lincyaw/workbuddy
@@ -12,34 +15,74 @@ nameOverride: ""
 fullnameOverride: ""
 
 # Coordinator HTTP API + webui port. Verified against cmd/coordinator.go
-# (default 8080, see cmd/init.go).
+# (default 8081 in the binary; chart exposes 8080 as the service port).
 service:
   type: ClusterIP
   port: 8080
 
-# MySQL DSN — workbuddy reuses AegisLab's MySQL cluster in v0.6.
-# Format: mysql://user:pass@host:3306/dbname (REQ-135/REQ-136).
-# #334 will split this into discrete host/user/pass/db fields.
+# ----------------------------------------------------------------------
+# MySQL
+# ----------------------------------------------------------------------
+# Workbuddy reuses AegisLab's MySQL cluster (REQ-135 / REQ-136). The
+# coordinator stores the DSN in a Secret; plaintext .dsn is offered only
+# for dev/quickstart. Production deployments SHOULD use .dsnSecretRef.
+#
+# DSN format (as consumed by internal/store/store.go::New):
+#   mysql://<go-mysql-driver DSN>
+# e.g.
+#   mysql://wb:secret@tcp(mysql.aegislab.svc.cluster.local:3306)/workbuddy?parseTime=true&loc=UTC&multiStatements=true
+#
+# Env contract: the pod receives WORKBUDDY_MYSQL_DSN. Coordinator-side
+# consumption is wired by the cmd/coordinator.go --db DSN-aware switch
+# (today the flag still accepts a plain SQLite path; switching the
+# coordinator to consume WORKBUDDY_MYSQL_DSN is tracked alongside this
+# change). README.md "Env contract" documents the precedence.
 mysql:
-  dsn: ""
+  dsn: ""                 # required (or set dsnSecretRef): full mysql:// DSN
+  dsnSecretRef:           # optional: read the DSN from an existing Secret
+    name: ""              #   Secret name. Empty disables the secretKeyRef path.
+    key: dsn              #   Secret key holding the DSN string.
 
-# OpenTelemetry collector endpoint. Workbuddy reuses AegisLab's collector
-# (decision doc Block 4). Empty disables exporter.
+# ----------------------------------------------------------------------
+# OpenTelemetry
+# ----------------------------------------------------------------------
+# Workbuddy honors the standard OTel SDK env vars (see
+# internal/tracing/tracing.go). The chart maps these values onto:
+#   - OTEL_EXPORTER_OTLP_ENDPOINT  (from otel.endpoint)
+#   - OTEL_EXPORTER_OTLP_PROTOCOL  (from otel.protocol)
+#   - OTEL_SERVICE_NAME            (from otel.serviceName)
+# When endpoint is empty, tracing.Init() returns a no-op exporter —
+# tracing is effectively disabled.
 otel:
-  endpoint: ""
+  endpoint: ""            # OTLP collector endpoint; empty = disabled
+  protocol: grpc          # grpc | http/protobuf (http is accepted as alias)
+  serviceName: workbuddy  # overrides OTEL_SERVICE_NAME default
 
-# Gitea (or GitHub) API token used by the coordinator for gh issue read /
-# comment writes. Two modes:
-#   - secretName != "": chart references an existing Secret with key "token".
-#   - secretName == "" && token != "": chart creates a Secret from .token.
+# ----------------------------------------------------------------------
+# Gitea / GitHub API token
+# ----------------------------------------------------------------------
+# Used by:
+#   - The Coordinator's GitHub poller (gh CLI, reads GH_TOKEN).
+#   - internal/labelwriter for AgentM-mode label writes against a Gitea
+#     REST API (reads GITEA_TOKEN).
+# The chart mounts a single Secret value into BOTH env vars so one
+# token covers Gitea repos and GitHub repos transparently.
+#
+# Modes:
+#   - secretName != "":  reference an existing Secret (recommended).
+#   - secretName == "" && token != "":  chart materializes a Secret for
+#                                       dev/quickstart only.
 giteaToken:
-  secretName: ""
-  token: ""
+  secretName: ""          # required for coordinator-managed mode
+  secretKey: token        # key inside the Secret holding the token string
+  token: ""               # plaintext token for dev only; ignored when secretName is set
 
-# Agent config ConfigMap (.github/workbuddy/agents/*.md). Mounted at
-# /etc/workbuddy/agents in the coordinator pod.
-#   - configMapName != "": chart references an existing ConfigMap.
-#   - configMapName == "": chart creates one from chart-bundled agents/*.md.
+# ----------------------------------------------------------------------
+# Agent definitions
+# ----------------------------------------------------------------------
+# .github/workbuddy/agents/*.md mounted at /etc/workbuddy/agents.
+#   - configMapName != "":  reference an existing ConfigMap.
+#   - configMapName == "":  chart renders one from deploy/helm/workbuddy/agents/*.md.
 agents:
   configMapName: ""
 

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -5478,3 +5478,70 @@ requirements:
       - internal/launcher/gitops_bridge_test.go
     deps:
       - REQ-134
+
+  - id: REQ-145
+    title: Helm chart values surface for MySQL DSN + OTel endpoint (v0.6)
+    description: >
+      Per docs/decisions/2026-05-13-k8s-agentm-otel.md Block 3
+      § Storage and Block 4 § Collector, the workbuddy chart consumes
+      external AegisLab MySQL and the AegisLab OTel collector via
+      values. Issue #334 hardens the values surface that REQ-143's
+      skeleton stubbed out so production deployments can wire real
+      Secret references and standard OTel SDK env vars without
+      editing the chart.
+
+      Scope:
+        - values.yaml: split mysql into mysql.dsn (plaintext, dev)
+          and mysql.dsnSecretRef.{name,key} (Secret keyRef, prod).
+          Split otel into otel.endpoint, otel.protocol, and
+          otel.serviceName so the standard OTel SDK env vars
+          (OTEL_EXPORTER_OTLP_ENDPOINT / OTEL_EXPORTER_OTLP_PROTOCOL /
+          OTEL_SERVICE_NAME) consumed by internal/tracing/tracing.go
+          can be set per release. Add giteaToken.secretKey so an
+          existing Secret with a non-"token" key still works.
+        - templates/deployment.yaml: switch to a conditional
+          WORKBUDDY_MYSQL_DSN env (Secret keyRef when dsnSecretRef.name
+          is set, plain value otherwise). Replace the
+          WORKBUDDY_OTEL_ENDPOINT / WORKBUDDY_GITEA_TOKEN placeholders
+          from the skeleton with the env vars the code actually
+          consumes: OTEL_EXPORTER_OTLP_ENDPOINT,
+          OTEL_EXPORTER_OTLP_PROTOCOL, OTEL_SERVICE_NAME (tracing.go),
+          and GH_TOKEN + GITEA_TOKEN both sourced from the same Secret
+          (gh CLI for the poller; internal/labelwriter for AgentM-mode
+          label writes).
+        - templates/secret.yaml: honor giteaToken.secretKey when
+          materializing the dev Secret so the keyRef in
+          deployment.yaml resolves.
+        - README.md: full values reference + "Env contract" table
+          listing each pod env var with the Go source that consumes
+          it, plus an "AegisLab topology" section with prerequisites
+          (Secrets/ConfigMaps created out-of-band, OTel collector DNS
+          name) and the canonical values-aegislab.yaml.
+
+      Out of scope (explicit non-goals per decision doc):
+        - Bundling MySQL or OTel collector as subcharts.
+        - agent-env values (workbuddy doesn't talk to agent-env;
+          AgentM handles its own Gateway client).
+        - Ingress (#333).
+        - Coordinator-side flag switch to consume WORKBUDDY_MYSQL_DSN
+          as the default --db source. The chart sets the env var
+          forward-compatibly; the flag switch is a separate slice.
+    priority: P1
+    version: v0.6.0
+    status: tested
+    acceptance_criteria:
+      - "AC-145-1: `helm template ... --set mysql.dsn=mysql://test/test --set otel.endpoint=http://otel:4317 --set giteaToken.secretName=gitea-token` renders cleanly."
+      - "AC-145-2: Coordinator pod env reflects all four values — WORKBUDDY_MYSQL_DSN, OTEL_EXPORTER_OTLP_ENDPOINT (+ protocol/serviceName), GH_TOKEN/GITEA_TOKEN from secretKeyRef, and the agents ConfigMap mount."
+      - "AC-145-3: README has an `AegisLab topology` section with the canonical values-aegislab.yaml, prerequisites, and the env contract table."
+      - "AC-145-4: `helm lint deploy/helm/workbuddy/` passes (only the optional icon INFO)."
+      - "AC-145-5: `mysql.dsnSecretRef.name` renders WORKBUDDY_MYSQL_DSN as a secretKeyRef; otherwise the plaintext mysql.dsn is rendered as the value."
+      - "AC-145-6: project-index.yaml has this REQ entry referencing issue #334 and the decision doc."
+    code:
+      - deploy/helm/workbuddy/values.yaml
+      - deploy/helm/workbuddy/README.md
+      - deploy/helm/workbuddy/templates/deployment.yaml
+      - deploy/helm/workbuddy/templates/secret.yaml
+    tests:
+      - deploy/helm/workbuddy/values.yaml
+    deps:
+      - REQ-143


### PR DESCRIPTION
Closes #334.

## Summary

Hardens the v0.6 Helm chart values surface laid down by REQ-143's skeleton so production deployments can wire AegisLab MySQL, AegisLab OTel collector, and the Gitea/GH token Secret via plain values references — no chart edits required.

- `values.yaml`: split `mysql` into `dsn` (plaintext, dev) and `dsnSecretRef.{name,key}` (Secret keyRef, prod). Split `otel` into `endpoint` / `protocol` / `serviceName` mapped onto the **standard OTel SDK env vars** consumed by `internal/tracing/tracing.go`. Add `giteaToken.secretKey` so existing Secrets with non-`token` keys still resolve.
- `templates/deployment.yaml`: `WORKBUDDY_MYSQL_DSN` as conditional secretKeyRef / plain value; replace the skeleton's placeholder names with the env vars the coordinator code actually consumes: `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_SERVICE_NAME` (`internal/tracing/tracing.go`) and `GH_TOKEN` + `GITEA_TOKEN` both sourced from the same Secret (`gh` CLI in the poller + `internal/labelwriter`).
- `templates/secret.yaml`: honor `giteaToken.secretKey` when materializing the dev-only Secret.
- `README.md`: full values reference, env-contract table mapping each pod env var to its consuming Go source, AegisLab topology section with the canonical `values-aegislab.yaml` and prerequisites.
- `project-index.yaml`: REQ-145 added (status `tested`, deps `REQ-143`).

## Env var contract (verified against source)

| Pod env var | Source code |
|-------------|-------------|
| `WORKBUDDY_MYSQL_DSN` | `internal/store/store.go::New` (DSN dispatch). Flag-level coordinator switch is a follow-up. |
| `OTEL_EXPORTER_OTLP_ENDPOINT` / `_PROTOCOL` / `OTEL_SERVICE_NAME` | `internal/tracing/tracing.go` |
| `GH_TOKEN` | `gh` CLI used by the poller / reporter |
| `GITEA_TOKEN` | `internal/labelwriter/labelwriter.go` |

The skeleton used `WORKBUDDY_OTEL_ENDPOINT` / `WORKBUDDY_GITEA_TOKEN` placeholders that no code actually reads; this PR corrects them.

## Acceptance criteria coverage

- **AC-1-1** `helm template ... --set mysql.dsn=mysql://test/test --set otel.endpoint=http://otel:4317 --set giteaToken.secretName=gitea-token` renders cleanly. ✅
- **AC-1-2** Coordinator pod env reflects all four values: `WORKBUDDY_MYSQL_DSN`, `OTEL_EXPORTER_OTLP_ENDPOINT` (+ protocol / serviceName), `GH_TOKEN` + `GITEA_TOKEN` via secretKeyRef, agents ConfigMap mount. ✅
- **AC-1-3** README has an `AegisLab topology` section with the canonical `values-aegislab.yaml`. ✅
- **AC-1-4** `helm lint deploy/helm/workbuddy/` passes (only the optional icon INFO). ✅
- **AC-1-5** `project-index.yaml` REQ-145 added and validates. ✅

## Test plan

- [x] `helm lint deploy/helm/workbuddy/`
- [x] `helm template my deploy/helm/workbuddy/ --set mysql.dsn=mysql://test/test --set otel.endpoint=http://otel:4317 --set giteaToken.secretName=gitea-token` — plaintext DSN path
- [x] `helm template my deploy/helm/workbuddy/ --set mysql.dsnSecretRef.name=aegislab-mysql-workbuddy --set otel.endpoint=http://otel-collector.aegislab.svc.cluster.local:4317 --set giteaToken.secretName=gitea-bot-token` — AegisLab topology
- [x] `helm template my deploy/helm/workbuddy/ --set giteaToken.token=ghp_xxx` — chart-managed dev Secret
- [x] `go build ./...` + `go vet ./...` (no Go changes; sanity)
- [x] `python3 ~/.autoharness/scripts/validate_index.py project-index.yaml`

## Out of scope (explicit non-goals)

- MySQL / OTel collector subcharts (per decision doc Block 3 / 4).
- agent-env values (AgentM handles its own Gateway client).
- Ingress (#333).
- Coordinator-side `--db` flag switch to consume `WORKBUDDY_MYSQL_DSN` as default. The chart sets the env var forward-compatibly; flipping the flag default is a separate slice so this PR stays chart-only.