### PR TITLE
deploy: k8s serve+agentm single-pod chart + combined image (REQ-162)

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -43,6 +43,7 @@ type serveOpts struct {
 	cookieInsecure    bool
 	reportBaseURL     string
 	hooksConfig       string
+	runtime           string
 }
 
 var serveCmd = &cobra.Command{
@@ -62,6 +63,7 @@ func init() {
 	serveCmd.Flags().Duration("poll-interval", defaultPollInterval, "GitHub poll interval")
 	serveCmd.Flags().Int("max-parallel-tasks", 0, fmt.Sprintf("Worker task concurrency override (0 = worker default, min(NumCPU, %d))", defaultMaxParallelTasks))
 	serveCmd.Flags().StringSlice("roles", []string{"dev", "test", "review"}, "Worker roles")
+	serveCmd.Flags().String("runtime", config.RuntimeClaudeCode, "Embedded worker runtime capability: claude-code, codex, or agentm")
 	serveCmd.Flags().String("config-dir", ".github/workbuddy", "Configuration directory")
 	serveCmd.Flags().String("db-path", ".workbuddy/workbuddy.db", "SQLite database path shared by coordinator and worker")
 	serveCmd.Flags().Bool("loopback-only", false, "Allow auth-free task endpoints only when the listen address is loopback-only")
@@ -89,6 +91,7 @@ func parseServeFlags(cmd *cobra.Command) (*serveOpts, error) {
 	pollInterval, _ := cmd.Flags().GetDuration("poll-interval")
 	maxParallelTasks, _ := cmd.Flags().GetInt("max-parallel-tasks")
 	roles, _ := cmd.Flags().GetStringSlice("roles")
+	runtimeName, _ := cmd.Flags().GetString("runtime")
 	configDir, _ := cmd.Flags().GetString("config-dir")
 	dbPath, _ := cmd.Flags().GetString("db-path")
 	authEnabled, _ := cmd.Flags().GetBool("auth")
@@ -107,6 +110,7 @@ func parseServeFlags(cmd *cobra.Command) (*serveOpts, error) {
 		pollInterval:      pollInterval,
 		maxParallelTasks:  maxParallelTasks,
 		roles:             roles,
+		runtime:           strings.TrimSpace(runtimeName),
 		configDir:         configDir,
 		dbPath:            dbPath,
 		auth:              authEnabled,
@@ -194,6 +198,7 @@ func runServeWithOutput(opts *serveOpts, ghReader poller.GHReader, launcherOverr
 			reportBaseURL:     resolvedReportBaseURL,
 			mgmtAuthToken:     strings.TrimSpace(os.Getenv("WORKBUDDY_AUTH_TOKEN")),
 			roleCSV:           strings.Join(opts.roles, ","),
+			runtime:           opts.runtime,
 			configDir:         opts.configDir,
 			workDir:           repoRoot,
 			sessionsDir:       deriveServeSessionsDir(opts.dbPath, repoRoot),

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/Lincyaw/workbuddy/internal/app"
+	"github.com/Lincyaw/workbuddy/internal/config"
 	"github.com/Lincyaw/workbuddy/internal/eventlog"
 	"github.com/Lincyaw/workbuddy/internal/poller"
 	"github.com/Lincyaw/workbuddy/internal/store"
@@ -158,6 +159,7 @@ func newServeFlagCommand(t *testing.T, configDir string) *cobra.Command {
 	cmd.Flags().Duration("poll-interval", defaultPollInterval, "")
 	cmd.Flags().Int("max-parallel-tasks", 0, "")
 	cmd.Flags().StringSlice("roles", []string{"dev"}, "")
+	cmd.Flags().String("runtime", config.RuntimeClaudeCode, "")
 	cmd.Flags().String("config-dir", configDir, "")
 	cmd.Flags().String("db-path", ".workbuddy/workbuddy.db", "")
 	cmd.Flags().Bool("loopback-only", false, "")
@@ -165,6 +167,37 @@ func newServeFlagCommand(t *testing.T, configDir string) *cobra.Command {
 	cmd.Flags().String("trusted-authors", "", "")
 	cmd.Flags().String("report-base-url", "", "")
 	return cmd
+}
+
+func TestParseServeFlagsRuntime(t *testing.T) {
+	configDir := setupTestConfigDir(t, "owner/repo")
+
+	// Default: claude-code, matching the standalone worker default so the
+	// embedded worker advertises the same capability.
+	cmd := newServeFlagCommand(t, configDir)
+	opts, err := parseServeFlags(cmd)
+	if err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	if opts.runtime != config.RuntimeClaudeCode {
+		t.Fatalf("default runtime = %q, want %q", opts.runtime, config.RuntimeClaudeCode)
+	}
+
+	// agentm flows through so the single-process serve pod can claim and
+	// execute coordinator-managed agentm tasks (otherwise ClaimNextTask's
+	// runtime filter starves them).
+	cmd = newServeFlagCommand(t, configDir)
+	_ = cmd.Flags().Set("runtime", config.RuntimeAgentM)
+	opts, err = parseServeFlags(cmd)
+	if err != nil {
+		t.Fatalf("parse flags (agentm): %v", err)
+	}
+	if opts.runtime != config.RuntimeAgentM {
+		t.Fatalf("runtime = %q, want %q", opts.runtime, config.RuntimeAgentM)
+	}
+	if _, _, err := normalizeWorkerRuntime(opts.runtime); err != nil {
+		t.Fatalf("normalizeWorkerRuntime(%q): %v", opts.runtime, err)
+	}
 }
 
 func TestParseServeFlagsRejectsNonLoopbackListenWithoutAuth(t *testing.T) {

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,0 +1,106 @@
+# syntax=docker/dockerfile:1
+#
+# Combined workbuddy + AgentM runtime image for the Kubernetes topology
+# (docs/decisions/2026-05-13-k8s-agentm-otel.md). Unlike hack/e2e/* (which
+# bakes a *fake* agentm), this image bundles the REAL AgentM CLI so the pod
+# can run `workbuddy serve --runtime agentm`:
+#
+#   - workbuddy (Go binary)            — coordinator + embedded worker.
+#   - agentm (Python CLI, on PATH)     — invoked as a subprocess by the
+#                                        worker's AgentM backend.
+#   - AgentM contrib tree at a stable  — the `agent_env_repo` scenario the
+#     path (/opt/agentm/contrib)         agent configs reference; drives the
+#                                        agent-env sandbox + cwd<->pod sync.
+#   - gh + git                         — the coordinator-managed gitops +
+#                                        labelwriter publish path.
+#
+# The agentm subprocess talks to the in-cluster agent-env Gateway over HTTP
+# (AGENTM_AGENT_ENV_GATEWAY_URL); workbuddy Go never calls the Gateway. No
+# GitHub credentials ever enter the sandbox pod — they live only in this
+# process (GH_TOKEN), per the credential boundary.
+
+ARG GO_VERSION=1.26
+ARG PYTHON_VERSION=3.12
+
+# --------------------------------------------------------------------------
+# Stage 1 — build the workbuddy Go binary.
+# --------------------------------------------------------------------------
+FROM golang:${GO_VERSION}-bookworm AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go mod download
+COPY . .
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=linux go build -trimpath -o /out/workbuddy ./
+
+# --------------------------------------------------------------------------
+# Stage 2 — runtime: Python base + real AgentM + gh + git + workbuddy.
+# --------------------------------------------------------------------------
+FROM python:${PYTHON_VERSION}-slim-bookworm AS runtime
+
+# AgentM source to bundle. Defaults to the public mirror @ main; pin
+# AGENTM_REF to a commit/tag for reproducible builds.
+ARG AGENTM_REPO=https://github.com/Lincyaw/AgentM.git
+ARG AGENTM_REF=main
+
+# Host tools: git + gh for the gitops/labelwriter publish path; curl/gnupg
+# only to add the gh apt repo; ca-certificates for outbound HTTPS.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl gnupg git \
+    && mkdir -p -m 755 /etc/apt/keyrings \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+         | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+         > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends gh \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# uv: AgentM builds with the uv_build backend and is uv-native, so we use
+# uv to materialize a self-contained venv with the agent-env extra.
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# Clone AgentM at the requested ref and install it EDITABLE (+ agent-env
+# extra = arl-env, the ARL Gateway SDK) into a dedicated venv. Editable is
+# load-bearing, not a shortcut: AgentM's contrib atoms + scenarios are
+# discovered by walking up from agentm.__file__ to a sibling contrib/ dir
+# (src/agentm/extensions/discover.py, loader.py). A non-editable wheel
+# install drops contrib/ entirely, so `operations_agent_env` / the
+# `agent_env_repo` scenario would be invisible. Editable keeps
+# agentm.__file__ at /opt/agentm/src/agentm so /opt/agentm/contrib resolves.
+#
+# This is the ONLY reason the AgentM source is vendored. Once `agentm` is
+# published to PyPI (shipping contrib/ as package data), this collapses to
+# `uv pip install "agentm[agent-env]"` with no clone — tracked upstream.
+ENV AGENTM_HOME=/opt/agentm
+ENV VIRTUAL_ENV=${AGENTM_HOME}/venv
+RUN git clone --depth 1 --branch "${AGENTM_REF}" "${AGENTM_REPO}" "${AGENTM_HOME}" \
+      || git clone "${AGENTM_REPO}" "${AGENTM_HOME}" \
+    && ( cd "${AGENTM_HOME}" && git checkout "${AGENTM_REF}" || true ) \
+    && uv venv "${VIRTUAL_ENV}" \
+    && uv pip install --python "${VIRTUAL_ENV}/bin/python" -e "${AGENTM_HOME}[agent-env]" \
+    && "${VIRTUAL_ENV}/bin/agentm" --help >/dev/null
+
+# Put the agentm console script on PATH for the worker subprocess lookup
+# (internal/agent/agentm/backend.go DefaultBinary = "agentm").
+ENV PATH=${VIRTUAL_ENV}/bin:${PATH}
+
+# Canonical scenario-resolution anchor (loader.py _candidate_roots root #1).
+# Lets the agent configs reference the scenario BY NAME (scenario:
+# agent_env_repo) instead of hardcoding an absolute path — and keeps name
+# resolution working even from an unrelated cwd (the per-repo worktree).
+ENV AGENTM_PROJECT_ROOT=${AGENTM_HOME}
+
+COPY --from=build /out/workbuddy /usr/local/bin/workbuddy
+
+# Working directory holds the per-repo clones + the SQLite DB under
+# .workbuddy/. The chart mounts a volume here.
+WORKDIR /var/lib/workbuddy
+
+ENTRYPOINT ["/usr/local/bin/workbuddy"]
+CMD ["serve"]

--- a/deploy/helm/workbuddy/Chart.yaml
+++ b/deploy/helm/workbuddy/Chart.yaml
@@ -1,14 +1,15 @@
 apiVersion: v2
 name: workbuddy
 description: |
-  Workbuddy coordinator — GitHub Issue-driven agent orchestration platform.
-  This chart deploys the coordinator process for the K8s topology (single-replica,
-  MySQL-backed, OTel-instrumented). Agent execution (claude-code, codex, agentm)
-  and ingress are configured separately; see the decision doc
-  docs/decisions/2026-05-13-k8s-agentm-otel.md for the full v0.6 design.
+  Workbuddy — GitHub Issue-driven agent orchestration platform. Default
+  mode=serve deploys a single self-contained pod (coordinator + embedded
+  worker) that runs runtime:agentm against a separate agent-env Gateway,
+  using the combined workbuddy+agentm image (deploy/docker/Dockerfile).
+  mode=coordinator keeps the legacy split topology. Single-replica,
+  OTel-instrumented; see docs/decisions/2026-05-13-k8s-agentm-otel.md.
 type: application
-version: 0.6.0
-appVersion: "v0.6.0"
+version: 0.7.0
+appVersion: "v0.7.0"
 keywords:
   - workbuddy
   - github

--- a/deploy/helm/workbuddy/README.md
+++ b/deploy/helm/workbuddy/README.md
@@ -1,31 +1,62 @@
 # workbuddy Helm chart
 
-Helm chart for deploying the workbuddy coordinator into a Kubernetes
-cluster. Single-replica, MySQL-backed, OTel-instrumented — the K8s
-topology described in `docs/decisions/2026-05-13-k8s-agentm-otel.md`
-Block 3 (Storage) and Block 4 (Collector).
+Helm chart for deploying workbuddy into a Kubernetes cluster, in the K8s
+topology described in `docs/decisions/2026-05-13-k8s-agentm-otel.md`.
 
-The chart is intentionally **service-reusing, not service-bundling**:
-MySQL and the OTel collector are reused from a co-located AegisLab
-release via plain values references. There is no MySQL subchart and no
-OTel-collector subchart — by design, per the decision doc.
+Two modes (`.Values.mode`):
 
-## Quickstart
+- **`serve`** (default) — one pod = coordinator + embedded worker. This is
+  the only mode that runs `runtime: agentm`: the agentm subprocess exec and
+  the coordinator-managed publish (commit + push + PR + label) both live in
+  the worker's runtime layer, so a bare coordinator cannot do agentm work.
+  Requires the **combined workbuddy+agentm image** (`deploy/docker/Dockerfile`),
+  which bundles the `agentm` CLI, gh, git, and the `agent_env_repo` scenario.
+- **`coordinator`** — poller + state machine only (legacy split topology;
+  pair with a standalone `workbuddy worker`). Cannot execute agentm.
+
+The chart is **service-reusing, not service-bundling**: MySQL, the OTel
+collector, and the **agent-env Gateway** are each a separate release reached
+by URL. No subcharts.
+
+## Build the image
+
+```bash
+docker build -f deploy/docker/Dockerfile \
+  --build-arg AGENTM_REF=main \
+  -t ghcr.io/lincyaw/workbuddy-agentm:dev .
+# kind: kind load docker-image ghcr.io/lincyaw/workbuddy-agentm:dev --name <cluster>
+```
+
+## Quickstart (serve + agentm)
+
+```bash
+helm install wb deploy/helm/workbuddy \
+  --set image.repository=ghcr.io/lincyaw/workbuddy-agentm --set image.tag=dev \
+  --set config.repo=OWNER/NAME \
+  --set agentEnv.gatewayUrl=http://arl-operator-gateway.arl.svc:8080 \
+  --set agentEnv.image=otel-demo-dev:latest \
+  --set giteaToken.token=ghp_xxx \
+  --set auth.token=$(openssl rand -hex 16) \
+  --set providerKeys.secretName=workbuddy-provider-keys
+```
+
+`providerKeys.secretName` is an existing Secret whose keys (e.g.
+`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `CRS_OAI_KEY`) are injected as env for
+the agentm subprocess. `agentEnv.gatewayUrl` points at a **separately
+deployed** agent-env release. The init container clones `config.repo` into
+the workspace PVC; the embedded worker `git worktree add`s from there.
+
+Credential boundary: the pod holds the GitHub token and pushes; the agentm
+subprocess shuttles diffs to/from the sandbox pod, which never sees a token.
+
+### Legacy coordinator-only mode
 
 ```bash
 helm install my-workbuddy deploy/helm/workbuddy \
+  --set mode=coordinator \
   --set mysql.dsnSecretRef.name=workbuddy-mysql \
   --set otel.endpoint=http://otel-collector.aegislab.svc.cluster.local:4317 \
   --set giteaToken.secretName=workbuddy-gitea
-```
-
-Or, for dev/CI where Secrets are inconvenient:
-
-```bash
-helm install my-workbuddy deploy/helm/workbuddy \
-  --set mysql.dsn='mysql://wb:wb@tcp(mysql:3306)/workbuddy?parseTime=true' \
-  --set otel.endpoint=http://otel:4317 \
-  --set giteaToken.token=ghp_xxx
 ```
 
 ## Values

--- a/deploy/helm/workbuddy/templates/_helpers.tpl
+++ b/deploy/helm/workbuddy/templates/_helpers.tpl
@@ -78,3 +78,37 @@ Name of the agent-configs ConfigMap to mount. Same pattern as Gitea Secret.
 {{- printf "%s-agents" (include "workbuddy.fullname" .) -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Name of the coordinator-config ConfigMap (config.yaml + workflows/default.md).
+*/}}
+{{- define "workbuddy.configConfigMapName" -}}
+{{- printf "%s-config" (include "workbuddy.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Name of the auth-token Secret. Existing one if supplied, else chart-managed.
+*/}}
+{{- define "workbuddy.authSecretName" -}}
+{{- if .Values.auth.secretName -}}
+{{- .Values.auth.secretName -}}
+{{- else -}}
+{{- printf "%s-auth" (include "workbuddy.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+In-container config directory passed to `serve --config-dir`.
+*/}}
+{{- define "workbuddy.configDir" -}}/etc/workbuddy{{- end -}}
+
+{{/*
+Resolved report base URL: explicit value, else the in-cluster Service DNS.
+*/}}
+{{- define "workbuddy.reportBaseURL" -}}
+{{- if .Values.reportBaseURL -}}
+{{- .Values.reportBaseURL -}}
+{{- else -}}
+{{- printf "http://%s.%s.svc:%v" (include "workbuddy.fullname" .) .Release.Namespace .Values.service.port -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/workbuddy/templates/config-configmap.yaml
+++ b/deploy/helm/workbuddy/templates/config-configmap.yaml
@@ -1,0 +1,67 @@
+{{- /*
+Coordinator config-dir contents: config.yaml (repo + poll settings) and the
+workflow Markdown. Mounted via subPath into {{ include "workbuddy.configDir" . }}
+so it composes with the agents ConfigMap at <config-dir>/agents.
+*/ -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "workbuddy.configConfigMapName" . }}
+  labels:
+    {{- include "workbuddy.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    environment: {{ .Values.config.environment | default "dev" }}
+    repo: {{ required "config.repo is required (OWNER/NAME)" .Values.config.repo | quote }}
+    poll_interval: {{ .Values.config.pollInterval | default "15s" }}
+    port: {{ .Values.service.port }}
+    notifications:
+      enabled: false
+  workflow-default.md: |
+{{- if .Values.workflow.inline }}
+{{ .Values.workflow.inline | indent 4 }}
+{{- else }}
+    ---
+    name: default
+    description: Default 2-agent lifecycle for any workbuddy-tracked issue
+    trigger:
+      issue_label: "workbuddy"
+    max_retries: 3
+    max_review_cycles: 3
+    ---
+
+    ## Default Workflow
+
+    Two-agent state machine applied to every issue labeled `workbuddy`.
+    Humans author issues with a `## Acceptance Criteria` section; in
+    coordinator-managed (agentm) mode workbuddy flips labels using the
+    structured `next_label` the agent returns.
+
+    ```yaml
+    states:
+      developing:
+        enter_label: "status:developing"
+        agent: dev-agent
+        transitions:
+          "status:reviewing": reviewing
+          "status:blocked": blocked
+
+      reviewing:
+        enter_label: "status:reviewing"
+        agent: review-agent
+        transitions:
+          "status:done": done
+          "status:developing": developing
+
+      blocked:
+        enter_label: "status:blocked"
+        transitions:
+          "status:developing": developing
+
+      done:
+        enter_label: "status:done"
+
+      failed:
+        enter_label: "status:failed"
+    ```
+{{- end }}

--- a/deploy/helm/workbuddy/templates/configmap.yaml
+++ b/deploy/helm/workbuddy/templates/configmap.yaml
@@ -1,10 +1,14 @@
 {{- /*
-Render an agent-configs ConfigMap only when the user has not pointed at an
-existing one via .Values.agents.configMapName. The chart bundles default
-agent definitions in deploy/helm/workbuddy/agents/*.md; .Files.Glob picks
-them up at render time. If no defaults are bundled the ConfigMap is created
-empty — production deployments should override `agents.configMapName` with
-their organization's ConfigMap (see README, #334 for the full surface).
+Agent-configs ConfigMap (mounted at <config-dir>/agents). Rendered only when
+the user has not pointed at an existing one via .Values.agents.configMapName.
+
+The chart ships templated defaults for the two-role catalog (dev + review),
+both runtime: agentm in coordinator-managed mode. They are rendered (not read
+from .Files) so the sandbox image (.Values.agentEnv.image) and the in-image
+scenario path (.Values.agents.scenarioPath) are injected from values and stay
+consistent with deploy/docker/Dockerfile. The doubled braces escape the agent
+template placeholders (e.g. {{ "{{" }}.Issue.Number{{ "}}" }}) so Helm emits
+them verbatim for workbuddy's own template engine.
 */ -}}
 {{- if not .Values.agents.configMapName }}
 apiVersion: v1
@@ -13,11 +17,85 @@ metadata:
   name: {{ include "workbuddy.agentsConfigMapName" . }}
   labels:
     {{- include "workbuddy.labels" . | nindent 4 }}
-{{- $files := .Files.Glob "agents/*.md" }}
-{{- if $files }}
 data:
-{{ ($files).AsConfig | indent 2 }}
-{{- else }}
-data: {}
-{{- end }}
+  dev-agent.md: |
+    ---
+    name: dev-agent
+    description: AgentM dev agent (agent-env sandbox, repo-synced)
+    triggers:
+      - state: developing
+    role: dev
+    runtime: agentm
+    scenario: {{ .Values.agents.scenarioName }}
+    {{- if .Values.agentEnv.image }}
+    dev_container_image: {{ .Values.agentEnv.image }}
+    {{- end }}
+    policy:
+      sandbox: danger-full-access
+      approval: never
+      timeout: {{ .Values.agents.devTimeout | default "15m" }}
+    context:
+      - Repo
+      - Issue.Number
+      - Issue.Title
+      - Issue.Body
+    ---
+
+    You are the dev agent for issue #{{ "{{" }}.Issue.Number{{ "}}" }} in {{ "{{" }}.Repo{{ "}}" }}.
+
+    Title: {{ "{{" }}.Issue.Title{{ "}}" }}
+
+    Body:
+    {{ "{{" }}.Issue.Body{{ "}}" }}
+
+    The repository is checked out in your sandbox working directory
+    (/workspace). Use the file and bash tools to make the code changes the
+    acceptance criteria require. Make the actual file changes in /workspace —
+    they are collected into a pull request automatically.
+
+    When finished, your FINAL line of output MUST be a single line of JSON
+    prefixed with `RESULT:` exactly in this form (no other text after it):
+
+    RESULT: {"success": true, "next_label": "status:reviewing", "failure_reason": ""}
+
+    Set "success" to true only if you made the required changes.
+  review-agent.md: |
+    ---
+    name: review-agent
+    description: AgentM review agent (agent-env sandbox, repo-synced)
+    triggers:
+      - state: reviewing
+    role: review
+    runtime: agentm
+    scenario: {{ .Values.agents.scenarioName }}
+    {{- if .Values.agentEnv.image }}
+    dev_container_image: {{ .Values.agentEnv.image }}
+    {{- end }}
+    policy:
+      sandbox: danger-full-access
+      approval: never
+      timeout: {{ .Values.agents.reviewTimeout | default "10m" }}
+    context:
+      - Repo
+      - Issue.Number
+      - Issue.Title
+      - Issue.Body
+    ---
+
+    You are the review agent for issue #{{ "{{" }}.Issue.Number{{ "}}" }} in {{ "{{" }}.Repo{{ "}}" }}.
+
+    Title: {{ "{{" }}.Issue.Title{{ "}}" }}
+
+    The dev agent's changes are checked out in your sandbox working directory
+    (/workspace). Verify the acceptance criteria are satisfied — read the
+    changed files and, where the criteria call for it, run the relevant
+    commands with the bash tool.
+
+    When finished, your FINAL line of output MUST be a single line of JSON
+    prefixed with `RESULT:` exactly in this form (no other text after it):
+
+    RESULT: {"success": true, "next_label": "status:done", "failure_reason": ""}
+
+    Set "next_label" to "status:done" when the criteria pass, or
+    "status:developing" to send it back to the dev agent with a reason.
 {{- end }}

--- a/deploy/helm/workbuddy/templates/deployment.yaml
+++ b/deploy/helm/workbuddy/templates/deployment.yaml
@@ -1,3 +1,6 @@
+{{- $isServe := eq (.Values.mode | default "serve") "serve" -}}
+{{- $cfgDir := include "workbuddy.configDir" . -}}
+{{- $mount := .Values.persistence.mountPath | default "/var/lib/workbuddy" -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -5,8 +8,9 @@ metadata:
   labels:
     {{- include "workbuddy.labels" . | nindent 4 }}
 spec:
-  # Single-replica + Recreate per decision doc Block 3 § Storage.
-  # Horizontal scale-out requires leader election and is deferred.
+  # Single-replica + Recreate per decision doc Block 3 § Storage. The
+  # workspace PVC is RWO and the SQLite DB is single-writer; horizontal
+  # scale-out would require leader election and is deferred.
   replicas: 1
   strategy:
     type: Recreate
@@ -17,10 +21,13 @@ spec:
     metadata:
       labels:
         {{- include "workbuddy.selectorLabels" . | nindent 8 }}
-      {{- with .Values.podAnnotations }}
       annotations:
+        # Roll the pod when config/agents change (subPath mounts don't auto-update).
+        checksum/config: {{ include (print $.Template.BasePath "/config-configmap.yaml") . | sha256sum }}
+        checksum/agents: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -30,53 +37,79 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if $isServe }}
+      initContainers:
+        # Clone the target repo into the workspace volume so the embedded
+        # worker can `git worktree add` (workbuddy does NOT auto-clone). The
+        # token is written into the clone's origin URL — the worker is the
+        # credentialed side of the boundary; no token ever enters a sandbox.
+        - name: clone-repo
+          image: {{ include "workbuddy.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bin/bash", "-ec"]
+          args:
+            - |
+              REPO={{ required "config.repo is required (OWNER/NAME)" .Values.config.repo | quote }}
+              DEST="{{ $mount }}/repo"
+              STATE="{{ $mount }}/state"
+              URL="https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
+              mkdir -p "$DEST" "$STATE"
+              git config --global --add safe.directory '*'
+              if [ -d "$DEST/.git" ]; then
+                echo "[clone-repo] existing clone -> fetch + reset"
+                git -C "$DEST" remote set-url origin "$URL"
+                git -C "$DEST" fetch --prune origin
+                BR="{{ .Values.config.branch }}"
+                [ -z "$BR" ] && BR="$(git -C "$DEST" remote show origin | sed -n 's/.*HEAD branch: //p')"
+                git -C "$DEST" checkout "$BR"
+                git -C "$DEST" reset --hard "origin/$BR"
+              else
+                echo "[clone-repo] fresh clone of $REPO"
+                git clone "$URL" "$DEST"
+                {{- if .Values.config.branch }}
+                git -C "$DEST" checkout {{ .Values.config.branch | quote }}
+                {{- end }}
+              fi
+          env:
+            - name: GH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "workbuddy.giteaSecretName" . | quote }}
+                  key: {{ .Values.giteaToken.secretKey | default "token" | quote }}
+          volumeMounts:
+            - name: workspace
+              mountPath: {{ $mount }}
+      {{- end }}
       containers:
-        - name: coordinator
+        - name: workbuddy
           image: {{ include "workbuddy.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if $isServe }}
+          workingDir: {{ $mount }}/repo
+          args:
+            - serve
+            - --config-dir={{ $cfgDir }}
+            - --runtime={{ .Values.runtime | default "agentm" }}
+            - --roles=dev,review
+            - --listen=0.0.0.0:{{ .Values.service.port }}
+            - --auth
+            - --report-base-url={{ include "workbuddy.reportBaseURL" . }}
+            - --poll-interval={{ .Values.config.pollInterval | default "15s" }}
+            - --db-path={{ $mount }}/state/workbuddy.db
+          {{- else }}
           args:
             - coordinator
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           env:
-            # ----------------------------------------------------------
-            # MySQL DSN — Secret keyRef when dsnSecretRef.name is set,
-            # otherwise the plaintext value. Empty values are still
-            # rendered so the coordinator can detect "unconfigured" and
-            # fall back to SQLite for dev.
-            # ----------------------------------------------------------
-            {{- if .Values.mysql.dsnSecretRef.name }}
-            - name: WORKBUDDY_MYSQL_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.mysql.dsnSecretRef.name | quote }}
-                  key: {{ .Values.mysql.dsnSecretRef.key | default "dsn" | quote }}
-            {{- else }}
-            - name: WORKBUDDY_MYSQL_DSN
-              value: {{ .Values.mysql.dsn | quote }}
-            {{- end }}
-            # ----------------------------------------------------------
-            # OpenTelemetry — standard SDK env vars consumed by
-            # internal/tracing/tracing.go. Empty endpoint disables export.
-            # ----------------------------------------------------------
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: {{ .Values.otel.endpoint | quote }}
-            - name: OTEL_EXPORTER_OTLP_PROTOCOL
-              value: {{ .Values.otel.protocol | default "grpc" | quote }}
-            - name: OTEL_SERVICE_NAME
-              value: {{ .Values.otel.serviceName | default "workbuddy" | quote }}
-            # ----------------------------------------------------------
-            # Gitea / GitHub token — one Secret value exposed as both
-            # env vars: GH_TOKEN (gh CLI in the poller) and GITEA_TOKEN
-            # (internal/labelwriter). Pre-existing Secret is required
-            # unless giteaToken.token is set for dev quickstart.
-            # ----------------------------------------------------------
+            # ---- GitHub / Gitea token: poller (GH_TOKEN) + labelwriter (GITEA_TOKEN) ----
             - name: GH_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -87,20 +120,105 @@ spec:
                 secretKeyRef:
                   name: {{ include "workbuddy.giteaSecretName" . | quote }}
                   key: {{ .Values.giteaToken.secretKey | default "token" | quote }}
-            - name: WORKBUDDY_AGENTS_DIR
-              value: /etc/workbuddy/agents
+            {{- if $isServe }}
+            # ---- coordinator HTTP auth + embedded worker authentication ----
+            - name: WORKBUDDY_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "workbuddy.authSecretName" . | quote }}
+                  key: {{ .Values.auth.secretKey | default "token" | quote }}
+            # Deterministic repo binding: derive only from config.repo, ignore
+            # any persisted worker-repos file on the volume.
+            - name: WORKBUDDY_WORKER_REPOS_FILE
+              value: /dev/null
+            # ---- agent-env Gateway (read by the agentm subprocess, not Go) ----
+            - name: AGENTM_AGENT_ENV_GATEWAY_URL
+              value: {{ required "agentEnv.gatewayUrl is required in serve mode" .Values.agentEnv.gatewayUrl | quote }}
+            {{- if .Values.agentEnv.image }}
+            - name: AGENTM_AGENT_ENV_IMAGE
+              value: {{ .Values.agentEnv.image | quote }}
+            {{- end }}
+            - name: AGENTM_AGENT_ENV_EXPERIMENT_ID
+              value: {{ .Values.agentEnv.experimentId | default "workbuddy" | quote }}
+            # git push/fetch from the worktree trusts the volume regardless of uid.
+            - name: GIT_CONFIG_COUNT
+              value: "1"
+            - name: GIT_CONFIG_KEY_0
+              value: safe.directory
+            - name: GIT_CONFIG_VALUE_0
+              value: "*"
+            {{- end }}
+            # ---- OpenTelemetry (standard SDK env, no-op when endpoint empty) ----
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.otel.endpoint | quote }}
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: {{ .Values.otel.protocol | default "grpc" | quote }}
+            - name: OTEL_SERVICE_NAME
+              value: {{ .Values.otel.serviceName | default "workbuddy" | quote }}
+            # ---- MySQL DSN (forward-compat; SQLite is the serve default) ----
+            {{- if .Values.mysql.dsnSecretRef.name }}
+            - name: WORKBUDDY_MYSQL_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.mysql.dsnSecretRef.name | quote }}
+                  key: {{ .Values.mysql.dsnSecretRef.key | default "dsn" | quote }}
+            {{- else if .Values.mysql.dsn }}
+            - name: WORKBUDDY_MYSQL_DSN
+              value: {{ .Values.mysql.dsn | quote }}
+            {{- end }}
+          {{- if .Values.providerKeys.secretName }}
+          envFrom:
+            # Provider API keys (ANTHROPIC_API_KEY, OPENAI_API_KEY, CRS_OAI_KEY, …)
+            # for the agentm subprocess. Every key in the Secret becomes an env var.
+            - secretRef:
+                name: {{ .Values.providerKeys.secretName | quote }}
+          {{- end }}
           volumeMounts:
-            - name: agents
-              mountPath: /etc/workbuddy/agents
+            - name: config
+              mountPath: {{ $cfgDir }}/config.yaml
+              subPath: config.yaml
               readOnly: true
+            - name: config
+              mountPath: {{ $cfgDir }}/workflows/default.md
+              subPath: workflow-default.md
+              readOnly: true
+            - name: agents
+              mountPath: {{ $cfgDir }}/agents
+              readOnly: true
+            {{- if $isServe }}
+            - name: workspace
+              mountPath: {{ $mount }}
+            {{- end }}
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       volumes:
+        - name: config
+          configMap:
+            name: {{ include "workbuddy.configConfigMapName" . }}
         - name: agents
           configMap:
             name: {{ include "workbuddy.agentsConfigMapName" . }}
+        {{- if $isServe }}
+        - name: workspace
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (printf "%s-workspace" (include "workbuddy.fullname" .)) }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/workbuddy/templates/deployment.yaml
+++ b/deploy/helm/workbuddy/templates/deployment.yaml
@@ -1,6 +1,19 @@
 {{- $isServe := eq (.Values.mode | default "serve") "serve" -}}
 {{- $cfgDir := include "workbuddy.configDir" . -}}
 {{- $mount := .Values.persistence.mountPath | default "/var/lib/workbuddy" -}}
+{{- /*
+Fail fast at render time when a hard-required Secret has no source. Without
+this the Deployment renders a dangling secretKeyRef and the pod wedges in
+CreateContainerConfigError with no clear cause. The GitHub/Gitea token backs
+the poller + gitops in both modes; serve additionally binds 0.0.0.0 with
+--auth, so an auth token is mandatory there.
+*/ -}}
+{{- if and (not .Values.giteaToken.secretName) (not .Values.giteaToken.token) -}}
+{{- fail "giteaToken.secretName or giteaToken.token is required (GitHub/Gitea API token for the poller + gitops)" -}}
+{{- end -}}
+{{- if and $isServe (not .Values.auth.secretName) (not .Values.auth.token) -}}
+{{- fail "serve mode binds 0.0.0.0 with --auth: set auth.token or auth.secretName" -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deploy/helm/workbuddy/templates/pvc.yaml
+++ b/deploy/helm/workbuddy/templates/pvc.yaml
@@ -1,0 +1,23 @@
+{{- /*
+Workspace PersistentVolumeClaim — repo clone, per-issue worktrees, and the
+SQLite DB under .workbuddy/. Rendered only when persistence is enabled and the
+user did not supply an existing claim. Single-replica + Recreate (see
+deployment.yaml) means ReadWriteOnce is sufficient.
+*/ -}}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "workbuddy.fullname" . }}-workspace
+  labels:
+    {{- include "workbuddy.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | default "ReadWriteOnce" }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | default "10Gi" }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/workbuddy/templates/secret.yaml
+++ b/deploy/helm/workbuddy/templates/secret.yaml
@@ -17,3 +17,22 @@ type: Opaque
 stringData:
   {{ .Values.giteaToken.secretKey | default "token" }}: {{ .Values.giteaToken.token | quote }}
 {{- end }}
+{{- /*
+Auth-token Secret for the coordinator HTTP surface + embedded worker. Same
+dev/quickstart-only pattern: rendered when auth.token is set and no existing
+auth.secretName is supplied. In serve mode a token is mandatory (the process
+binds 0.0.0.0 and --auth is required), so the deployment fails fast if neither
+auth.token nor auth.secretName is provided.
+*/ -}}
+{{- if and (not .Values.auth.secretName) .Values.auth.token }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "workbuddy.authSecretName" . }}
+  labels:
+    {{- include "workbuddy.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.auth.secretKey | default "token" }}: {{ .Values.auth.token | quote }}
+{{- end }}

--- a/deploy/helm/workbuddy/values.yaml
+++ b/deploy/helm/workbuddy/values.yaml
@@ -5,8 +5,26 @@
 # AegisLab via plain values references — NEITHER is bundled here as a
 # subchart, per the decision doc.
 
+# ----------------------------------------------------------------------
+# Execution mode
+# ----------------------------------------------------------------------
+# "serve"       — single pod = coordinator + embedded worker (one process,
+#                 shared DB). This is the K8s realization of the decision
+#                 doc's "single-process in K8s" model and the only mode
+#                 that can run runtime: agentm (the embedded worker owns
+#                 the agentm subprocess + coordinator-managed publish).
+# "coordinator" — poller + state machine only; CANNOT execute agentm
+#                 (no worker to claim tasks). Kept for split topologies
+#                 that pair it with a standalone `workbuddy worker`.
+mode: serve
+
+# Embedded-worker runtime capability advertised to the claim filter. Must
+# be "agentm" for the sandbox topology; "claude-code"/"codex" are host-exec
+# and not supported in K8s (see decision doc Block 2 mode matrix).
+runtime: agentm
+
 image:
-  repository: ghcr.io/lincyaw/workbuddy
+  repository: ghcr.io/lincyaw/workbuddy-agentm   # combined workbuddy+agentm image (deploy/docker/Dockerfile)
   tag: ""          # defaults to .Chart.AppVersion when empty
   pullPolicy: IfNotPresent
 
@@ -85,6 +103,14 @@ giteaToken:
 #   - configMapName == "":  chart renders one from deploy/helm/workbuddy/agents/*.md.
 agents:
   configMapName: ""
+  # AgentM scenario referenced BY NAME (not a path). Resolved inside the
+  # image from AGENTM_PROJECT_ROOT (deploy/docker/Dockerfile). The bundled
+  # agent_env_repo scenario seeds the sandbox from the worktree's git HEAD
+  # and syncs the agent's diff back — the cwd<->pod sync that makes
+  # coordinator-managed PRs non-empty.
+  scenarioName: agent_env_repo
+  devTimeout: 15m
+  reviewTimeout: 10m
 
 # Ingress for the coordinator Service. Disabled by default; enable in K8s
 # topologies that need external webui + webhook access (decision doc Block 3
@@ -100,6 +126,77 @@ ingress:
   tls:
     enabled: false
     secretName: ""
+
+# ----------------------------------------------------------------------
+# Coordinator config (rendered into config.yaml in the mounted config-dir)
+# ----------------------------------------------------------------------
+# The single repository the coordinator polls. The init container clones it
+# into the workspace volume so the embedded worker can `git worktree add`.
+# Multi-repo fan-out (dynamic worker repo registration) is out of scope for
+# this chart; deploy one release per repo, or extend with --repos.
+config:
+  repo: ""                     # required, "OWNER/NAME" form
+  environment: dev
+  pollInterval: 15s
+  # Default branch to clone/track. Empty = the remote's default branch.
+  branch: ""
+
+# Workflow Markdown mounted at <config-dir>/workflows/default.md. The chart
+# ships the standard 2-agent (dev → review) state machine; override to point
+# at your own by setting workflow.inline to the full Markdown document.
+workflow:
+  inline: ""                   # empty = use the bundled default workflow
+
+# ----------------------------------------------------------------------
+# Coordinator HTTP bind + auth
+# ----------------------------------------------------------------------
+# In K8s the process must bind 0.0.0.0 so the Service / kubelet probes can
+# reach it, which workbuddy requires --auth for (a non-loopback bind without
+# auth is rejected). The embedded worker authenticates to the in-pod
+# coordinator with the same token, so a token is mandatory in serve mode.
+auth:
+  token: ""                    # plaintext; chart materializes a Secret (dev)
+  secretName: ""               # or reference an existing Secret (recommended)
+  secretKey: token
+
+# URL written into GitHub issue comments as the prefix of session links.
+# Required because the process binds non-loopback. Defaults to the in-cluster
+# Service DNS (not browser-clickable but valid); set to your ingress host for
+# clickable links.
+reportBaseURL: ""
+
+# ----------------------------------------------------------------------
+# agent-env (ARL sandbox Gateway) — consumed by the agentm subprocess
+# ----------------------------------------------------------------------
+# workbuddy Go never talks to the Gateway; the agentm CLI does, via these
+# AGENTM_AGENT_ENV_* env vars. agent-env is a SEPARATE Helm release; point
+# gatewayUrl at its in-cluster Service.
+agentEnv:
+  gatewayUrl: ""               # required, e.g. http://arl-operator-gateway.arl.svc:8080
+  image: ""                    # sandbox dev-container image, e.g. otel-demo-dev:latest
+  experimentId: workbuddy      # AGENTM_AGENT_ENV_EXPERIMENT_ID
+
+# ----------------------------------------------------------------------
+# Provider API keys for the agentm subprocess (ANTHROPIC_API_KEY,
+# OPENAI_API_KEY, CRS_OAI_KEY, …). All keys in the referenced Secret are
+# injected as env via envFrom. Leave empty to inherit nothing (the agent
+# will fail at model-call time).
+# ----------------------------------------------------------------------
+providerKeys:
+  secretName: ""               # existing Secret; every key becomes an env var
+
+# ----------------------------------------------------------------------
+# Workspace volume — holds the repo clone, per-issue worktrees, and (by
+# default) the SQLite DB under .workbuddy/. Use a PVC for persistence across
+# restarts; emptyDir is fine for ephemeral test runs.
+# ----------------------------------------------------------------------
+persistence:
+  enabled: true
+  existingClaim: ""
+  storageClass: ""
+  accessMode: ReadWriteOnce
+  size: 10Gi
+  mountPath: /var/lib/workbuddy
 
 resources: {}
 nodeSelector: {}

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -6954,3 +6954,79 @@ requirements:
       - docs/planned/agentm-runtime.md
     deps:
       - REQ-160
+
+  - id: REQ-162
+    title: Kubernetes deployment — combined workbuddy+agentm image + single-pod serve Helm chart
+    description: >
+      The v0.6 Helm chart (deploy/helm/workbuddy) deployed only the bare
+      `coordinator`, which CANNOT execute runtime:agentm — the agentm
+      subprocess exec and the coordinator-managed publish both live in the
+      runtime layer the WORKER drives (internal/runtime/agent_bridge.go:
+      publishAgentMArtifact). This requirement makes the chart actually run
+      agentm on K8s, as a single self-contained pod, matching the decision
+      doc's "single-process in K8s" model.
+
+      Three pieces:
+
+      1. `serve --runtime` flag. cmd/serve.go's embedded worker never set a
+         runtime, so it defaulted away from agentm and ClaimNextTask's
+         runtime filter starved agentm tasks. serve now exposes --runtime
+         (default claude-code, matching `worker`) and threads it into the
+         embedded workerOpts, making `serve --runtime agentm` a working
+         single-process coordinator+worker that claims and executes agentm.
+
+      2. Combined container image (deploy/docker/Dockerfile). Multi-stage:
+         Go-builds workbuddy, then a python:3.12-slim layer with gh + git +
+         the REAL AgentM installed EDITABLE from a build-arg ref
+         (AGENTM_REF). Editable is load-bearing: AgentM discovers contrib
+         atoms + scenarios by walking up from agentm.__file__ to a sibling
+         contrib/ (discover.py, loader.py), which a non-editable wheel drops.
+         AGENTM_PROJECT_ROOT is set so the agent_env_repo scenario resolves
+         BY NAME (loader.py _candidate_roots root #1) — agent configs say
+         `scenario: agent_env_repo`, never an absolute path. The agentm CLI
+         is on PATH for the worker's DefaultBinary lookup. (Vendoring AgentM
+         source is required only until `agentm` is published to PyPI with
+         contrib as package data; then the clone collapses to a pip install.)
+
+      3. Chart serve topology. mode=serve runs the combined image as one
+         Deployment: an initContainer git-clones the configured repo into a
+         workspace PVC (workbuddy does NOT auto-clone — the worker
+         `git worktree add`s an existing clone); config.yaml + the default
+         2-agent workflow + templated agentm dev/review agent configs are
+         mounted via a config ConfigMap (subPath) + agents ConfigMap;
+         AGENTM_AGENT_ENV_GATEWAY_URL/IMAGE/EXPERIMENT_ID point the agentm
+         subprocess at a SEPARATE in-cluster agent-env release (workbuddy Go
+         never calls the Gateway); provider API keys come via envFrom a
+         Secret; GH/Gitea token + a mandatory auth token (serve binds
+         0.0.0.0 so probes/Service work, which requires --auth) come from
+         Secrets. SQLite on the workspace PVC is the serve default; the
+         MySQL DSN env is rendered forward-compat.
+
+      The credential boundary is preserved end-to-end: the worker container
+      clones with the token (origin URL), the agentm subprocess shuttles the
+      diff to/from the sandbox pod, and no GitHub credential ever enters the
+      pod.
+    priority: P1
+    version: v0.7.0
+    status: implemented
+    acceptance_criteria:
+      - "AC-162-1: `workbuddy serve --runtime agentm` advertises the agentm capability on the embedded worker so ClaimNextTask hands it agentm tasks; default remains claude-code; covered by cmd/serve_test.go TestParseServeFlagsRuntime."
+      - "AC-162-2: deploy/docker/Dockerfile builds an image with `workbuddy` + `agentm` on PATH, gh + git installed, and the agent_env_repo scenario resolvable BY NAME via discover_contrib_atoms + load_scenario (editable install + AGENTM_PROJECT_ROOT)."
+      - "AC-162-3: `helm lint` and `helm template` succeed for mode=serve; the rendered Deployment runs `serve --config-dir --runtime=agentm --listen=0.0.0.0 --auth`, mounts config+agents+workspace, sets the AGENTM_AGENT_ENV_* / token / provider env, and has an initContainer that clones config.repo into the workspace PVC."
+      - "AC-162-4: agent configs reference `scenario: agent_env_repo` by name (no absolute path); the sandbox image is injected from agentEnv.image as dev_container_image."
+      - "AC-162-5: Live kind smoke — the chart deploys into a cluster with an agent-env Gateway, and an issue with a real-code AC runs developing→reviewing→done with a non-empty PR whose diff is exactly the agent's changes."
+    code:
+      - cmd/serve.go
+      - deploy/docker/Dockerfile
+      - deploy/helm/workbuddy/values.yaml
+      - deploy/helm/workbuddy/templates/deployment.yaml
+      - deploy/helm/workbuddy/templates/config-configmap.yaml
+      - deploy/helm/workbuddy/templates/configmap.yaml
+      - deploy/helm/workbuddy/templates/secret.yaml
+      - deploy/helm/workbuddy/templates/pvc.yaml
+      - deploy/helm/workbuddy/templates/_helpers.tpl
+    tests:
+      - cmd/serve_test.go
+    deps:
+      - REQ-160
+      - REQ-161

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -7008,13 +7008,13 @@ requirements:
       pod.
     priority: P1
     version: v0.7.0
-    status: implemented
+    status: tested
     acceptance_criteria:
       - "AC-162-1: `workbuddy serve --runtime agentm` advertises the agentm capability on the embedded worker so ClaimNextTask hands it agentm tasks; default remains claude-code; covered by cmd/serve_test.go TestParseServeFlagsRuntime."
       - "AC-162-2: deploy/docker/Dockerfile builds an image with `workbuddy` + `agentm` on PATH, gh + git installed, and the agent_env_repo scenario resolvable BY NAME via discover_contrib_atoms + load_scenario (editable install + AGENTM_PROJECT_ROOT)."
       - "AC-162-3: `helm lint` and `helm template` succeed for mode=serve; the rendered Deployment runs `serve --config-dir --runtime=agentm --listen=0.0.0.0 --auth`, mounts config+agents+workspace, sets the AGENTM_AGENT_ENV_* / token / provider env, and has an initContainer that clones config.repo into the workspace PVC."
       - "AC-162-4: agent configs reference `scenario: agent_env_repo` by name (no absolute path); the sandbox image is injected from agentEnv.image as dev_container_image."
-      - "AC-162-5: Live kind smoke — the chart deploys into a cluster with an agent-env Gateway, and an issue with a real-code AC runs developing→reviewing→done with a non-empty PR whose diff is exactly the agent's changes."
+      - "AC-162-5: Live kind smoke (VERIFIED) — chart deployed into kind arl-agentm (agentEnv.gatewayUrl=http://arl-operator-gateway.arl.svc:8080, combined image kind-loaded); initContainer cloned the repo into the workspace PVC; serve bound 0.0.0.0:8080 with --auth and ran the embedded agentm worker; issue #9 (real-code AC) ran developing→reviewing→done autonomously and produced PR #10 containing the agent's actual k8s_marker.py + test (the agent ran the test in-sandbox). The credential boundary held: the pod cloned/pushed with the token, the sandbox got none."
     code:
       - cmd/serve.go
       - deploy/docker/Dockerfile


### PR DESCRIPTION
Makes the Helm chart actually run `runtime: agentm` on Kubernetes as a single self-contained pod (the bare `coordinator` it deployed before cannot — agentm exec + coordinator-managed publish live in the worker's runtime layer).

## What
- **`serve --runtime`** (`cmd/serve.go`): the embedded worker now advertises a runtime, so `serve --runtime agentm` claims+executes agentm tasks.
- **Combined image** (`deploy/docker/Dockerfile`): workbuddy + gh + git + real AgentM, scenario referenced by name.
- **Chart serve topology**: initContainer clones the repo into a workspace PVC; config + workflow + templated agentm dev/review agents via ConfigMaps; `AGENTM_AGENT_ENV_*` point at a separate agent-env Gateway; provider keys via envFrom; mandatory auth/gitea tokens via Secrets (render-time guarded).

## Verified
go build/vet/test green (pre-existing flaky `TestWorkerDynamicRepoAdd…` excepted); `helm lint`/`template` clean; combined image built; **live kind smoke**: issue → developing→reviewing→done → PR with the agent's real code. Credential boundary intact (token only in the pod, never the sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)