### PR TITLE
agentm: fix temp-dir leak, task.json perms, stale labelwriter doc (REQ-134, REQ-146)

### DIFF
--- a/internal/agent/agentm/backend.go
+++ b/internal/agent/agentm/backend.go
@@ -149,11 +149,18 @@ func (b *Backend) NewSession(ctx context.Context, spec agent.Spec) (agent.Sessio
 	// log event for transcript capture.
 	go func() {
 		defer close(events)
-		defer close(s.done)
-		// Intentionally do NOT remove tmpDir here: the session-log file is
-		// referenced by Result.SessionPath / session_log_path and consumed by
-		// the audit layer after Wait returns. Lifecycle cleanup is the
-		// caller's responsibility (worker session manager).
+		// tmpDir holds task.json/result.json/session.jsonl. These must
+		// outlive the process exit because Wait() / SessionLogPath() read
+		// the result and session log after the process returns. The bridge
+		// (internal/runtime/agent_bridge.go) copies session.jsonl into the
+		// durable worker session dir, then the worker calls Close() once the
+		// run is finalized — Close() removes tmpDir. If Close() raced ahead
+		// of process exit, the cleanup is deferred to here via removeTmpDir,
+		// which is a no-op until both done is closed and Close() ran.
+		defer func() {
+			close(s.done)
+			s.removeTmpDir()
+		}()
 
 		s.scanStdout(stdout)
 		stderrWG.Wait()
@@ -206,15 +213,22 @@ type session struct {
 	resultFile string
 	sessionLog string
 
-	mu             sync.Mutex
-	exitCode       int
-	duration       time.Duration
-	waitErr        error
-	finalMsg       string
-	sessionRef     agent.SessionRef
-	output         *Output
-	parseErr       error
-	resultLineRaw  string
+	mu            sync.Mutex
+	exitCode      int
+	duration      time.Duration
+	waitErr       error
+	finalMsg      string
+	sessionRef    agent.SessionRef
+	output        *Output
+	parseErr      error
+	resultLineRaw string
+
+	// closeRequested is set by Close(); tmpDirGone makes removal idempotent.
+	// Both are guarded by mu. tmpDir is removed only once both the process
+	// has exited (done closed) and Close() has been called, whichever order
+	// they happen in — see removeTmpDir.
+	closeRequested bool
+	tmpDirGone     bool
 }
 
 func (s *session) ID() string                 { return s.id }
@@ -272,7 +286,39 @@ func (s *session) Interrupt(ctx context.Context) error {
 	return nil
 }
 
-func (s *session) Close() error { return nil }
+// Close marks the session as finalized and removes the per-session temp dir
+// (task.json/result.json/session.jsonl). The worker calls this after audit
+// has persisted the run, so the durable session artifacts are already copied
+// out of tmpDir by the bridge. Close is safe to call multiple times and from
+// either the running or completed state: if the process is still running,
+// removal is deferred until the stdout-reader goroutine exits.
+func (s *session) Close() error {
+	s.mu.Lock()
+	s.closeRequested = true
+	s.mu.Unlock()
+	s.removeTmpDir()
+	return nil
+}
+
+// removeTmpDir deletes tmpDir exactly once, but only after both the process
+// has exited (s.done closed) and Close() has been requested. It is called
+// from both Close() and the stdout-reader goroutine's deferred cleanup so
+// that whichever happens last performs the removal — no leak regardless of
+// ordering.
+func (s *session) removeTmpDir() {
+	select {
+	case <-s.done:
+	default:
+		return // process still running; nothing to clean yet
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.tmpDirGone || !s.closeRequested || s.tmpDir == "" {
+		return
+	}
+	_ = os.RemoveAll(s.tmpDir)
+	s.tmpDirGone = true
+}
 
 // Output exposes the parsed structured output for callers that need to
 // route on next_label / failure_reason / artifact_path. Returns (nil, err)
@@ -368,12 +414,24 @@ type Output struct {
 	FailureReason  string `json:"failure_reason,omitempty"`
 }
 
+// emit is lossy by design: if the buffered events channel is full (a slow or
+// stalled consumer) the event is dropped rather than blocking the stdout/
+// stderr reader goroutines. Blocking here would risk deadlocking the reader
+// against a wedged consumer and prevent the process from being reaped.
+//
+// Routing is never affected by a drop: the canonical RESULT: line is captured
+// into s.resultLineRaw inside scanStdout BEFORE emit runs, and the
+// --result-file fallback is read from disk in resolveOutput. Only the
+// transcript rendering on the secondary events stream can lose a line. The
+// agentm-native session log (session.jsonl) is captured separately and copied
+// to the durable worker session dir by the bridge, so the full conversation
+// is preserved independent of this channel.
 func emit(ch chan<- agent.Event, evt agent.Event) {
 	defer func() { _ = recover() }()
 	select {
 	case ch <- evt:
 	default:
-		// Drop on slow consumer to avoid blocking the read goroutine.
+		// Drop on slow consumer — see doc comment above.
 	}
 }
 
@@ -405,7 +463,10 @@ func writeTaskFile(path string, spec agent.Spec) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0o644)
+	// 0o600: task.json carries the rendered prompt and lives in a shared
+	// temp location. The enclosing MkdirTemp dir is 0o700, but keep the file
+	// owner-only too so a permissive umask can't widen it.
+	return os.WriteFile(path, data, 0o600)
 }
 
 func fileExists(p string) bool {

--- a/internal/agent/agentm/backend_test.go
+++ b/internal/agent/agentm/backend_test.go
@@ -80,6 +80,53 @@ func TestBackend_HappyPath_Success(t *testing.T) {
 	}
 }
 
+func TestBackend_Close_RemovesTempDir(t *testing.T) {
+	fake := agentmtest.BuildFake(t, agentmtest.Config{Mode: agentmtest.ModeSuccess})
+	be := &agentm.Backend{Binary: fake}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	sess, err := be.NewSession(ctx, newSpec(t))
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	go func() {
+		for range sess.Events() {
+		}
+	}()
+	if _, err := sess.Wait(ctx); err != nil {
+		t.Fatalf("Wait returned error: %v", err)
+	}
+
+	extractor := sess.(interface {
+		SessionLogPath() string
+	})
+	logPath := extractor.SessionLogPath()
+	if logPath == "" {
+		t.Fatalf("expected session log path")
+	}
+	// The session log lives inside the per-session temp dir; capture its
+	// parent so we can assert removal after the full lifecycle.
+	tmpDir := filepath.Dir(logPath)
+	if _, err := os.Stat(tmpDir); err != nil {
+		t.Fatalf("temp dir missing before close: %v", err)
+	}
+
+	// The worker calls Close() after audit has persisted the run. This must
+	// remove the temp dir so successful dispatches don't leak /tmp.
+	if err := sess.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := os.Stat(tmpDir); !os.IsNotExist(err) {
+		t.Fatalf("temp dir %q still exists after Close (err=%v): agentm dispatch leaks /tmp", tmpDir, err)
+	}
+
+	// Close must be idempotent.
+	if err := sess.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}
+
 func TestBackend_MalformedJSON_IsInfraFailure(t *testing.T) {
 	fake := agentmtest.BuildFake(t, agentmtest.Config{Mode: agentmtest.ModeMalformedJSON})
 	be := &agentm.Backend{Binary: fake}

--- a/internal/labelwriter/labelwriter.go
+++ b/internal/labelwriter/labelwriter.go
@@ -9,9 +9,13 @@
 // coordinator owns the GH/Gitea write surface and must apply the label
 // transition the agent suggests in its structured Result.
 //
-// This package is intentionally dormant until the dispatch path wires it
-// (tracked in #332). It compiles and is unit-tested, but no production
-// code path imports ApplyNextLabel yet.
+// This package is wired into the production dispatch path (#332). The chain:
+// cmd/worker.go calls Launcher.SetAgentMLabelWriter with
+// launcher.NewAgentMLabelWriterAdapter(store), which wraps *Writer in a
+// runtime.AgentMLabelWriter; internal/runtime/agent_bridge.go's
+// AgentBridgeSession.Run invokes ApplyNextLabel after a successful AgentM run
+// AND a successful gitops publish. Self-managed runtimes (claude-code, codex)
+// never wire this adapter, so the Go-side label write stays AgentM-only.
 package labelwriter
 
 import (

--- a/internal/runtime/agent_bridge.go
+++ b/internal/runtime/agent_bridge.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -308,8 +310,19 @@ func (s *AgentBridgeSession) Run(ctx context.Context, events chan<- launchereven
 		Output() (*agentm.Output, error)
 		SessionLogPath() string
 	}); ok {
+		// The agentm session log lives inside the backend's per-session temp
+		// dir, which the backend removes on Close() (called by the worker
+		// after this run). Copy it into the durable worker session dir before
+		// that happens so the native conversation log survives for audit, and
+		// point SessionPath at the copy rather than the soon-to-be-deleted
+		// temp file. If there's no handle (e.g. the one-shot Launch path) or
+		// the copy fails, fall back to the temp path — correctness of the run
+		// does not depend on capturing the log.
 		if logPath := extractor.SessionLogPath(); logPath != "" {
 			sessionPath = logPath
+			if durable, err := copyAgentMSessionLog(s.Handle, logPath); err == nil && durable != "" {
+				sessionPath = durable
+			}
 		}
 		out, perr := extractor.Output()
 		switch {
@@ -593,6 +606,33 @@ func bridgeSessionPath(handle BridgeSessionHandle) string {
 		return ""
 	}
 	return handle.StdoutPath()
+}
+
+// copyAgentMSessionLog copies the agentm-native session log out of the
+// backend's per-session temp dir (which the backend deletes on Close) into
+// the durable worker session dir, alongside stdout. It returns the path to
+// the copy. An empty handle, an empty source path, or an unreadable source
+// yields ("", err) and the caller keeps the original path.
+func copyAgentMSessionLog(handle BridgeSessionHandle, srcPath string) (string, error) {
+	if handle == nil || srcPath == "" {
+		return "", nil
+	}
+	stdoutPath := handle.StdoutPath()
+	if stdoutPath == "" {
+		return "", nil
+	}
+	data, err := os.ReadFile(srcPath)
+	if err != nil {
+		return "", err
+	}
+	dst := filepath.Join(filepath.Dir(stdoutPath), "agentm-session.jsonl")
+	if dst == srcPath {
+		return dst, nil
+	}
+	if err := os.WriteFile(dst, data, 0o600); err != nil {
+		return "", err
+	}
+	return dst, nil
 }
 
 func TranslateAgentEventKind(kind string) launcherevents.EventKind {

--- a/internal/runtime/agentm_bridge_test.go
+++ b/internal/runtime/agentm_bridge_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Lincyaw/workbuddy/internal/agent/agentm"
 	"github.com/Lincyaw/workbuddy/internal/agent/agentm/agentmtest"
 	"github.com/Lincyaw/workbuddy/internal/config"
+	launcherevents "github.com/Lincyaw/workbuddy/internal/launcher/events"
 )
 
 // TestAgentMBridge_HappyPath wires an AgentMBackend (pointed at the fake
@@ -197,5 +198,89 @@ func TestAgentMBridge_DevContainerImageNotInjectedForOtherRuntimes(t *testing.T)
 	}, map[string]string{})
 	if _, ok := env2[EnvDevContainerImage]; ok {
 		t.Fatalf("empty dev_container_image must not be injected, got %v", env2)
+	}
+}
+
+// TestAgentMBridge_SessionLogDurableAndNoLeak covers the resource-leak fix:
+// when a session handle is wired (the production worker path), the bridge
+// copies the agentm-native session log into the durable worker session dir
+// and points SessionPath at the copy, and the backend's per-session temp dir
+// is removed on Close() so successful dispatches don't leak /tmp.
+func TestAgentMBridge_SessionLogDurableAndNoLeak(t *testing.T) {
+	fake := agentmtest.BuildFake(t, agentmtest.Config{Mode: agentmtest.ModeSuccess})
+	rt := NewAgentBridgeRuntime(config.RuntimeAgentM, func() (agent.Backend, error) {
+		return &agentm.Backend{Binary: fake}, nil
+	})
+
+	work := t.TempDir()
+	sessionsDir := filepath.Join(t.TempDir(), "sessions")
+	mgr := NewSessionManager(sessionsDir, nil)
+	handle, err := mgr.Create(SessionCreateInput{SessionID: "test-session", Repo: "Lincyaw/workbuddy", IssueNum: 319})
+	if err != nil {
+		t.Fatalf("create managed session: %v", err)
+	}
+
+	task := &TaskContext{
+		Repo:     "Lincyaw/workbuddy",
+		WorkDir:  work,
+		RepoRoot: work,
+		Issue:    IssueContext{Number: 319, Title: "test"},
+		Session:  SessionContext{ID: "test-session", TaskID: "task-1", Attempt: 1},
+	}
+	task.SetSessionHandle(handle)
+	agentCfg := &config.AgentConfig{Name: "dev-agent", Runtime: config.RuntimeAgentM, Role: "dev", Prompt: "ship it"}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	sess, err := rt.Start(ctx, agentCfg, task)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Reach into the backend session to capture the temp dir before Close.
+	bridgeSess, ok := sess.(*AgentBridgeSession)
+	if !ok {
+		t.Fatalf("expected *AgentBridgeSession, got %T", sess)
+	}
+	logExtractor := bridgeSess.Session.(interface{ SessionLogPath() string })
+
+	ch := make(chan launcherevents.Event, 32)
+	drained := make(chan struct{})
+	go func() {
+		for range ch {
+		}
+		close(drained)
+	}()
+	res, runErr := sess.Run(ctx, ch)
+	close(ch)
+	<-drained
+	if runErr != nil {
+		t.Fatalf("Run: %v", runErr)
+	}
+
+	tmpDir := filepath.Dir(logExtractor.SessionLogPath())
+
+	// SessionPath must point at the durable copy in the session dir, not the
+	// backend temp dir that Close() will delete.
+	if res.SessionPath == "" {
+		t.Fatalf("expected SessionPath populated")
+	}
+	if got := filepath.Dir(res.SessionPath); got != handle.Dir() {
+		t.Fatalf("SessionPath %q not in durable session dir %q", res.SessionPath, handle.Dir())
+	}
+	if _, err := os.Stat(res.SessionPath); err != nil {
+		t.Fatalf("durable session log missing: %v", err)
+	}
+
+	if err := sess.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// The durable copy survives Close; the backend temp dir does not.
+	if _, err := os.Stat(res.SessionPath); err != nil {
+		t.Fatalf("durable session log removed by Close: %v", err)
+	}
+	if _, err := os.Stat(tmpDir); !os.IsNotExist(err) {
+		t.Fatalf("backend temp dir %q still exists after Close (err=%v): agentm leaks /tmp", tmpDir, err)
 	}
 }


### PR DESCRIPTION
Fixes from code review of the agentm coordinator-managed runtime integration.

- **Temp-dir leak (#1)**: agentm backend's `MkdirTemp` dir was never removed after a successful run (only on early-error paths). The bridge now copies the native session log into the durable worker session dir and `Close()` removes tmpDir.
- **Stale doc (#2)**: labelwriter package doc claimed it was dormant/unwired — it is wired in production (cmd/worker.go → adapter → bridge). Rewritten.
- **File perms (#3)**: task.json now written 0600 (was 0644) since it carries the rendered prompt.
- Skipped lossy-emit (#4): would risk the pump-goroutine deadlock worker/session was hardened against; documented instead.

Tests added: `TestBackend_Close_RemovesTempDir`, `TestAgentMBridge_SessionLogDurableAndNoLeak`. Gates green (build/vet/test/lint/validate-docs/index).

🤖 Generated with [Claude Code](https://claude.com/claude-code)