### PR TITLE
v0.6: align AgentM env var with upstream AGENTM_AGENT_ENV_IMAGE

### DIFF
--- a/docs/planned/agentm-runtime.md
+++ b/docs/planned/agentm-runtime.md
@@ -87,7 +87,7 @@ inherits):
 | `WORKBUDDY_REPO` | yes | `owner/repo` form. |
 | `GH_TOKEN` | host-exec only | Same PAT codex/claude-code receive today. **In v0.6 sandbox mode this MUST NOT be injected.** |
 | `ANTHROPIC_API_KEY` / provider keys | provider-dependent | AgentM expects its provider extension to find these in env. |
-| `WORKBUDDY_DEV_CONTAINER_IMAGE` | optional, v0.6+ | Dev container image AgentM should run the task inside, sourced from the agent config field `dev_container_image` (issue #328 / REQ-140). Injected only when the agent's `runtime` is `agentm` and the field is non-empty. When unset, AgentM falls back to its own default image. workbuddy passes the image name through verbatim and does NOT talk to agent-env directly — sandbox dispatch is AgentM's job (see decision doc Block 2). Setting `dev_container_image` on other runtimes is a config warning, not an error. |
+| `AGENTM_AGENT_ENV_IMAGE` | optional, v0.6+ | Dev container image AgentM should run the task inside, sourced from the agent config field `dev_container_image` (issue #328 / REQ-140). Injected only when the agent's `runtime` is `agentm` and the field is non-empty. When unset, AgentM falls back to its own default image. workbuddy passes the image name through verbatim and does NOT talk to agent-env directly — sandbox dispatch is AgentM's job (see decision doc Block 2). Setting `dev_container_image` on other runtimes is a config warning, not an error. |
 
 ### stdin
 

--- a/internal/agent/agentm/agentmtest/fake.go
+++ b/internal/agent/agentm/agentmtest/fake.go
@@ -54,7 +54,7 @@ type Config struct {
 	// EnvDumpPath, when non-empty, makes the fake write its full process
 	// environment (one `KEY=VALUE` per line) to this absolute path before
 	// emitting RESULT:. Tests use it to assert workbuddy-injected env vars
-	// (TRACEPARENT, WORKBUDDY_DEV_CONTAINER_IMAGE, …) actually reach the
+	// (TRACEPARENT, AGENTM_AGENT_ENV_IMAGE, …) actually reach the
 	// AgentM subprocess.
 	EnvDumpPath string
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -362,13 +362,13 @@ func normalizeAgentConfig(agent *AgentConfig) ([]Warning, error) {
 	}
 
 	// dev_container_image is only meaningful for the agentm runtime, which
-	// forwards it to the AgentM subprocess as WORKBUDDY_DEV_CONTAINER_IMAGE
+	// forwards it to the AgentM subprocess as AGENTM_AGENT_ENV_IMAGE
 	// (see docs/planned/agentm-runtime.md). Setting it on claude-code /
 	// codex is a no-op today; warn (do not error) so configs that pre-stage
 	// the field for a planned runtime swap still validate.
 	if strings.TrimSpace(agent.DevContainerImage) != "" && agent.Runtime != RuntimeAgentM {
 		warnings = append(warnings, Warning{Message: fmt.Sprintf(
-			"agent %q: dev_container_image is set but runtime is %q; the field is only honored for runtime=%q (workbuddy passes WORKBUDDY_DEV_CONTAINER_IMAGE to AgentM only)",
+			"agent %q: dev_container_image is set but runtime is %q; the field is only honored for runtime=%q (workbuddy passes AGENTM_AGENT_ENV_IMAGE to AgentM only)",
 			agent.Name, agent.Runtime, RuntimeAgentM,
 		)})
 	}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -137,7 +137,7 @@ type AgentConfig struct {
 	// DevContainerImage names the dev container image AgentM should run
 	// inside when the runtime is `agentm`. workbuddy passes the value
 	// through to the AgentM subprocess as the env var
-	// WORKBUDDY_DEV_CONTAINER_IMAGE; AgentM is responsible for the actual
+	// AGENTM_AGENT_ENV_IMAGE; AgentM is responsible for the actual
 	// sandbox dispatch (workbuddy does not talk to agent-env directly).
 	// See docs/planned/agentm-runtime.md for the invocation contract and
 	// docs/decisions/2026-05-13-k8s-agentm-otel.md (Block 2) for design

--- a/internal/runtime/agent_bridge.go
+++ b/internal/runtime/agent_bridge.go
@@ -550,10 +550,10 @@ func injectTraceContext(ctx context.Context, env map[string]string, task *TaskCo
 // AgentM owns the actual agent-env Gateway call; workbuddy just forwards
 // the agent-config field. See docs/planned/agentm-runtime.md and
 // docs/decisions/2026-05-13-k8s-agentm-otel.md (Block 2).
-const EnvDevContainerImage = "WORKBUDDY_DEV_CONTAINER_IMAGE"
+const EnvDevContainerImage = "AGENTM_AGENT_ENV_IMAGE"
 
 // injectAgentMEnv adds AgentM-specific env vars derived from the agent
-// config. Today that's just dev_container_image → WORKBUDDY_DEV_CONTAINER_IMAGE,
+// config. Today that's just dev_container_image → AGENTM_AGENT_ENV_IMAGE,
 // injected only when runtime=agentm; other runtimes ignore the field
 // (and config validation already warned about it).
 func injectAgentMEnv(agentCfg *config.AgentConfig, env map[string]string) map[string]string {

--- a/internal/runtime/agentm_bridge_test.go
+++ b/internal/runtime/agentm_bridge_test.go
@@ -131,7 +131,7 @@ func TestAgentMBridge_TaskFailure(t *testing.T) {
 
 // TestAgentMBridge_DevContainerImageEnv covers REQ-140 / issue #328 AC-1-1:
 // when the agent config sets dev_container_image and runtime=agentm, the
-// AgentM subprocess MUST receive WORKBUDDY_DEV_CONTAINER_IMAGE in its env.
+// AgentM subprocess MUST receive AGENTM_AGENT_ENV_IMAGE in its env.
 // workbuddy passes the image name only — AgentM owns the actual sandbox
 // dispatch, so this is a pass-through assertion, not an end-to-end one.
 func TestAgentMBridge_DevContainerImageEnv(t *testing.T) {

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -5370,7 +5370,7 @@ requirements:
         field for a planned runtime swap without breaking validation.
 
       - internal/runtime/agent_bridge.go declares the env-var name
-        EnvDevContainerImage = "WORKBUDDY_DEV_CONTAINER_IMAGE" and
+        EnvDevContainerImage = "AGENTM_AGENT_ENV_IMAGE" and
         adds injectAgentMEnv(agentCfg, env) which only injects the
         var when runtime == agentm and dev_container_image is
         non-empty. The injection runs after injectTraceContext so
@@ -5395,7 +5395,7 @@ requirements:
     version: v0.6.0
     status: tested
     acceptance_criteria:
-      - "AC-140-1: Agent config with `dev_container_image: foo:bar` and `runtime: agentm` validates; the value reaches the AgentM subprocess env as WORKBUDDY_DEV_CONTAINER_IMAGE (asserted via env-dump fake)."
+      - "AC-140-1: Agent config with `dev_container_image: foo:bar` and `runtime: agentm` validates; the value reaches the AgentM subprocess env as AGENTM_AGENT_ENV_IMAGE (asserted via env-dump fake)."
       - "AC-140-2: Agent config with `dev_container_image` set on `runtime: claude-code` produces a config validation warning (not an error)."
       - "AC-140-3: When `dev_container_image` is unset for `runtime: agentm`, the env var is NOT injected (AgentM falls back to its own default image)."
       - "AC-140-4: docs/planned/agentm-runtime.md documents the env var."

--- a/schemas/agent.schema.json
+++ b/schemas/agent.schema.json
@@ -117,7 +117,7 @@
     "dev_container_image": {
       "type": "string",
       "minLength": 1,
-      "description": "Dev container image AgentM should run the task inside. Only meaningful for runtime=agentm; workbuddy injects it into the AgentM subprocess env as WORKBUDDY_DEV_CONTAINER_IMAGE (see docs/planned/agentm-runtime.md). Setting it on other runtimes produces a config warning, not an error. workbuddy does NOT talk to agent-env directly — image dispatch is AgentM's job."
+      "description": "Dev container image AgentM should run the task inside. Only meaningful for runtime=agentm; workbuddy injects it into the AgentM subprocess env as AGENTM_AGENT_ENV_IMAGE (see docs/planned/agentm-runtime.md). Setting it on other runtimes produces a config warning, not an error. workbuddy does NOT talk to agent-env directly — image dispatch is AgentM's job."
     }
   }
 }


### PR DESCRIPTION
## Summary
- Pure rename: `WORKBUDDY_DEV_CONTAINER_IMAGE` → `AGENTM_AGENT_ENV_IMAGE` everywhere.
- AGENTM_AGENT_ENV_IMAGE is the upstream contract (Lincyaw/AgentM PR #155). Workbuddy was emitting the wrong namespace, so the value never reached AgentM's managed-sandbox selection path.

## End-to-end chain (now wired)

workbuddy `dev_container_image` config → `AGENTM_AGENT_ENV_IMAGE` env → AgentM `operations_agent_env` atom → `arl.ManagedSession(image=...)` → agent-env auto-managed pool.

## Validation
- arl.ManagedSession(image=...) spawned a fresh pod on the live aidevops minikube cluster, ran `echo hello`, exit 0.
- AgentM PR #155 unit-tests cover the selection rule (image → ManagedSession, pool_ref → SandboxSession, both → managed wins).
- Workbuddy `go build && go vet && go test ./...` green.

## Test plan
- [x] go build ./...
- [x] go vet ./...
- [x] go test ./internal/runtime/... ./internal/config/... ./internal/agent/... -count=1
- [x] validate_index.py passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)